### PR TITLE
Discover nested AGENTS.md alongside .cursor/.coddy/.claude/.codex rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Coddy is a distroless-friendly **harness**: drop it into minimal images (`scratc
 - **Harness-first** - ACP server, session lifecycle, prompts, LLM backends, MCP merge, distroless-ready binary
 - **ReAct loop** - LLM alternates between reasoning, acting (tool calls), and observing results (coding-agent persona out of the box)
 - **Two operating modes** - `agent` (full tool access) and `plan` (planning + text files only)
-- **Rules** - auto-discovers **`.cursor/rules/`**, **`.coddy/rules/`**, **`.claude/rules/`**, and **`.codex/rules/`** under the session cwd - see [Rules](docs/rules.md)
+- **Rules** - auto-discovers **`.cursor/rules/`**, **`.coddy/rules/`**, **`.claude/rules/`**, **`.codex/rules/`**, and nested **`**/AGENTS.md`** ([agents.md](https://agents.md/)) under the session cwd - see [Rules](docs/rules.md)
 - **Skills** - slash commands and **`SKILL.md`** packs from **`skills.dirs`** (defaults: **`~/.agents/skills`**, **`~/.coddy/skills`**, **`${CWD}/.coddy/skills`**; later dirs override earlier) - see [Skills](docs/skills.md)
 - **MCP server integration** - connect any MCP server for additional tools
 - **Multi-provider LLM** - OpenAI, Anthropic, Ollama, any OpenAI-compatible API
@@ -333,7 +333,7 @@ Use your editor session mode selector (or **`session/set_config_option`**).
 
 ## Rules
 
-Project rules (injected as **`{{.Rules}}`**) are discovered under the session working directory from **`.coddy/rules`**, **`.cursor/rules`**, **`.claude/rules`**, and **`.codex/rules`** when **`rules.auto_discover`** is true. See **[`docs/rules.md`](docs/rules.md)**.
+Project rules (injected as **`{{.Rules}}`**) are discovered under the session working directory from **`.coddy/rules`**, **`.cursor/rules`**, **`.claude/rules`**, **`.codex/rules`**, and nested **`**/AGENTS.md`** ([agents.md](https://agents.md/) convention; the root `AGENTS.md` is injected separately as a project docs preamble) when **`rules.auto_discover`** is true. See **[`docs/rules.md`](docs/rules.md)**.
 
 Rule files often use Cursor-style frontmatter, for example:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ by pluggable LLM providers. Ship it as one binary suitable for scratch or distro
 sidecars, CI sandboxes, or local installs.
 
 The default toolset and prompts are tuned so the harness presents as an **interactive coding agent**
-(ACP clients spawn `coddy acp`; users get filesystem, commands, MCP, project rules from `.coddy`/`.cursor`/`.claude`/`.codex` rule trees under session cwd, and skills from `skills.dirs`).
+(ACP clients spawn `coddy acp`; users get filesystem, commands, MCP, project rules from `.coddy`/`.cursor`/`.claude`/`.codex` rule trees plus nested `AGENTS.md` files under session cwd, and skills from `skills.dirs`).
 That coding-agent surface is **a productized profile on top of the harness**, not the only way to run Coddy.
 
 ## High-Level Architecture
@@ -186,7 +186,7 @@ Loads `SKILL.md` from configured `skills.dirs` (see `docs/skills.md`). Default d
 
 ### Rules engine (`internal/rules`)
 
-Discovers `.mdc` / `.md` rules from `.coddy/rules`, `.cursor/rules`, `.claude/rules`, `.codex/rules` under session CWD. Injected into **`{{.Rules}}`** separately from skills; see **`docs/rules.md`**.
+Discovers `.mdc` / `.md` rules from `.coddy/rules`, `.cursor/rules`, `.claude/rules`, `.codex/rules`, plus nested `**/AGENTS.md` files ([agents.md](https://agents.md/) convention), under session CWD. Injected into **`{{.Rules}}`** separately from skills; see **`docs/rules.md`**.
 
 Activation uses globs, **`alwaysApply`**, **`@mention`**, and sticky auto rules (see **`docs/rules.md`**).
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -137,11 +137,12 @@ skills:
     - "${CWD}/.coddy/skills"
 
 # Project rules (Go: config.Rules, internal/config/rules.go)
-# Discovered from .coddy/rules, .cursor/rules, .claude/rules, .codex/rules under session CWD.
+# Discovered from .coddy/rules, .cursor/rules, .claude/rules, .codex/rules,
+# and nested **/AGENTS.md under session CWD.
 # Injected into {{.Rules}} in the system prompt (separate from skills). See docs/rules.md.
 rules:
   auto_discover: true
-  systems: []   # optional: coddy, cursor, claude, codex
+  systems: []   # optional: coddy, cursor, claude, codex, agents
 
 # MCP servers available to all sessions (Go: []config.MCPServerConfig, internal/config/mcp_servers.go)
 mcp_servers:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -23,8 +23,11 @@ When `rules.auto_discover` is true (default), Coddy scans:
 | Cursor | `.cursor/rules/` |
 | Claude | `.claude/rules/` |
 | Codex | `.codex/rules/` (markdown only in v1) |
+| Agents | nested `**/AGENTS.md` ([agents.md](https://agents.md/) convention; hidden dirs, `node_modules`, `vendor` skipped) |
 
-Duplicate rule files (same basename) resolve with precedence: **coddy > cursor > claude > codex**.
+Duplicate rule files (same basename) resolve with precedence: **coddy > cursor > claude > codex > agents**. Nested `AGENTS.md` files are keyed by full path, so they never collapse into each other.
+
+Nested `AGENTS.md` files are always-loaded: no frontmatter, no globs, active immediately. The **root** `AGENTS.md` is not part of this set — it already enters the prompt unconditionally as a project docs preamble (below).
 
 CLI: `coddy rules list [--cwd DIR]` prints the discovered catalog.
 
@@ -63,7 +66,7 @@ After each agent turn, Coddy estimates tokens per category (`systemPrompt`, `too
 ```yaml
 rules:
   auto_discover: true
-  systems: []   # optional filter: coddy, cursor, claude, codex
+  systems: []   # optional filter: coddy, cursor, claude, codex, agents
 ```
 
 ## References

--- a/internal/rules/agents.go
+++ b/internal/rules/agents.go
@@ -1,0 +1,81 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// agentsSkipDirs are dependency trees never scanned for AGENTS.md.
+var agentsSkipDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+}
+
+// AgentsProvider discovers nested **/AGENTS.md files (https://agents.md/)
+// under the project root and injects them as always-loaded rules.
+// The root AGENTS.md is excluded: it already enters the prompt
+// unconditionally as a project docs preamble (see LoadProjectDocs).
+type AgentsProvider struct{}
+
+func (p *AgentsProvider) ID() Source { return SourceAgents }
+
+// RulesRoot is empty: AGENTS.md files live in the project tree itself.
+func (p *AgentsProvider) RulesRoot() string { return "" }
+
+func (p *AgentsProvider) Load(root string) ([]*Rule, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, os.ErrNotExist
+	}
+	root = filepath.Clean(root)
+	var out []*Rule
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != root && (strings.HasPrefix(name, ".") || agentsSkipDirs[name]) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.EqualFold(d.Name(), "AGENTS.md") {
+			return nil
+		}
+		if filepath.Dir(path) == root {
+			// Root AGENTS.md is the project docs preamble.
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		out = append(out, &Rule{
+			ID:          string(SourceAgents) + ":" + path,
+			Name:        filepath.ToSlash(rel),
+			FilePath:    path,
+			Source:      SourceAgents,
+			AlwaysApply: true,
+			ApplyMode:   ApplyAuto,
+			Content:     content,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/rules/factory.go
+++ b/internal/rules/factory.go
@@ -13,6 +13,7 @@ type Factory struct {
 // DefaultFactory returns built-in providers in discover precedence order (lowest wins on dedupe).
 func DefaultFactory() *Factory {
 	return NewFactory(
+		&AgentsProvider{},
 		NewMarkdownProvider(SourceCodex, ".codex/rules"),
 		NewMarkdownProvider(SourceClaude, ".claude/rules"),
 		NewMarkdownProvider(SourceCursor, ".cursor/rules"),
@@ -42,12 +43,14 @@ func (f *Factory) Providers() []Provider {
 func sourceRank(s Source) int {
 	switch s {
 	case SourceCoddy:
-		return 4
+		return 5
 	case SourceCursor:
-		return 3
+		return 4
 	case SourceClaude:
-		return 2
+		return 3
 	case SourceCodex:
+		return 2
+	case SourceAgents:
 		return 1
 	default:
 		return 0

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -13,6 +13,7 @@ const (
 	SourceCursor Source = "cursor"
 	SourceClaude Source = "claude"
 	SourceCodex  Source = "codex"
+	SourceAgents Source = "agents"
 )
 
 // ApplyMode controls how a rule enters the prompt.
@@ -51,9 +52,13 @@ func (r *Rule) CanonicalName() string {
 }
 
 // DedupeKey returns a stable key for catalog deduplication (basename across sources).
+// Nested AGENTS.md files all share a basename, so agents rules key on the full path.
 func (r *Rule) DedupeKey() string {
 	if r == nil {
 		return ""
+	}
+	if r.Source == SourceAgents {
+		return strings.ToLower(filepath.ToSlash(r.FilePath))
 	}
 	return strings.ToLower(filepath.Base(r.FilePath))
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -3,6 +3,7 @@ package rules_test
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -93,6 +94,68 @@ func TestDiscoverPrecedence(t *testing.T) {
 	}
 	if !strings.Contains(got[0].Content, "from coddy") {
 		t.Fatalf("want coddy win, got %q", got[0].Content)
+	}
+}
+
+func TestDiscoverNestedAgentsMD(t *testing.T) {
+	tmp := t.TempDir()
+	// Root AGENTS.md is the unconditional project docs preamble, not a rule.
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("root preamble"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{"internal/agent", "external/httpserver", ".git/sub", "node_modules/pkg"} {
+		if err := os.MkdirAll(filepath.Join(tmp, filepath.FromSlash(dir)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = os.WriteFile(filepath.Join(tmp, "internal", "agent", "AGENTS.md"), []byte("agent loop notes"), 0o644)
+	_ = os.WriteFile(filepath.Join(tmp, "external", "httpserver", "AGENTS.md"), []byte("http notes"), 0o644)
+	// Hidden and dependency dirs must be skipped.
+	_ = os.WriteFile(filepath.Join(tmp, ".git", "sub", "AGENTS.md"), []byte("hidden"), 0o644)
+	_ = os.WriteFile(filepath.Join(tmp, "node_modules", "pkg", "AGENTS.md"), []byte("dep"), 0o644)
+
+	got, err := rules.DefaultFactory().Discover(tmp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 nested AGENTS.md rules, got %d: %+v", len(got), got)
+	}
+	for _, r := range got {
+		if r.Source != rules.SourceAgents {
+			t.Fatalf("source = %q, want agents", r.Source)
+		}
+		if !r.AlwaysApply || r.ApplyMode != rules.ApplyAuto || len(r.Globs) != 0 {
+			t.Fatalf("AGENTS.md rule must be always-loaded: %+v", r)
+		}
+	}
+	names := []string{got[0].CanonicalName(), got[1].CanonicalName()}
+	sort.Strings(names)
+	if names[0] != "external/httpserver/AGENTS.md" || names[1] != "internal/agent/AGENTS.md" {
+		t.Fatalf("names = %v", names)
+	}
+}
+
+func TestDiscoverAgentsMDSystemsFilter(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.WriteFile(filepath.Join(tmp, "sub", "AGENTS.md"), []byte("sub notes"), 0o644)
+
+	got, err := rules.DefaultFactory().Discover(tmp, rules.ParseSystems([]string{"agents"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("agents filter: expected 1 rule, got %d", len(got))
+	}
+	got, err = rules.DefaultFactory().Discover(tmp, rules.ParseSystems([]string{"coddy"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("coddy filter must exclude agents rules, got %d", len(got))
 	}
 }
 

--- a/internal/rules/systems.go
+++ b/internal/rules/systems.go
@@ -18,6 +18,8 @@ func ParseSystems(ss []string) []Source {
 			out = append(out, SourceClaude)
 		case "codex":
 			out = append(out, SourceCodex)
+		case "agents":
+			out = append(out, SourceAgents)
 		}
 	}
 	return out


### PR DESCRIPTION
Closes #41

## What

Adds `AGENTS.md` ([agents.md](https://agents.md/) convention) to the rule-discovery set. Nested `**/AGENTS.md` files under session CWD are now discovered by a new `AgentsProvider` and injected as always-loaded rules into the same `{{.Rules}}` system-prompt slot as `.coddy/rules/*.md` and friends.

## Design notes

- **Root `AGENTS.md` is not double-injected**: it already enters the prompt unconditionally as the project docs preamble (`LoadProjectDocs`), so the provider skips it and only picks up nested files.
- **Precedence**: agents ranks lowest (`coddy > cursor > claude > codex > agents`), so `.coddy/rules/` overrides `AGENTS.md` on a basename conflict, per the issue's suggested behavior. Nested `AGENTS.md` files dedupe by full path (they all share a basename), so sibling files never collapse into each other.
- **Walk hygiene**: hidden directories (`.git`, `.coddy`, …), `node_modules`, and `vendor` are skipped.
- **Config**: `rules.systems` accepts a new `agents` value for filtering; empty list still means all sources.
- Rules are plain markdown, `alwaysApply`-equivalent, active immediately (no frontmatter/globs) — "always-loaded system prompt fragment" per the issue.

## Tests

- `TestDiscoverNestedAgentsMD`: nested discovery, root exclusion, hidden/`node_modules` skipping, always-loaded semantics, path-based names.
- `TestDiscoverAgentsMDSystemsFilter`: `systems: [agents]` includes them, `systems: [coddy]` excludes them.
- Written red-first; `go test ./internal/rules` green, `make lint` clean. Pre-existing environment failures on this Windows machine (missing `rg`, session-store rename race) reproduce identically on pristine HEAD and are unrelated.

## Docs

Updated `docs/rules.md` (discovery table, precedence, config), `docs/config.md`, `docs/architecture.md`, and README rule bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)