### PR TITLE
docs: Windows install paths, PATH refresh guidance, absolute-path tip for integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Coddy is a distroless-friendly **harness**: drop it into minimal images (`scratc
 
 Coddy is an **ACP server** (`coddy acp`). **Obsidian**, **VS Code**, **Zed**, scripts, and the bundled **`coddy http`** UI are clients that share the same **`CODDY_HOME`** sessions when configured with the same home directory.
 
+Configure clients with the **absolute path** to the binary rather than relying on `PATH` — some harnesses spawn the agent via `cmd /c` or `sh -c` without the user `PATH` (on Windows: `%LOCALAPPDATA%\Programs\coddy\coddy.exe`; see [`docs/install.md`](docs/install.md#windows)).
+
 Protocol details: **`docs/acp-protocol.md`**. Harness examples: **`examples/acp/`**.
 
 ## Quick Start
@@ -102,6 +104,8 @@ irm https://coddy.dev/install.ps1 | iex
 ```
 
 Creates **`~/.coddy/config.yaml`** from the release **`config.example.yaml`** when missing. Puts **`coddy`** on **`PATH`** (Unix: `~/.local/bin`; Windows: `%LOCALAPPDATA%\Programs\coddy`). Full installer options: **[`docs/install.md`](docs/install.md)**.
+
+> **Windows.** The binary lands at `%LOCALAPPDATA%\Programs\coddy\coddy.exe`; config and sessions live under `%USERPROFILE%\.coddy\` (use `$env:USERPROFILE`, not `$HOME`). The installing terminal does not see the updated `PATH` — open a new one or refresh it in place. Details: [`docs/install.md`](docs/install.md#windows).
 
 Then set a provider key in **`~/.coddy/config.yaml`** (or **`OPENAI_API_KEY`** in the environment) and run **`coddy http`** for the UI, or **`coddy acp`** for an editor client.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,6 +27,40 @@ coddy -v
 coddy http
 ```
 
+## Windows
+
+### Install locations
+
+| What | Path |
+|------|------|
+| Binary | `%LOCALAPPDATA%\Programs\coddy\coddy.exe` |
+| Config | `%USERPROFILE%\.coddy\config.yaml` |
+| Sessions / memory | `%USERPROFILE%\.coddy\sessions\` |
+
+The user directory is **`$env:USERPROFILE`** (`%USERPROFILE%`), **not** `$HOME` — `$HOME` is unreliable across Windows PowerShell and Git Bash setups (Git Bash `$HOME` may differ from `%USERPROFILE%`).
+
+### PATH in the current session
+
+`install.ps1` adds the binary directory to the **user** `PATH`. New terminals pick it up automatically; the terminal you installed from does **not**. Either open a new terminal, or refresh in place:
+
+```powershell
+$env:Path = [Environment]::GetEnvironmentVariable("Path","User") + ";" + [Environment]::GetEnvironmentVariable("Path","Machine")
+```
+
+(`refreshenv` also works if you have Chocolatey.)
+
+### Editor / agent integrations: use the absolute path
+
+Some harnesses spawn **`coddy acp`** via `cmd /c` or `sh -c` and do not inherit the user `PATH`. To avoid "command not found" wiring bugs, configure clients with the absolute path:
+
+```text
+%LOCALAPPDATA%\Programs\coddy\coddy.exe
+```
+
+### Package managers
+
+Scoop / winget manifests are not published yet — tracked in [issue #42](https://github.com/coddy-project/coddy-agent/issues/42). Until then use `install.ps1` above and upgrade with `coddy update -y`.
+
 ## Docker
 
 ```bash


### PR DESCRIPTION
Addresses #42 (items 1, 2, 4).

## What changed

- **docs/install.md** — new **Windows** section:
  - Install locations table: binary `%LOCALAPPDATA%\Programs\coddy\coddy.exe`, config `%USERPROFILE%\.coddy\config.yaml`, sessions `%USERPROFILE%\.coddy\sessions\` — with an explicit note to use `$env:USERPROFILE`, not `$HOME`.
  - PATH refresh guidance for the installing terminal (one-liner + `refreshenv` mention).
  - Absolute-path recommendation for editor/agent integrations that spawn `coddy acp` via `cmd /c` / `sh -c` without the user PATH.
  - Note that scoop/winget manifests are not published yet (tracked in #42).
- **README.md** — Windows callout in Quick Start linking to the new section, and the absolute-path tip in *Editor and IDE integration*.

## Not included

Item 3 (scoop/winget manifests) is a publishing decision for maintainers — the issue author offered to submit manifests once interest is confirmed; the docs now point at #42 for tracking.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)