### PR TITLE
feat(config): support api_key_command credential helper for providers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,11 @@ providers:
   - name: openai
     type: openai
     api_key: "${OPENAI_API_KEY}"
+    # Optional credential helper: when api_key is empty, this command is run via the
+    # shell and its trimmed stdout is used as the key (like git/docker credential
+    # helpers or AWS credential_process). Lets a provider fetch short-lived or
+    # login-issued keys without storing a static secret. Falls back to NAME_API_KEY.
+    # api_key_command: "my-cli print-token"
     # Optional outbound proxy for this provider only (http, https, socks5, socks5h).
     # proxy: "http://127.0.0.1:8888"
     # proxy: "socks5h://127.0.0.1:1080"

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,11 +23,16 @@ Agent name, title, and build version are not configurable here. They are fixed i
 # Each providers[].name must match ^[a-zA-Z][a-zA-Z0-9_-]*$ (ASCII letter first, then letters, digits, hyphen, underscore).
 # api_key may be a literal, "${ENV}" expanded when the file loads, or empty to read NAME_API_KEY at LLM call time
 # (NAME is the provider name in uppercase with hyphens mapped to underscores, for example rpa -> RPA_API_KEY).
+# api_key_command (optional): when api_key is empty, this command is run via the shell and its trimmed stdout is
+# used as the key (credential helper, like git/docker helpers or AWS credential_process). It lets a provider fetch
+# short-lived or login-issued keys without storing a static secret. On failure resolution falls back to NAME_API_KEY.
+# Resolution order: literal api_key -> api_key_command stdout -> NAME_API_KEY env.
 providers:
   - name: "openai"
     type: "openai"
     api_key: "${OPENAI_API_KEY}"
     # api_base: ""                    # optional override for OpenAI-compatible base URL
+    # api_key_command: "my-cli print-token"  # optional credential helper; used when api_key is empty
     # proxy: "http://127.0.0.1:8888"   # optional per-provider HTTP(S) or SOCKS5/SOCKS5h proxy
 
   - name: "anthropic"

--- a/internal/config/jsondto.go
+++ b/internal/config/jsondto.go
@@ -62,12 +62,14 @@ type InstructionsJSON struct {
 }
 
 // ProviderJSON mirrors ProviderConfig for JSON APIs.
+// Field order and types must match ProviderConfig (direct struct conversion is used below).
 type ProviderJSON struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	APIBase string `json:"api_base,omitempty"`
-	APIKey  string `json:"api_key,omitempty"`
-	Proxy   string `json:"proxy,omitempty"`
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	APIBase       string `json:"api_base,omitempty"`
+	APIKey        string `json:"api_key,omitempty"`
+	APIKeyCommand string `json:"api_key_command,omitempty"`
+	Proxy         string `json:"proxy,omitempty"`
 }
 
 // ModelJSON mirrors ModelEntry for JSON APIs.

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -1,11 +1,17 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
+
+// apiKeyCommandTimeout bounds how long a provider api_key_command may run.
+const apiKeyCommandTimeout = 30 * time.Second
 
 // validProviderName constrains providers[].name to ASCII letters, digits, hyphen, and underscore,
 // starting with a letter (stable mapping to environment variable names).
@@ -23,6 +29,12 @@ type ProviderConfig struct {
 	Type    string `yaml:"type"`
 	APIBase string `yaml:"api_base"`
 	APIKey  string `yaml:"api_key"`
+	// APIKeyCommand is an optional credential-helper command. When api_key is empty,
+	// the command is run via the shell and its trimmed stdout is used as the key
+	// (akin to git/docker credential helpers or AWS credential_process). This lets a
+	// provider fetch short-lived or login-issued keys without storing a static secret
+	// in the config. On failure resolution falls back to the conventional env var.
+	APIKeyCommand string `yaml:"api_key_command"`
 	// Proxy is an optional HTTP, HTTPS, SOCKS5, or SOCKS5h proxy URL for outbound LLM requests for this provider only.
 	Proxy string `yaml:"proxy"`
 }
@@ -38,14 +50,21 @@ func ProviderAPIKeyEnvVarName(providerName string) string {
 	return strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_API_KEY"
 }
 
-// EffectiveAPIKey returns the key to pass to LLM clients: the configured non-empty api_key, or else
-// the value of the conventional environment variable derived from the provider name (see ProviderAPIKeyEnvVarName).
+// EffectiveAPIKey returns the key to pass to LLM clients. Resolution order:
+// the configured non-empty api_key, then api_key_command stdout (when set and it
+// succeeds), then the conventional environment variable derived from the provider
+// name (see ProviderAPIKeyEnvVarName).
 func (p *ProviderConfig) EffectiveAPIKey() string {
 	if p == nil {
 		return ""
 	}
 	if k := strings.TrimSpace(p.APIKey); k != "" {
 		return k
+	}
+	if cmd := strings.TrimSpace(p.APIKeyCommand); cmd != "" {
+		if k := runAPIKeyCommand(cmd); k != "" {
+			return k
+		}
 	}
 	env := ProviderAPIKeyEnvVarName(p.Name)
 	if env == "" {
@@ -54,12 +73,26 @@ func (p *ProviderConfig) EffectiveAPIKey() string {
 	return strings.TrimSpace(os.Getenv(env))
 }
 
+// runAPIKeyCommand executes a provider credential-helper command via the shell and
+// returns its trimmed stdout. It returns "" on any error (non-zero exit, timeout,
+// spawn failure) so EffectiveAPIKey can fall back to the conventional env var.
+func runAPIKeyCommand(command string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), apiKeyCommandTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "sh", "-c", command).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // Normalize trims string fields in place.
 func (p *ProviderConfig) Normalize() {
 	p.Name = strings.TrimSpace(p.Name)
 	p.Type = strings.TrimSpace(p.Type)
 	p.APIBase = strings.TrimSpace(p.APIBase)
 	p.APIKey = strings.TrimSpace(p.APIKey)
+	p.APIKeyCommand = strings.TrimSpace(p.APIKeyCommand)
 	p.Proxy = strings.TrimSpace(p.Proxy)
 }
 

--- a/internal/config/providers_env_test.go
+++ b/internal/config/providers_env_test.go
@@ -44,6 +44,30 @@ func TestProviderConfigEffectiveAPIKey(t *testing.T) {
 	}
 }
 
+func TestProviderConfigEffectiveAPIKeyCommand(t *testing.T) {
+	// api_key_command stdout (trimmed) becomes the key when api_key is empty.
+	p := &ProviderConfig{Name: "rpa", Type: "openai", APIKeyCommand: "printf 'k-from-cmd\\n'"}
+	if got := p.EffectiveAPIKey(); got != "k-from-cmd" {
+		t.Fatalf("EffectiveAPIKey command: got %q want k-from-cmd", got)
+	}
+	// A literal api_key wins over the command.
+	p.APIKey = "literal"
+	if got := p.EffectiveAPIKey(); got != "literal" {
+		t.Fatalf("literal should win over command: got %q", got)
+	}
+	// The command wins over the conventional env var.
+	t.Setenv("RPA_API_KEY", "from-env")
+	p = &ProviderConfig{Name: "rpa", Type: "openai", APIKeyCommand: "printf 'k-from-cmd'"}
+	if got := p.EffectiveAPIKey(); got != "k-from-cmd" {
+		t.Fatalf("command should win over env: got %q", got)
+	}
+	// A failing/empty command falls back to the env var (best-effort helper).
+	p = &ProviderConfig{Name: "rpa", Type: "openai", APIKeyCommand: "exit 3"}
+	if got := p.EffectiveAPIKey(); got != "from-env" {
+		t.Fatalf("failed command should fall back to env: got %q", got)
+	}
+}
+
 func TestResolveLLMUsesEffectiveAPIKey(t *testing.T) {
 	t.Setenv("RPA_API_KEY", "k-env")
 	cfg := &Config{

--- a/internal/config/ui_schema.go
+++ b/internal/config/ui_schema.go
@@ -194,6 +194,8 @@ func UISchemaMap() map[string]interface{} {
 		},
 		"api_base": strProp("API base URL", "Optional override of the default API base URL for this provider."),
 		"api_key":  providerAPIKey,
+		"api_key_command": strProp("API key command",
+			"Optional credential-helper command. When api_key is empty it is run via the shell and its trimmed stdout is used as the key (like git/docker credential helpers or AWS credential_process), letting the provider fetch short-lived or login-issued keys without storing a static secret. On failure resolution falls back to the conventional NAME_API_KEY variable."),
 		"proxy": strProp("HTTP or SOCKS proxy",
 			"Optional per-provider outbound proxy. Use http:// or https:// for an HTTP proxy, or socks5:// / socks5h:// for SOCKS5 (socks5h resolves hostnames via the proxy). Leave empty for a direct connection."),
 	}


### PR DESCRIPTION
## What

Add an optional `api_key_command` to providers: a **credential-helper** command. When a provider's `api_key` is empty, the command is run via the shell and its trimmed stdout is used as the key — the same pattern as **git/docker credential helpers** and **AWS `credential_process`**.

This lets a provider fetch **short-lived or login-issued keys** without storing a static secret in `config.yaml` (e.g. an OAuth/login helper that prints a freshly-minted token, key rotation, vault lookups).

## Resolution order

```
literal api_key  →  api_key_command stdout  →  NAME_API_KEY env
```

Best-effort: a failing/empty command falls back to the conventional env var. The command runs with a 30s timeout.

```yaml
providers:
  - name: example
    type: openai
    api_base: "https://api.example.com/v1"
    # api_key left empty:
    api_key_command: "my-cli print-token"
```

## Changes

- `internal/config/providers.go` — `ProviderConfig.APIKeyCommand` + `runAPIKeyCommand`, wired into `EffectiveAPIKey` and `Normalize`.
- `internal/config/jsondto.go` — mirror the field in `ProviderJSON` (kept in field order for the direct struct conversion).
- `internal/config/ui_schema.go` — expose `api_key_command` in the provider UI schema.
- `internal/config/providers_env_test.go` — `TestProviderConfigEffectiveAPIKeyCommand` (command stdout, literal wins, command over env, failure → env fallback).
- Docs: `config.example.yaml` + `docs/config.md`.

## Tests

`make test` green — 248 packages across all tag combinations (default, `memory`, `http`, `http,memory`, `scheduler`, `scheduler,memory`, then `ui-build` + `http,ui`, `http,ui,memory`, `http,scheduler`, …) plus the embedded UI build. `gofmt`/`go vet` clean.
