### PR TITLE
Fix YAML config parsing on Windows when expanding path vars

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,61 @@ func TestExpandPathHelpers(t *testing.T) {
 			t.Fatalf("got %q", s)
 		}
 	})
+	t.Run("ExpandPathVarsUsesForwardSlashes", func(t *testing.T) {
+		p := config.Paths{Home: `C:\Users\dev\.coddy`, CWD: `C:\work\proj`}
+		got := config.ExpandPathVars(`dirs: ["${CODDY_HOME}/skills", "${CWD}/x"]`, p)
+		want := `dirs: ["C:/Users/dev/.coddy/skills", "C:/work/proj/x"]`
+		if got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+}
+
+// Regression: ${CODDY_HOME} expanded into a double-quoted YAML scalar must not
+// inject backslashes; Windows paths like C:\Users\... were parsed as escape
+// sequences and failed with "did not find expected hexdecimal number".
+func TestLoadFromYAML_BackslashHomeInQuotedScalar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `
+providers:
+  - name: local
+    type: openai
+    api_key: "test-key"
+
+models:
+  - model: "local/gpt-4o"
+    max_tokens: 4096
+    temperature: 0.1
+
+agent:
+  model: "local/gpt-4o"
+
+skills:
+  dirs:
+    - "${CODDY_HOME}/extra"
+
+sessions:
+  dir: "${CODDY_HOME}/mysess"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := config.Paths{Home: `C:\Users\dev\.coddy`, CWD: dir, ConfigPath: path}
+	cfg, err := config.LoadWithPaths(paths)
+	if err != nil {
+		t.Fatalf("LoadWithPaths: %v", err)
+	}
+	if len(cfg.Skills.Dirs) != 1 {
+		t.Fatalf("skills.dirs len: got %d", len(cfg.Skills.Dirs))
+	}
+	if got, want := filepath.ToSlash(cfg.Skills.Dirs[0]), "C:/Users/dev/.coddy/extra"; got != want {
+		t.Errorf("skills.dirs[0]: got %q want %q", got, want)
+	}
+	if got, want := filepath.ToSlash(cfg.Sessions.Dir), "C:/Users/dev/.coddy/mysess"; got != want {
+		t.Errorf("sessions.dir: got %q want %q", got, want)
+	}
 }
 
 func TestLoadFromYAML_EndToEnd(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -108,10 +108,20 @@ func Resolve(cli CLIPaths) (Paths, error) {
 
 // ExpandPathVars substitutes ${CODDY_HOME} and ${CWD}, then expands ~.
 // Use for config file body and paths that intentionally bake in the process working directory.
+// Substituted paths use forward slashes: the result is spliced into raw YAML, where
+// backslashes inside double-quoted scalars (Windows paths like C:\Users\...) would be
+// parsed as escape sequences and break the document. Forward-slash paths remain valid
+// for os and filepath functions on Windows.
 func ExpandPathVars(s string, p Paths) string {
-	s = strings.ReplaceAll(s, "${CODDY_HOME}", p.Home)
-	s = strings.ReplaceAll(s, "${CWD}", p.CWD)
+	s = strings.ReplaceAll(s, "${CODDY_HOME}", yamlSafePath(p.Home))
+	s = strings.ReplaceAll(s, "${CWD}", yamlSafePath(p.CWD))
 	return expandHome(s)
+}
+
+// yamlSafePath converts backslashes to forward slashes so a path can be substituted
+// into YAML text without introducing escape sequences.
+func yamlSafePath(path string) string {
+	return strings.ReplaceAll(path, `\`, "/")
 }
 
 // ExpandCODDYHomeOnly substitutes ${CODDY_HOME} and expands ~. Leaves ${CWD} for per-session expansion.


### PR DESCRIPTION
## What

`go test ./internal/config -run TestLoadFromYAML_EndToEnd` failed on Windows with:

```
yaml: line 21: did not find expected hexdecimal number
```

`readConfigFile` expands `${CODDY_HOME}` / `${CWD}` into the raw YAML text before parsing. On Windows the substituted path contains backslashes (`C:\Users\...`), and inside double-quoted YAML scalars `\U` is read as a unicode escape, breaking the parse.

## Fix

`ExpandPathVars` (internal/config/paths.go) now substitutes paths through a `yamlSafePath` helper that converts backslashes to forward slashes. Forward-slash paths are valid for `os`/`filepath` on Windows, and `filepath.Clean` at the consumption sites normalizes them back to native separators. Both call sites (`readConfigFile` and `tryRecoverFromBackup`) go through the same function, so backup recovery is covered too.

## Tests

- `ExpandPathVarsUsesForwardSlashes` subtest: unit check of the substitution with Windows-style paths, deterministic on any OS.
- `TestLoadFromYAML_BackslashHomeInQuotedScalar`: end-to-end regression via `LoadWithPaths` with `Home = C:\Users\dev\.coddy` — fails with the original parse error before the fix on any platform.
- Existing `TestLoadFromYAML_EndToEnd` now passes on Windows.

## Verification

- `go test ./internal/config` green across build-tag combos (`memory`, `scheduler`, `http,scheduler,memory`).
- `golangci-lint run ./...` — 0 issues.
- `make test` has 5 pre-existing failures in `internal/session` / `internal/tools*` unrelated to this change (confirmed by rerunning on a stashed tree): missing `ripgrep` in PATH, Unix path expectations, and a Windows rename race.

## Note for reviewers

Paths containing literal backslashes on Unix (a legal filename character there) are now converted to forward slashes during YAML-body expansion. That case was already broken (same YAML escape problem), so this is not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
