### PR TITLE
Document YAML config schema: field reference + JSON Schema (closes #43)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,5 +1,5 @@
 ---
-description: BDD-style workflow, HTTP OpenAPI sync before lint, final checks
+description: BDD-style workflow, HTTP OpenAPI and config schema sync before lint, final checks
 paths:
   - "**/*.go"
   - "docs/**/*.md"
@@ -17,8 +17,9 @@ When adding or changing behavior (including words like feature, add, implement, 
 3. Implement the smallest change that makes the test pass (green).
 4. Run **`make test`** (default, **`http`**, **`scheduler`**, **`ui-build`** then **`http,ui`**, combined scheduler tags). Everything must pass.
 5. **HTTP OpenAPI narrative** - If you changed the optional OpenAI-compatible HTTP API (routes, methods, headers, request or response bodies, status codes, or anything reflected in the served spec), update **`external/httpserver/openapi.go`** (`openAPISpec`) so it matches **`external/httpserver/server.go`** handlers and tests. Align **`docs/http-api.md`** (and **`README.md`** HTTP bullets) when user-facing descriptions change.
-6. Update documentation and specs if needed.
-7. Run **`make lint`** (`golangci-lint`). Fix reported issues.
+6. **Config schema sync** - If you changed the YAML config surface (**`internal/config`** structs: added, renamed, retyped, or removed a yaml-tagged field, enum value, or default), update **`docs/config.schema.json`** and the tables in **`docs/config-reference.md`** to match. **`TestDocsConfigSchemaMatchesStructs`** (**`internal/config/docs_schema_test.go`**) catches key/type drift, but descriptions, defaults, enums-in-prose, and the reference tables are not auto-checked - keep them accurate by hand. Mirror user-facing fields in **`config.example.yaml`** and **`UISchemaMap()`** (**`internal/config/ui_schema.go`**) as well.
+7. Update documentation and specs if needed.
+8. Run **`make lint`** (`golangci-lint`). Fix reported issues.
 
 Then report briefly: goal, tests added or changed, `make test` and `make lint` outcome, files touched.
 
@@ -28,11 +29,13 @@ Then report briefly: goal, tests added or changed, `make test` and `make lint` o
 2. Fix the code; confirm the new test passes.
 3. Run **`make test`**.
 4. If the bug or fix touches the HTTP API surface, complete step 5 (OpenAPI and docs) from the feature flow.
-5. Run **`make lint`**.
+5. If it touches **`internal/config`** yaml-tagged structs, complete step 6 (config schema sync) from the feature flow.
+6. Run **`make lint`**.
 
 ## Before calling work done
 
 - **`make test`** green.
 - OpenAPI and HTTP docs updated when the HTTP API changed.
+- **`docs/config.schema.json`** and **`docs/config-reference.md`** updated when `internal/config` yaml fields changed.
 - **`make lint`** clean.
 - **Rules sync** — if any `.claude/rules/*.md` file was added or changed, propagate to `.cursor/rules/`: copy the content body, replace `paths:` with Cursor-compatible `globs:`/`alwaysApply:`, rename to `.mdc`. Files without `paths:` get `alwaysApply: true`.

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -1,5 +1,5 @@
 ---
-description: BDD-style workflow, HTTP OpenAPI sync before lint, final checks
+description: BDD-style workflow, HTTP OpenAPI and config schema sync before lint, final checks
 globs: **/*.go, docs/**/*.md, README.md
 alwaysApply: true
 ---
@@ -15,8 +15,9 @@ When adding or changing behavior (including words like feature, add, implement, 
 3. Implement the smallest change that makes the test pass (green).
 4. Run **`make test`** (default, **`http`**, **`scheduler`**, **`ui-build`** then **`http,ui`**, combined scheduler tags). Everything must pass.
 5. **HTTP OpenAPI narrative** - If you changed the optional OpenAI-compatible HTTP API (routes, methods, headers, request or response bodies, status codes, or anything reflected in the served spec), update **`external/httpserver/openapi.go`** (`openAPISpec`) so it matches **`external/httpserver/server.go`** handlers and tests. Align **`docs/http-api.md`** (and **`README.md`** HTTP bullets) when user-facing descriptions change.
-6. Update documentation and specs if needed.
-7. Run **`make lint`** (`golangci-lint`). Fix reported issues.
+6. **Config schema sync** - If you changed the YAML config surface (**`internal/config`** structs: added, renamed, retyped, or removed a yaml-tagged field, enum value, or default), update **`docs/config.schema.json`** and the tables in **`docs/config-reference.md`** to match. **`TestDocsConfigSchemaMatchesStructs`** (**`internal/config/docs_schema_test.go`**) catches key/type drift, but descriptions, defaults, enums-in-prose, and the reference tables are not auto-checked - keep them accurate by hand. Mirror user-facing fields in **`config.example.yaml`** and **`UISchemaMap()`** (**`internal/config/ui_schema.go`**) as well.
+7. Update documentation and specs if needed.
+8. Run **`make lint`** (`golangci-lint`). Fix reported issues.
 
 Then report briefly: goal, tests added or changed, `make test` and `make lint` outcome, files touched.
 
@@ -26,12 +27,14 @@ Then report briefly: goal, tests added or changed, `make test` and `make lint` o
 2. Fix the code; confirm the new test passes.
 3. Run **`make test`**.
 4. If the bug or fix touches the HTTP API surface, complete step 5 (OpenAPI and docs) from the feature flow.
-5. Run **`make lint`**.
+5. If it touches **`internal/config`** yaml-tagged structs, complete step 6 (config schema sync) from the feature flow.
+6. Run **`make lint`**.
 
 ## Before calling work done
 
 - **`make test`** green.
 - OpenAPI and HTTP docs updated when the HTTP API changed.
+- **`docs/config.schema.json`** and **`docs/config-reference.md`** updated when `internal/config` yaml fields changed.
 - **`make lint`** clean.
 - **Rules sync** — if any `.cursor/rules/*.mdc` file was added or changed, propagate to `.claude/rules/`: copy the content body, replace `globs:`/`alwaysApply:` with Claude-compatible `paths:` (list form), rename to `.md`. Files with `alwaysApply: true` keep `paths:` matching the globs.
 
@@ -46,3 +49,6 @@ Then report briefly: goal, tests added or changed, `make test` and `make lint` o
 @docs/http-api.md
 @external/httpserver/server.go
 @external/httpserver/openapi.go
+@docs/config.schema.json
+@docs/config-reference.md
+@internal/config/docs_schema_test.go

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Full guide — access levels, group isolation modes, per-chat overrides, and how
 
 ## Configuration
 
-Full configuration reference in [docs/config.md](docs/config.md).
+Full configuration reference in [docs/config.md](docs/config.md); field-by-field tables in [docs/config-reference.md](docs/config-reference.md). A [JSON Schema](docs/config.schema.json) enables editor autocomplete and validation via a `# yaml-language-server: $schema=...` header (see `config.example.yaml`).
 
 Key settings:
 
@@ -477,7 +477,7 @@ See [Architecture docs](docs/architecture.md) for full details.
 - [Architecture](docs/architecture.md) - system design and component overview
 - [ACP Protocol](docs/acp-protocol.md) - protocol reference and message formats
 - [ReAct Agent](docs/react-agent.md) - ReAct loop design and tool specifications
-- [Configuration](docs/config.md) - full config file reference
+- [Configuration](docs/config.md) - full config file reference; [field tables](docs/config-reference.md) and [JSON Schema](docs/config.schema.json) for editor validation
 - [HTTP API](docs/http-api.md) - REST gateway (**`-tags=http`**) and embedded UI (**`-tags=http,ui`**); includes **`/coddy/config`** for live YAML editing from the SPA (**#/settings**).
 - [Embedded UI](docs/ui.md) - functional spec, Vite dev workflow, build tags
 - [DESIGN.md](DESIGN.md) - UI tokens and layout (English)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/coddy-project/coddy-agent/main/docs/config.schema.json
+# Full field reference: docs/config-reference.md
+
 # .env file support
 # If $CODDY_HOME/.env exists, it is loaded at startup before config.yaml is parsed.
 # Variables already set in the process environment are NOT overridden — .env is a fallback only.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,251 @@
+# `config.yaml` Field Reference
+
+Field-by-field reference for `~/.coddy/config.yaml`. For narrative documentation (file discovery, `.env`, provider guides) see [config.md](config.md).
+
+A machine-readable [JSON Schema](config.schema.json) accompanies this reference. Point your editor's YAML language server at it to get autocomplete and typo checking:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/coddy-project/coddy-agent/main/docs/config.schema.json
+```
+
+VS Code (with the YAML extension), IntelliJ, and Zed pick this comment up automatically. The schema is kept in sync with the Go config structs by `TestDocsConfigSchemaMatchesStructs` in `internal/config/docs_schema_test.go`.
+
+Every field is optional unless marked **required**; an empty `config.yaml` (or none at all) is valid and uses built-in defaults. Any string value may reference environment variables with `${VAR_NAME}` (expanded when the file is loaded). `${CODDY_HOME}` and `${CWD}` are expanded by the loader (see [config.md](config.md#environment-variable-references)).
+
+## Top-level keys
+
+| Key | Type | Purpose | Build tag |
+|---|---|---|---|
+| [`providers`](#providers) | list | LLM API credentials and endpoints | — |
+| [`models`](#models) | list | Logical model entries selectable per session | — |
+| [`agent`](#agent) | object | ReAct loop model and safety caps | — |
+| [`prompts`](#prompts) | object | System prompt template overrides | — |
+| [`instructions`](#instructions) | object | Project instruction files (AGENTS.md) | — |
+| [`skills`](#skills) | object | Skill discovery directories | — |
+| [`rules`](#rules) | object | Project rules discovery | — |
+| [`mcp_servers`](#mcp_servers) | list | MCP servers connected per session | — |
+| [`tools`](#tools) | object | Permission policy for built-in tools | — |
+| [`logger`](#logger) | object | Log level, outputs, rotation | — |
+| [`sessions`](#sessions) | object | Session bundle storage | — |
+| [`memory`](#memory) | object | Long-term memory copilot | `memory` |
+| [`httpserver`](#httpserver) | object | OpenAI-compatible HTTP API defaults | `http` |
+| [`scheduler`](#scheduler) | object | Cron scheduler | `scheduler` |
+| [`gateways`](#gateways) | object | Messenger bot adapters | `gateway` / `gateway.telegram` |
+
+"Build tag" means the block only takes effect in binaries built with that `-tags` value; it is parsed and ignored otherwise.
+
+## `providers`
+
+List of LLM backends (`[]config.ProviderConfig`, `internal/config/providers.go`).
+
+| Field | Type | Required | Default | Env fallback | Description |
+|---|---|---|---|---|---|
+| `name` | string | **yes** | — | — | Logical id used as the first segment of `models[].model`. Must match `^[a-zA-Z][a-zA-Z0-9_-]*$`. |
+| `type` | string | **yes** | — | — | Wire protocol: `openai` or `anthropic`. Use `openai` for any OpenAI-compatible endpoint (DeepSeek, Groq, Ollama, llama.cpp, LM Studio). |
+| `api_base` | string | no | provider SDK default | — | Base URL override. For `type: openai` include `/v1` (e.g. `http://localhost:11434/v1`); for `type: anthropic` an Anthropic-compatible gateway. |
+| `api_key` | string | no | `""` | `NAME_API_KEY` | Literal secret or `"${ENV}"` reference. Empty reads `NAME_API_KEY` at LLM call time (NAME = provider name uppercased, hyphens → underscores; e.g. `deepseek` → `DEEPSEEK_API_KEY`). |
+| `api_key_command` | string | no | `""` | — | Credential-helper command run via the shell when `api_key` is empty; trimmed stdout becomes the key. Falls back to `NAME_API_KEY` on failure. |
+| `proxy` | string | no | direct | — | Per-provider outbound proxy: `http://`, `https://`, `socks5://`, or `socks5h://` URL. |
+
+Key resolution order: `api_key` → `api_key_command` stdout → `NAME_API_KEY` env var.
+
+```yaml
+providers:
+  - name: openai
+    type: openai
+    api_key: "${OPENAI_API_KEY}"
+  - name: local
+    type: openai
+    api_base: "http://localhost:11434/v1"
+    api_key: "~"
+```
+
+## `models`
+
+List of logical models (`[]config.ModelEntry`, `internal/config/models.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `model` | string | **yes** | — | `"provider_name/api_model_id"`. First segment must match a `providers[].name`; the remainder is sent to the API verbatim (may contain slashes). |
+| `max_tokens` | int | no | `0` | Completion-token cap per assistant message. |
+| `temperature` | float | no | `0` | Sampling temperature. |
+| `max_context_tokens` | int | no | `0` | UI hint for the context bar; `0` derives from provider metadata. |
+| `multimodal` | bool | no | `false` | Model accepts image/file inputs; UI shows an attachment button. |
+| `reasoning_levels` | string list | no | auto-detected | Override the offered reasoning levels. Omitted: auto-detect from the model id (`gpt-5*` → `minimal,low,medium,high`; o-series and Claude thinking models → `low,medium,high`). Explicit `[]` hides the selector. |
+| `reasoning_default` | string | no | — | Level pre-selected for new chats; must be one of the resolved levels. |
+
+```yaml
+models:
+  - model: "openai/gpt-4o"
+    max_tokens: 8192
+    temperature: 0.2
+    multimodal: true
+  - model: "openai/gpt-5"
+    max_tokens: 8192
+    reasoning_default: medium
+```
+
+## `agent`
+
+ReAct loop settings (`config.Agent`, `internal/config/agent.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `model` | string | required when `models` is non-empty | — | Default `models[].model` id until the client overrides per session. |
+| `max_turns` | int | no | `30` | Max LLM calls per prompt turn. |
+| `max_tokens_per_turn` | int | no | `200000` | Max tokens across all calls in one turn. |
+| `llm_retry_max` | int | no | `3` | Retries after retryable LLM errors (e.g. HTTP 429). |
+| `llm_retry_base_ms` | int | no | `1000` | Initial backoff between retries, ms. |
+| `llm_min_interval_ms` | int | no | `0` | Minimum gap between consecutive LLM calls, ms (e.g. `12000` on strict free tiers). |
+
+## `prompts`
+
+System prompt template overrides (`config.Prompts`, `internal/config/prompts.go`). Template fields are documented in [config.md](config.md#full-configuration-schema).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `dir` | string | no | `""` (embedded templates) | Directory with Go text/template files. Supports `~` and `${CWD}` (session cwd at render time). |
+| `agent_prompt` | string | no | `agent.md` | Template file name for agent mode, inside `dir`. |
+| `plan_prompt` | string | no | `plan.md` | Template file name for plan mode, inside `dir`. |
+
+## `instructions`
+
+Project instruction files (`config.Instructions`, `internal/config/instructions.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `files` | string list | no | `["AGENTS.md"]` | Filenames relative to the session CWD, read and appended to the system prompt. |
+
+## `skills`
+
+Skill discovery (`config.Skills`, `internal/config/skills.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `dirs` | string list | no | `["~/.agents/skills", "${CODDY_HOME}/skills", "${CWD}/.coddy/skills"]` | Directories scanned for skills. Later entries have **higher** priority on name conflicts. `${CODDY_HOME}` and `${CWD}` expand at runtime (per-session cwd for `${CWD}`). |
+
+## `rules`
+
+Project rules discovery (`config.Rules`, `internal/config/rules.go`). See [rules.md](rules.md).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `auto_discover` | bool | no | `true` | Scan `.coddy/rules`, `.cursor/rules`, `.claude/rules`, `.codex/rules` under the session CWD. |
+| `systems` | string list | no | `[]` (all) | Restrict which rule systems are loaded: `coddy`, `cursor`, `claude`, `codex`. |
+
+## `mcp_servers`
+
+MCP servers connected for every new session (`[]config.MCPServerConfig`, `internal/config/mcp_servers.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `type` | string | no | `stdio` | Transport: `stdio` (local command) or `http` (remote endpoint). |
+| `name` | string | **yes** | — | Stable unique id. |
+| `command` | string | stdio only | — | Executable for stdio transport. |
+| `args` | string list | no | `[]` | Argv after `command`. `${CWD}` expands to the session cwd. |
+| `env` | list of `{name, value}` | no | `[]` | Extra environment variables for the stdio child process. |
+| `url` | string | http only | — | HTTP(S) endpoint for `type: http`. |
+| `headers` | list of `{name, value}` | no | `[]` | Headers sent with MCP HTTP requests (e.g. `Authorization`). |
+
+```yaml
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]
+```
+
+## `tools`
+
+Permission policy (`config.Tools`, `internal/config/tools.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `permission_mode` | string | no | `ask` | `ask` — prompt for commands and file writes; `accept_edits` — auto-approve writes, prompt for commands; `bypass` — never ask (trusted environments only). Overridable per session via ACP `session/set_config_option`. |
+| `command_allowlist` | string list | no | `[]` | Commands that never require permission. Exact or prefix match (prefix + space + args). `"*"` allows everything. |
+| `ssh_connect_timeout` | int | no | `30` | TCP dial timeout in seconds for the `ssh_run_command` tool. |
+
+## `logger`
+
+Logging (`config.Logger`, `internal/config/logger.go`). ACP flags `--log-level`, `--log-output`, `--log-file`, `--log-format` override these when set.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `level` | string | no | `info` | `debug`, `info`, `warn`, `error` (`warning` accepted as alias of `warn`). |
+| `outputs` | string list | no | `["stderr"]` | Any combination of `stdout`, `stderr`, `file`. |
+| `file` | string | required when `outputs` includes `file` | `""` | Path for the file sink. Supports `${CODDY_HOME}`. |
+| `format` | string | no | `text` | `text` or `json`. |
+| `rotation.max_size_mb` | int | no | `0` | Rotate after this size in MB; `0` disables size-based rotation. |
+| `rotation.max_files` | int | no | `0` | Rotated backups to keep when `max_size_mb > 0`. |
+
+## `sessions`
+
+Session bundle storage (`config.Sessions`, `internal/config/sessions.go`).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `dir` | string | no | `""` → `${CODDY_HOME}/sessions` | Sessions root. Supports `${CODDY_HOME}` and `~`. Overridden by the `--sessions-dir` flag. |
+
+## `memory`
+
+Long-term memory copilot (`config.MemoryConfig`, `internal/config/memory.go`; implementation in `external/memory`, `memory` build tag).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `enabled` | bool | no | `false` | Turn on the memory copilot. |
+| `model` | string | no | `""` (agent model) | Exact `models[].model` id used only for recall/persist LLM calls. |
+| `dir` | string | no | `""` → `${CODDY_HOME}/memory` | Long-term memory root. Supports `${CODDY_HOME}` and `~`. |
+| `recall_max_turns` | int | no | `6` | Bounds recall-side LLM rounds. |
+| `persist_max_turns` | int | no | `12` | Bounds persist-side LLM rounds. |
+| `copilot_max_tokens` | int | no | `4096` | Completion cap for memory LLM calls. |
+| `max_search_hits` | int | no | `8` | Max snippets returned by `memory_search`. |
+
+## `httpserver`
+
+OpenAI-compatible HTTP API defaults (`config.HTTPServerConfig`, `internal/config/http.go`; `http` build tag). See [http-api.md](http-api.md).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `host` | string | no | `""` → `0.0.0.0` | Default bind address when `coddy http` does not pass `-H/--host`. |
+| `port` | int | no | `0` → `12345` | Default listen port when `coddy http` does not pass `-P/--port`. Range 0–65535. |
+
+## `scheduler`
+
+Cron scheduler (`config.SchedulerConfig`, `internal/config/scheduler.go`; `scheduler` build tag). Job file format is described in [config.md](config.md#scheduler-optional-build).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `enabled` | bool | no | `false` | Run the scheduler daemon and expose `coddy_scheduler_*` tools. `coddy acp\|http -scheduler-enabled` forces it per process. |
+| `dir` | string | no | `""` → `${CODDY_HOME}/scheduler` | Directory with flat `*.md` job definitions. |
+| `max_queue` | int | no | `10` | Concurrent scheduled runs; extra firings are skipped when saturated. |
+| `timeout` | string | no | `"30m"` | Per-run wall-clock limit (Go duration, e.g. `1h30m`). |
+| `retain_sessions` | int | no | `5` | Completed run session dirs kept per `job_id` under `sessions.dir`. |
+
+## `gateways`
+
+Messenger gateways (`config.GatewayConfig`, `internal/config/gateway.go`; `gateway` or `gateway.telegram` build tag; run with `coddy gateway`). See [gateway.md](gateway.md).
+
+### `gateways.telegram`
+
+| Field | Type | Required | Default | Env fallback | Description |
+|---|---|---|---|---|---|
+| `enabled` | bool | no | `false` | — | Activate the Telegram adapter. |
+| `token` | string | no | `""` | `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather. Empty reads the env var (e.g. via `~/.coddy/.env`). |
+| `proxy` | string | no | direct | — | Outbound proxy: `http`, `https`, `socks5`, `socks5h`. |
+| `rich_messages` | bool | no | `false` | — | Bot API 10.1 Rich Messages; falls back to legacy formatting when unsupported. |
+| `admins` | int list | no | `[]` | — | Telegram user IDs with elevated rights; always pass access checks. |
+| `default_access` | string | no | `all` | — | `all`, `admins`, or `group:<name>`. |
+| `default_isolation` | string | no | `individual` | — | `individual`, `shared`, or `admin`. |
+| `user_groups` | list | no | `[]` | — | Named sets: `{name, user_ids}`. Referenced as `group:<name>`. |
+| `chats` | list | no | `[]` | — | Per-chat overrides: `{chat_id, isolation, access}`. `chat_id` is negative for groups/supergroups. |
+
+## Related environment variables
+
+These control config discovery itself, not individual fields (see [config.md](config.md#config-file-location-and-paths)):
+
+| Variable | Flag equivalent | Meaning |
+|---|---|---|
+| `CODDY_HOME` | `--home` | Agent state directory (default `~/.coddy`). |
+| `CODDY_CWD` | `--cwd` | Default session working directory. |
+| `CODDY_CONFIG` | `--config` | Explicit path to `config.yaml`. |
+| `NAME_API_KEY` | — | Per-provider API key fallback (see [`providers`](#providers)). |
+| `TELEGRAM_BOT_TOKEN` | — | Telegram bot token fallback (see [`gateways.telegram`](#gatewaystelegram)). |

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,16 @@
 # Configuration Reference
 
+This page is the narrative guide. Two companion artifacts cover the full key list:
+
+- **[config-reference.md](config-reference.md)** - field-by-field tables: type, default, env-var fallback, required/optional, examples.
+- **[config.schema.json](config.schema.json)** - JSON Schema (draft-07) for editor autocomplete and validation. Add this header line to your `config.yaml` and any editor with a YAML language server (VS Code YAML extension, IntelliJ, Zed) validates keys and values as you type:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/coddy-project/coddy-agent/main/docs/config.schema.json
+```
+
+The schema is kept in sync with the Go config structs by `TestDocsConfigSchemaMatchesStructs` (`internal/config/docs_schema_test.go`); CI fails when a config field is added or renamed without updating the schema.
+
 ## Config File Location and Paths
 
 Resolved locations use environment variables and flags (see README). In short:

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1,0 +1,538 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/coddy-project/coddy-agent/main/docs/config.schema.json",
+  "title": "Coddy config.yaml",
+  "description": "Configuration file for the Coddy agent (default location: ~/.coddy/config.yaml). Reference: docs/config-reference.md. Any string value may reference environment variables with ${VAR_NAME}; ${CODDY_HOME} and ${CWD} are expanded by the loader.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "providers": {
+      "type": "array",
+      "title": "LLM providers",
+      "description": "API credentials and transport selection for upstream LLM vendors. When api_key is empty, the runtime reads the NAME_API_KEY environment variable (NAME is the provider name in uppercase with hyphens mapped to underscores).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "type"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Logical id used as the first segment of models[].model. ASCII letters, digits, hyphen, underscore; must start with a letter.",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+          },
+          "type": {
+            "type": "string",
+            "description": "Wire protocol for this provider. Use \"openai\" for any OpenAI-compatible endpoint (OpenAI, DeepSeek, Groq, Ollama, llama.cpp, LM Studio).",
+            "enum": ["openai", "anthropic"]
+          },
+          "api_base": {
+            "type": "string",
+            "description": "Optional base URL override. For type \"openai\" include /v1 (e.g. http://localhost:11434/v1); for type \"anthropic\" an Anthropic-compatible gateway (default https://api.anthropic.com)."
+          },
+          "api_key": {
+            "type": "string",
+            "description": "Provider secret. A literal key, a \"${ENV}\" reference expanded at load time, or empty to read NAME_API_KEY at LLM call time. Resolution order: api_key -> api_key_command stdout -> NAME_API_KEY."
+          },
+          "api_key_command": {
+            "type": "string",
+            "description": "Optional credential-helper command. When api_key is empty it runs via the shell and the trimmed stdout is used as the key (like git/docker credential helpers). On failure resolution falls back to NAME_API_KEY."
+          },
+          "proxy": {
+            "type": "string",
+            "description": "Optional per-provider outbound proxy URL: http://, https://, socks5://, or socks5h:// (socks5h resolves hostnames via the proxy)."
+          }
+        }
+      }
+    },
+    "models": {
+      "type": "array",
+      "title": "Logical models",
+      "description": "Named model entries the agent and UI can select.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["model"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "\"provider_name/api_model_id\": the first path segment must match a providers[].name; the remainder is sent to the LLM API (may itself contain slashes).",
+            "pattern": "^[^/]+/.+$"
+          },
+          "max_tokens": {
+            "type": "integer",
+            "description": "Upper bound on completion tokens per assistant message."
+          },
+          "temperature": {
+            "type": "number",
+            "description": "Sampling temperature (0 = deterministic; higher = more random)."
+          },
+          "max_context_tokens": {
+            "type": "integer",
+            "description": "Optional UI hint for the composer context bar; 0 derives it from provider metadata when available.",
+            "default": 0
+          },
+          "multimodal": {
+            "type": "boolean",
+            "description": "Model accepts image/file inputs in addition to text; the UI shows a file attachment button for this model.",
+            "default": false
+          },
+          "reasoning_levels": {
+            "type": "array",
+            "description": "Override the reasoning levels offered for this model. Omit to auto-detect from the model id (gpt-5* -> minimal,low,medium,high; o-series and Claude thinking models -> low,medium,high). An explicit empty list hides the selector.",
+            "items": { "type": "string" }
+          },
+          "reasoning_default": {
+            "type": "string",
+            "description": "Reasoning level pre-selected for new chats; must be one of the resolved levels, otherwise ignored."
+          }
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "title": "ReAct agent loop",
+      "description": "Defaults for the main agent loop (model id and safety caps).",
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Default models[].model id used until the client overrides the model per session. Required when models is non-empty."
+        },
+        "max_turns": {
+          "type": "integer",
+          "description": "Hard cap on LLM calls per prompt turn.",
+          "default": 30,
+          "minimum": 0
+        },
+        "max_tokens_per_turn": {
+          "type": "integer",
+          "description": "Max tokens across all LLM calls in one turn.",
+          "default": 200000,
+          "minimum": 0
+        },
+        "llm_retry_max": {
+          "type": "integer",
+          "description": "Retries after retryable LLM errors such as HTTP 429.",
+          "default": 3,
+          "minimum": 0
+        },
+        "llm_retry_base_ms": {
+          "type": "integer",
+          "description": "Initial backoff between LLM retries, in milliseconds.",
+          "default": 1000,
+          "minimum": 0
+        },
+        "llm_min_interval_ms": {
+          "type": "integer",
+          "description": "Minimum gap between consecutive LLM calls in milliseconds (0 disables pacing; e.g. 12000 on strict free tiers).",
+          "default": 0,
+          "minimum": 0
+        }
+      }
+    },
+    "prompts": {
+      "type": "object",
+      "title": "System prompt templates",
+      "description": "Override the built-in system prompt templates (Go text/template).",
+      "additionalProperties": false,
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Directory containing prompt template files. Empty uses embedded defaults. Supports ~ and ${CWD} (session cwd at render time).",
+          "default": ""
+        },
+        "agent_prompt": {
+          "type": "string",
+          "description": "File name inside prompts.dir for agent mode.",
+          "default": "agent.md"
+        },
+        "plan_prompt": {
+          "type": "string",
+          "description": "File name inside prompts.dir for plan mode.",
+          "default": "plan.md"
+        }
+      }
+    },
+    "instructions": {
+      "type": "object",
+      "title": "Project instructions",
+      "description": "Files read from the session working directory and appended to the system prompt (AGENTS.md convention).",
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "type": "array",
+          "description": "Filenames relative to the session CWD.",
+          "default": ["AGENTS.md"],
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "skills": {
+      "type": "object",
+      "title": "Skills",
+      "description": "Directories scanned for skills (SKILL.md and root .md/.mdc files).",
+      "additionalProperties": false,
+      "properties": {
+        "dirs": {
+          "type": "array",
+          "description": "Search paths; later entries win on name conflicts. Defaults (lowest to highest priority): ~/.agents/skills, ${CODDY_HOME}/skills, ${CWD}/.coddy/skills. ${CODDY_HOME} and ${CWD} expand at runtime.",
+          "default": ["~/.agents/skills", "${CODDY_HOME}/skills", "${CWD}/.coddy/skills"],
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "rules": {
+      "type": "object",
+      "title": "Project rules",
+      "description": "Discovery of rule files from .coddy/rules, .cursor/rules, .claude/rules, .codex/rules under the session CWD. See docs/rules.md.",
+      "additionalProperties": false,
+      "properties": {
+        "auto_discover": {
+          "type": "boolean",
+          "description": "Scan the session CWD rule roots automatically.",
+          "default": true
+        },
+        "systems": {
+          "type": "array",
+          "description": "Restrict which rule systems are loaded: coddy, cursor, claude, codex. Empty means all.",
+          "default": [],
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "mcp_servers": {
+      "type": "array",
+      "title": "MCP servers",
+      "description": "Model Context Protocol servers connected for every new session.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Transport. \"stdio\" (default when empty) runs a local command; \"http\" connects to a remote endpoint via url/headers.",
+            "enum": ["stdio", "http"]
+          },
+          "name": {
+            "type": "string",
+            "description": "Stable id referenced by the agent; must be unique in this list."
+          },
+          "command": {
+            "type": "string",
+            "description": "Executable for stdio transport (leave empty when using an http url)."
+          },
+          "args": {
+            "type": "array",
+            "description": "Argv passed after command for stdio servers. ${CWD} expands to the session cwd.",
+            "items": { "type": "string" }
+          },
+          "env": {
+            "type": "array",
+            "description": "Extra environment variables for the stdio child process.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name", "value"],
+              "properties": {
+                "name": { "type": "string", "description": "Environment variable name." },
+                "value": { "type": "string", "description": "Environment variable value. ${CWD} expands to the session cwd." }
+              }
+            }
+          },
+          "url": {
+            "type": "string",
+            "description": "HTTP(S) endpoint when type is \"http\"."
+          },
+          "headers": {
+            "type": "array",
+            "description": "Optional headers sent with MCP HTTP requests.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name", "value"],
+              "properties": {
+                "name": { "type": "string", "description": "HTTP header name." },
+                "value": { "type": "string", "description": "HTTP header value." }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "title": "Tools and permissions",
+      "description": "Filesystem and shell policy for built-in tools.",
+      "additionalProperties": false,
+      "properties": {
+        "permission_mode": {
+          "type": "string",
+          "description": "When the agent asks for user approval: \"ask\" prompts for commands and file writes; \"accept_edits\" auto-approves writes but prompts for commands; \"bypass\" never asks (trusted environments only).",
+          "default": "ask",
+          "enum": ["ask", "accept_edits", "bypass"]
+        },
+        "command_allowlist": {
+          "type": "array",
+          "description": "Commands that never require permission. Exact or prefix match (prefix + space + any args). \"*\" allows all commands.",
+          "items": { "type": "string" }
+        },
+        "ssh_connect_timeout": {
+          "type": "integer",
+          "description": "TCP dial timeout for SSH connections (ssh_run_command tool), in seconds.",
+          "default": 30
+        }
+      }
+    },
+    "logger": {
+      "type": "object",
+      "title": "Logging",
+      "description": "Process log level, outputs, format, and file rotation.",
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "description": "Minimum severity written to the configured outputs (\"warning\" is accepted as an alias of \"warn\").",
+          "default": "info",
+          "enum": ["debug", "info", "warn", "warning", "error"]
+        },
+        "outputs": {
+          "type": "array",
+          "description": "Where log records go; any combination of stdout, stderr, file. Empty means stderr only.",
+          "default": ["stderr"],
+          "items": {
+            "type": "string",
+            "enum": ["stdout", "stderr", "file"]
+          }
+        },
+        "file": {
+          "type": "string",
+          "description": "Path for the file sink; required when outputs includes \"file\". Supports ${CODDY_HOME}."
+        },
+        "format": {
+          "type": "string",
+          "description": "Log record format.",
+          "default": "text",
+          "enum": ["text", "json"]
+        },
+        "rotation": {
+          "type": "object",
+          "description": "Size-based rotation for the file sink.",
+          "additionalProperties": false,
+          "properties": {
+            "max_size_mb": {
+              "type": "integer",
+              "description": "Rotate after the file reaches this size in MB; 0 disables size-based rotation.",
+              "default": 0,
+              "minimum": 0
+            },
+            "max_files": {
+              "type": "integer",
+              "description": "Rotated backups to keep when max_size_mb > 0.",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "sessions": {
+      "type": "object",
+      "title": "Session storage",
+      "description": "Where persisted session bundles are stored.",
+      "additionalProperties": false,
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Sessions root directory. Empty resolves to ${CODDY_HOME}/sessions. Supports ${CODDY_HOME} and ~.",
+          "default": ""
+        }
+      }
+    },
+    "memory": {
+      "type": "object",
+      "title": "Long-term memory copilot",
+      "description": "Optional memory copilot (implementation in external/memory; enable at runtime with memory.enabled).",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Turn on the memory copilot.",
+          "default": false
+        },
+        "model": {
+          "type": "string",
+          "description": "Exact models[].model id used only for recall/persist LLM calls; empty falls back to agent.model or the session override.",
+          "default": ""
+        },
+        "dir": {
+          "type": "string",
+          "description": "Long-term memory root. Empty resolves to ${CODDY_HOME}/memory. Supports ${CODDY_HOME} and ~.",
+          "default": ""
+        },
+        "recall_max_turns": {
+          "type": "integer",
+          "description": "Bounds recall-side LLM rounds in the memory loop.",
+          "default": 6
+        },
+        "persist_max_turns": {
+          "type": "integer",
+          "description": "Bounds persist-side LLM rounds in the memory loop.",
+          "default": 12
+        },
+        "copilot_max_tokens": {
+          "type": "integer",
+          "description": "Completion token cap for memory copilot LLM calls.",
+          "default": 4096
+        },
+        "max_search_hits": {
+          "type": "integer",
+          "description": "Maximum snippets returned by memory_search.",
+          "default": 8
+        }
+      }
+    },
+    "httpserver": {
+      "type": "object",
+      "title": "HTTP gateway",
+      "description": "OpenAI-compatible HTTP API defaults (used only by binaries built with -tags http; the embedded SPA needs -tags http,ui). See docs/http-api.md.",
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Default bind address when coddy http does not pass -H/--host. Empty falls back to 0.0.0.0.",
+          "default": ""
+        },
+        "port": {
+          "type": "integer",
+          "description": "Default listen port when coddy http does not pass -P/--port. 0 falls back to 12345.",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 65535
+        }
+      }
+    },
+    "scheduler": {
+      "type": "object",
+      "title": "Cron scheduler",
+      "description": "Cron-driven scheduled jobs (used only by binaries built with -tags scheduler). Jobs are flat *.md files with YAML frontmatter under scheduler.dir; five-field crontab in UTC.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run the scheduler daemon and expose the coddy_scheduler_* tools. Can also be forced per process with coddy acp|http -scheduler-enabled.",
+          "default": false
+        },
+        "dir": {
+          "type": "string",
+          "description": "Directory with *.md job definitions. Empty resolves to ${CODDY_HOME}/scheduler.",
+          "default": ""
+        },
+        "max_queue": {
+          "type": "integer",
+          "description": "Concurrent scheduled runs; when saturated, extra firings are skipped until a slot frees.",
+          "default": 10
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Wall-clock limit for one scheduled agent run, as a Go duration (e.g. \"30m\", \"1h30m\").",
+          "default": "30m"
+        },
+        "retain_sessions": {
+          "type": "integer",
+          "description": "Completed scheduler-run session directories kept per job_id under sessions.dir; older runs are pruned.",
+          "default": 5
+        }
+      }
+    },
+    "gateways": {
+      "type": "object",
+      "title": "Messenger gateways",
+      "description": "Messenger bot adapters (used only by binaries built with -tags gateway or -tags gateway.telegram; run with coddy gateway). See docs/gateway.md.",
+      "additionalProperties": false,
+      "properties": {
+        "telegram": {
+          "type": "object",
+          "description": "Telegram bot adapter.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Activate the Telegram adapter when coddy gateway starts.",
+              "default": false
+            },
+            "token": {
+              "type": "string",
+              "description": "Bot token from @BotFather. Leave empty to read the TELEGRAM_BOT_TOKEN environment variable (e.g. via ~/.coddy/.env).",
+              "default": ""
+            },
+            "proxy": {
+              "type": "string",
+              "description": "Optional outbound proxy for Telegram API requests: http, https, socks5, or socks5h URL.",
+              "default": ""
+            },
+            "rich_messages": {
+              "type": "boolean",
+              "description": "Use Bot API 10.1 Rich Messages (native Markdown, streamed thinking placeholder, collapsible tool list). Falls back to legacy formatting when unsupported.",
+              "default": false
+            },
+            "admins": {
+              "type": "array",
+              "description": "Telegram user IDs with elevated rights; admins always pass access checks.",
+              "items": { "type": "integer" }
+            },
+            "default_access": {
+              "type": "string",
+              "description": "Fallback access level for chats without an override: \"all\", \"admins\", or \"group:<name>\".",
+              "default": "all"
+            },
+            "default_isolation": {
+              "type": "string",
+              "description": "Fallback session isolation for group chats: \"individual\" (session per user), \"shared\" (one session for all), \"admin\" (admins only, shared session).",
+              "default": "individual",
+              "enum": ["individual", "shared", "admin"]
+            },
+            "user_groups": {
+              "type": "array",
+              "description": "Named sets of user IDs referenced from access fields as group:<name>.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "description": "Group name referenced as group:<name>." },
+                  "user_ids": {
+                    "type": "array",
+                    "description": "Telegram numeric user IDs in this group.",
+                    "items": { "type": "integer" }
+                  }
+                }
+              }
+            },
+            "chats": {
+              "type": "array",
+              "description": "Per-chat overrides; chat_id is negative for groups and supergroups.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["chat_id"],
+                "properties": {
+                  "chat_id": { "type": "integer", "description": "Telegram chat id (negative for groups/supergroups)." },
+                  "isolation": {
+                    "type": "string",
+                    "description": "Per-chat session isolation override.",
+                    "enum": ["individual", "shared", "admin"]
+                  },
+                  "access": {
+                    "type": "string",
+                    "description": "Per-chat access override: \"all\", \"admins\", or \"group:<name>\"."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/config/docs_schema_test.go
+++ b/internal/config/docs_schema_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// docsSchemaPath is the published editor-facing JSON Schema for config.yaml.
+const docsSchemaPath = "../../docs/config.schema.json"
+
+func loadDocsSchema(t *testing.T) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(docsSchemaPath))
+	if err != nil {
+		t.Fatalf("read %s: %v (the schema must be committed alongside the config structs)", docsSchemaPath, err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", docsSchemaPath, err)
+	}
+	return doc
+}
+
+// yamlFieldName returns the effective YAML key for a struct field, or "" when skipped.
+func yamlFieldName(f reflect.StructField) string {
+	tag := f.Tag.Get("yaml")
+	name := tag
+	if c := strings.IndexByte(tag, ','); c >= 0 {
+		name = tag[:c]
+	}
+	if name == "-" {
+		return ""
+	}
+	if name == "" {
+		return strings.ToLower(f.Name)
+	}
+	return name
+}
+
+// schemaTypeForGoType maps a Go config field type to the expected JSON Schema "type" value.
+func schemaTypeForGoType(t reflect.Type) string {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "integer"
+	case reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	case reflect.Struct, reflect.Map:
+		return "object"
+	default:
+		return ""
+	}
+}
+
+// checkSchemaNodeMatchesType recursively verifies that a schema node describes goType.
+func checkSchemaNodeMatchesType(t *testing.T, path string, goType reflect.Type, node map[string]interface{}) {
+	t.Helper()
+	if goType.Kind() == reflect.Pointer {
+		goType = goType.Elem()
+	}
+	wantType := schemaTypeForGoType(goType)
+	gotType, _ := node["type"].(string)
+	if gotType != wantType {
+		t.Errorf("%s: schema type %q, want %q", path, gotType, wantType)
+		return
+	}
+	switch goType.Kind() {
+	case reflect.Slice, reflect.Array:
+		items, ok := node["items"].(map[string]interface{})
+		if !ok {
+			t.Errorf("%s: array schema missing items", path)
+			return
+		}
+		checkSchemaNodeMatchesType(t, path+"[]", goType.Elem(), items)
+	case reflect.Struct:
+		props, ok := node["properties"].(map[string]interface{})
+		if !ok {
+			t.Errorf("%s: object schema missing properties", path)
+			return
+		}
+		if ap, ok := node["additionalProperties"].(bool); !ok || ap {
+			t.Errorf("%s: object schema must set additionalProperties:false so editors flag typos", path)
+		}
+		want := map[string]reflect.Type{}
+		for i := 0; i < goType.NumField(); i++ {
+			f := goType.Field(i)
+			name := yamlFieldName(f)
+			if name == "" {
+				continue
+			}
+			want[name] = f.Type
+		}
+		for name, ft := range want {
+			sub, ok := props[name].(map[string]interface{})
+			if !ok {
+				t.Errorf("%s: schema missing property %q (add it to docs/config.schema.json)", path, name)
+				continue
+			}
+			checkSchemaNodeMatchesType(t, path+"."+name, ft, sub)
+		}
+		for name := range props {
+			if _, ok := want[name]; !ok {
+				t.Errorf("%s: schema has property %q not present in the Go config structs (remove it or add the field)", path, name)
+			}
+		}
+	}
+}
+
+// TestDocsConfigSchemaMatchesStructs keeps docs/config.schema.json in sync with the
+// yaml-tagged config structs: every YAML key must appear in the schema with the right
+// type, and the schema must not describe keys the loader does not know.
+func TestDocsConfigSchemaMatchesStructs(t *testing.T) {
+	doc := loadDocsSchema(t)
+	checkSchemaNodeMatchesType(t, "$", reflect.TypeOf(Config{}), doc)
+}
+
+// TestDocsConfigSchemaEnums pins schema enums to the constants the loader validates against.
+func TestDocsConfigSchemaEnums(t *testing.T) {
+	doc := loadDocsSchema(t)
+
+	enumAt := func(pathParts ...string) []string {
+		node := doc
+		for i, p := range pathParts {
+			var ok bool
+			if node, ok = node[p].(map[string]interface{}); !ok {
+				t.Fatalf("schema path %v: segment %q not found", pathParts, pathParts[i])
+			}
+		}
+		raw, ok := node["enum"].([]interface{})
+		if !ok {
+			t.Fatalf("schema path %v: enum missing", pathParts)
+		}
+		out := make([]string, 0, len(raw))
+		for _, v := range raw {
+			s, _ := v.(string)
+			out = append(out, s)
+		}
+		return out
+	}
+
+	assertSet := func(name string, got []string, want map[string]struct{}) {
+		t.Helper()
+		gotSet := map[string]struct{}{}
+		for _, v := range got {
+			gotSet[v] = struct{}{}
+		}
+		if len(gotSet) != len(want) {
+			t.Errorf("%s: enum %v, want keys of %v", name, got, want)
+			return
+		}
+		for k := range want {
+			if _, ok := gotSet[k]; !ok {
+				t.Errorf("%s: enum %v missing %q", name, got, k)
+			}
+		}
+	}
+
+	assertSet("providers[].type",
+		enumAt("properties", "providers", "items", "properties", "type"),
+		AllowedLLMProviderTypes)
+
+	assertSet("tools.permission_mode",
+		enumAt("properties", "tools", "properties", "permission_mode"),
+		map[string]struct{}{PermModeAsk: {}, PermModeAcceptEdits: {}, PermModeBypass: {}})
+
+	assertSet("logger.format",
+		enumAt("properties", "logger", "properties", "format"),
+		map[string]struct{}{LogFormatText: {}, LogFormatJSON: {}})
+
+	assertSet("logger.level",
+		enumAt("properties", "logger", "properties", "level"),
+		map[string]struct{}{
+			LogLevelDebug: {}, LogLevelInfo: {}, LogLevelWarn: {}, LogLevelError: {},
+			// The loader also accepts "warning" and normalises it to "warn".
+			"warning": {},
+		})
+
+	assertSet("logger.outputs[]",
+		enumAt("properties", "logger", "properties", "outputs", "items"),
+		map[string]struct{}{LogOutputStdout: {}, LogOutputStderr: {}, LogOutputFile: {}})
+
+	assertSet("gateways.telegram.default_isolation",
+		enumAt("properties", "gateways", "properties", "telegram", "properties", "default_isolation"),
+		map[string]struct{}{
+			string(IsolationIndividual): {}, string(IsolationShared): {}, string(IsolationAdmin): {},
+		})
+}


### PR DESCRIPTION
Closes #43.

## What

- **`docs/config.schema.json`** — JSON Schema (draft-07) covering every `config.yaml` key: descriptions, defaults, enums (`providers[].type`, `tools.permission_mode`, `logger.*`, isolation modes), patterns (`providers[].name`, `models[].model`), and `additionalProperties: false` on every object so editors flag typos like `api_kye` before runtime.
- **`docs/config-reference.md`** — field-by-field reference tables for every top-level key + subkey: type, default, env-var fallback (`NAME_API_KEY`, `TELEGRAM_BOT_TOKEN`), required/optional, examples, and which build tag each block needs.
- **Sync test** — `internal/config/docs_schema_test.go` walks the yaml-tagged Go config structs with reflection and fails when the schema misses a key, describes an unknown key, or has a wrong type; a second test pins schema enums to the loader constants (`AllowedLLMProviderTypes`, `PermMode*`, `Log*`, isolation modes). Adding or renaming a config field without updating the schema now breaks CI.
- **Editor integration** — `config.example.yaml` now starts with `# yaml-language-server: $schema=https://raw.githubusercontent.com/coddy-project/coddy-agent/main/docs/config.schema.json`, and `docs/config.md` / `README.md` document the header. The schema's `$id` points at the same GitHub raw URL, so it is stable as soon as this merges (a coddy.dev URL can alias it later without breaking anything).

## Notes

- The schema is hand-written (per the issue's suggested scope) because the existing `UISchemaMap()` targets the JSON DTO for the settings UI, which intentionally hides `httpserver` and lacks YAML-only fields (`rules`, `tools.ssh_connect_timeout`). The new reflection test provides the keep-in-sync guarantee instead.
- `mcp_servers[].type` is documented as `stdio`/`http` matching the config structs and docs; the session manager currently only connects `stdio`.

## Testing

- `go test ./internal/config` — new `TestDocsConfigSchemaMatchesStructs` and `TestDocsConfigSchemaEnums` pass.
- `golangci-lint run ./internal/config/...` (v2.12.2, same as CI) — clean.
- Full `make test` on this Windows machine hits pre-existing environment failures (missing `rg` in PATH, Windows path-separator assumptions, and a pre-existing `${CODDY_HOME}`-into-YAML backslash-escape bug in `TestLoadFromYAML_EndToEnd`); all of them reproduce identically on a clean checkout without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)