### PR TITLE
Fix: авто-синхронизация default model в ReAct при переименовании логической модели

### DIFF
--- a/external/ui/src/ui/settings/SettingsSection.test.tsx
+++ b/external/ui/src/ui/settings/SettingsSection.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { afterEach, expect, test } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { SettingsSection } from "./SettingsSection";
 import type { JsonSchema } from "./SchemaForm";
 import type { SectionDescriptor } from "./settingsSections";
@@ -73,6 +79,68 @@ test("NeuralDeep provider shows a read-only API base URL pinned to the fixed end
   // Editing is rejected: the field stays pinned to the fixed endpoint.
   fireEvent.change(base, { target: { value: "https://custom.example/v1" } });
   expect(base.value).toBe("https://api.neuraldeep.ru/v1");
+});
+
+const modelsSection: SectionDescriptor = {
+  id: "models",
+  label: "Logical models",
+  kind: "array",
+  schemaKey: "models",
+  labelField: "model",
+};
+
+const modelsSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    models: {
+      type: "array",
+      title: "Logical models",
+      items: {
+        type: "object",
+        properties: {
+          model: { type: "string", title: "Model id" },
+        },
+        "x-coddy-property-order": ["model"],
+      },
+    },
+  },
+};
+
+test("renaming the sole model id follows through to agent.model", async () => {
+  function ModelsHarness() {
+    const [doc, setDoc] = React.useState<Record<string, unknown>>({
+      providers: [{ name: "neuraldeep", type: "neuraldeep" }],
+      models: [{ model: "neuraldeep/gpt-120b-oss" }],
+      agent: { model: "neuraldeep/gpt-120b-oss", max_turns: 20 },
+    });
+    return (
+      <>
+        <span data-testid="agent-model">
+          {String((doc.agent as Record<string, unknown>).model)}
+        </span>
+        <SettingsSection
+          section={modelsSection}
+          schema={modelsSchema}
+          doc={doc}
+          setDoc={setDoc}
+        />
+      </>
+    );
+  }
+
+  render(<ModelsHarness />);
+  fireEvent.click(screen.getByTestId("settings-master-item-0"));
+
+  const model = screen.getByTestId("model-field-model") as HTMLInputElement;
+  expect(model.value).toBe("neuraldeep/gpt-120b-oss");
+  fireEvent.change(model, { target: { value: "neuraldeep/qwen-3.6" } });
+
+  // The ReAct default-model reference tracked the rename automatically.
+  await waitFor(() => {
+    expect(screen.getByTestId("agent-model").textContent).toBe(
+      "neuraldeep/qwen-3.6",
+    );
+  });
 });
 
 test("switching type away from NeuralDeep restores the previously entered API base", async () => {

--- a/external/ui/src/ui/settings/SettingsSection.tsx
+++ b/external/ui/src/ui/settings/SettingsSection.tsx
@@ -1,4 +1,5 @@
 import { AppearanceThemePicker } from "../theme/AppearanceModal";
+import { applyModelsChange } from "./applyModelsChange";
 import { ModelField } from "./ModelField";
 import { ModelPicker } from "./ModelPicker";
 import { SchemaForm, type FieldOverride, type JsonSchema } from "./SchemaForm";
@@ -137,11 +138,18 @@ export function SettingsSection(props: {
         : key === "providers"
           ? neuralDeepAPIBaseOverride
           : undefined;
+    // Renaming a logical model id must follow through to the default-model
+    // references (agent.model / memory.model), or the saved config becomes
+    // invalid ("not found in models list"). applyModelsChange reconciles them.
+    const onArrayChange =
+      key === "models"
+        ? (v: unknown[]) => setDoc(applyModelsChange(doc, v))
+        : (v: unknown[]) => setKey(key, v);
     return (
       <SettingsArraySection
         schema={sub}
         value={asArray(doc[key])}
-        onChange={(v) => setKey(key, v)}
+        onChange={onArrayChange}
         labelField={section.labelField}
         fieldOverride={override}
         backLabelUsesItemName={!props.isMobileShell}

--- a/external/ui/src/ui/settings/applyModelsChange.test.ts
+++ b/external/ui/src/ui/settings/applyModelsChange.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { applyModelsChange } from "./applyModelsChange";
+
+function baseDoc(
+  models: Array<Record<string, unknown>>,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> {
+  return { providers: [], models, ...extra };
+}
+
+describe("applyModelsChange", () => {
+  it("updates agent.model when the sole model id is renamed", () => {
+    const doc = baseDoc([{ model: "neuraldeep/gpt-120b-oss" }], {
+      agent: { model: "neuraldeep/gpt-120b-oss", max_turns: 20 },
+    });
+    const next = applyModelsChange(doc, [{ model: "neuraldeep/qwen-3.6" }]);
+    expect((next.agent as Record<string, unknown>).model).toBe(
+      "neuraldeep/qwen-3.6",
+    );
+    // Unrelated agent fields preserved.
+    expect((next.agent as Record<string, unknown>).max_turns).toBe(20);
+    // Models replaced with the new array.
+    expect(next.models).toEqual([{ model: "neuraldeep/qwen-3.6" }]);
+  });
+
+  it("updates memory.model referencing the same old id", () => {
+    const doc = baseDoc([{ model: "neuraldeep/gpt-120b-oss" }], {
+      agent: { model: "neuraldeep/gpt-120b-oss" },
+      memory: { enabled: true, model: "neuraldeep/gpt-120b-oss" },
+    });
+    const next = applyModelsChange(doc, [{ model: "neuraldeep/qwen-3.6" }]);
+    expect((next.memory as Record<string, unknown>).model).toBe(
+      "neuraldeep/qwen-3.6",
+    );
+    expect((next.memory as Record<string, unknown>).enabled).toBe(true);
+  });
+
+  it("leaves memory.model pointing at a different id untouched", () => {
+    const doc = baseDoc(
+      [{ model: "neuraldeep/gpt-120b-oss" }, { model: "openai/gpt-4o" }],
+      {
+        agent: { model: "neuraldeep/gpt-120b-oss" },
+        memory: { model: "openai/gpt-4o" },
+      },
+    );
+    const next = applyModelsChange(doc, [
+      { model: "neuraldeep/qwen-3.6" },
+      { model: "openai/gpt-4o" },
+    ]);
+    expect((next.agent as Record<string, unknown>).model).toBe(
+      "neuraldeep/qwen-3.6",
+    );
+    expect((next.memory as Record<string, unknown>).model).toBe(
+      "openai/gpt-4o",
+    );
+  });
+
+  it("leaves agent.model pointing at an unchanged model untouched", () => {
+    const doc = baseDoc(
+      [{ model: "neuraldeep/gpt-120b-oss" }, { model: "openai/gpt-4o" }],
+      { agent: { model: "openai/gpt-4o" } },
+    );
+    const next = applyModelsChange(doc, [
+      { model: "neuraldeep/qwen-3.6" },
+      { model: "openai/gpt-4o" },
+    ]);
+    expect((next.agent as Record<string, unknown>).model).toBe("openai/gpt-4o");
+  });
+
+  it("does not repoint references when a model is added (length grows)", () => {
+    const doc = baseDoc([{ model: "neuraldeep/gpt-120b-oss" }], {
+      agent: { model: "neuraldeep/gpt-120b-oss" },
+    });
+    const next = applyModelsChange(doc, [
+      { model: "neuraldeep/gpt-120b-oss" },
+      { model: "openai/gpt-4o" },
+    ]);
+    expect((next.agent as Record<string, unknown>).model).toBe(
+      "neuraldeep/gpt-120b-oss",
+    );
+  });
+
+  it("does not repoint references when a model is removed (length shrinks)", () => {
+    const doc = baseDoc(
+      [{ model: "neuraldeep/gpt-120b-oss" }, { model: "openai/gpt-4o" }],
+      { agent: { model: "neuraldeep/gpt-120b-oss" } },
+    );
+    const next = applyModelsChange(doc, [{ model: "openai/gpt-4o" }]);
+    expect((next.agent as Record<string, unknown>).model).toBe(
+      "neuraldeep/gpt-120b-oss",
+    );
+  });
+
+  it("renames only the reference matching the changed entry", () => {
+    const doc = baseDoc(
+      [{ model: "neuraldeep/gpt-120b-oss" }, { model: "openai/gpt-4o" }],
+      {
+        agent: { model: "openai/gpt-4o" },
+        memory: { model: "neuraldeep/gpt-120b-oss" },
+      },
+    );
+    const next = applyModelsChange(doc, [
+      { model: "neuraldeep/gpt-120b-oss" },
+      { model: "openai/gpt-4o-mini" },
+    ]);
+    // agent referenced the renamed one -> updated.
+    expect((next.agent as Record<string, unknown>).model).toBe(
+      "openai/gpt-4o-mini",
+    );
+    // memory referenced the untouched one -> unchanged.
+    expect((next.memory as Record<string, unknown>).model).toBe(
+      "neuraldeep/gpt-120b-oss",
+    );
+  });
+
+  it("ignores a rename from an empty id", () => {
+    const doc = baseDoc([{ model: "" }], {
+      agent: { model: "" },
+    });
+    const next = applyModelsChange(doc, [{ model: "neuraldeep/qwen-3.6" }]);
+    // Empty ids are not treated as a rename source.
+    expect((next.agent as Record<string, unknown>).model).toBe("");
+  });
+
+  it("returns the doc unchanged when there are no model references", () => {
+    const doc = baseDoc([{ model: "neuraldeep/gpt-120b-oss" }]);
+    const next = applyModelsChange(doc, [{ model: "neuraldeep/qwen-3.6" }]);
+    expect(next.models).toEqual([{ model: "neuraldeep/qwen-3.6" }]);
+    expect(next.agent).toBeUndefined();
+  });
+});

--- a/external/ui/src/ui/settings/applyModelsChange.ts
+++ b/external/ui/src/ui/settings/applyModelsChange.ts
@@ -1,0 +1,72 @@
+/**
+ * applyModelsChange replaces the `models` array in the settings doc and keeps the
+ * default-model references in sync. When a logical model id is renamed in place
+ * (the model list keeps the same length, one entry's `model` string changes),
+ * every reference that used the old id — `agent.model` and `memory.model` — is
+ * rewritten to the new id. This prevents the config from becoming invalid
+ * (backend rejects `agent.model`/`memory.model` not present in the models list)
+ * after renaming the only model of a provider.
+ *
+ * Only in-place renames are reconciled. On add/remove (length change) references
+ * are left untouched — removing a referenced model should not silently repoint it.
+ */
+export function applyModelsChange(
+  doc: Record<string, unknown>,
+  nextModels: unknown[],
+): Record<string, unknown> {
+  const base: Record<string, unknown> = { ...doc, models: nextModels };
+
+  const prevIds = modelIds(doc.models);
+  const nextIds = modelIds(nextModels);
+  if (prevIds.length !== nextIds.length) {
+    return base;
+  }
+
+  const renames = new Map<string, string>();
+  for (let i = 0; i < prevIds.length; i++) {
+    const from = prevIds[i]!;
+    const to = nextIds[i]!;
+    if (from !== "" && from !== to) {
+      renames.set(from, to);
+    }
+  }
+  if (renames.size === 0) {
+    return base;
+  }
+
+  base.agent = renameModelRef(base.agent, renames);
+  base.memory = renameModelRef(base.memory, renames);
+  return base;
+}
+
+function renameModelRef(
+  section: unknown,
+  renames: Map<string, string>,
+): unknown {
+  if (!section || typeof section !== "object" || Array.isArray(section)) {
+    return section;
+  }
+  const obj = section as Record<string, unknown>;
+  const current = obj.model;
+  if (typeof current !== "string") {
+    return section;
+  }
+  const renamed = renames.get(current);
+  if (renamed === undefined) {
+    return section;
+  }
+  return { ...obj, model: renamed };
+}
+
+function modelIds(models: unknown): string[] {
+  if (!Array.isArray(models)) {
+    return [];
+  }
+  return models.map((row) => {
+    if (row && typeof row === "object" && !Array.isArray(row)) {
+      const cell = (row as Record<string, unknown>).model;
+      return cell === undefined || cell === null ? "" : String(cell);
+    }
+    return "";
+  });
+}


### PR DESCRIPTION
## Проблема

В Settings UI поле **ReAct → Default model** (`agent.model`), а также **Memory → model** (`memory.model`) — это *ссылки по id* на запись из списка **Models**, а не независимые значения.

Когда пользователь переименовывает **единственную** логическую модель провайдера прямо в разделе Models — например `neuraldeep/gpt-120b-oss` → `neuraldeep/qwen-3.6` — ссылка `agent.model` остаётся указывать на старый, уже несуществующий id. При сохранении конфиг падает на бэкенд-валидации:

- `internal/config/resolve.go` → `agent.model %q: not found in models list`
- `internal/config/memory_validate.go` → `memory.model %q not found in models list`

Чтобы сохранить конфиг, приходилось вручную идти в раздел ReAct и заново выбирать модель. Это неочевидно и легко упустить.

### Почему так происходило

Состояние конфига (`doc` / `setDoc`) общее и живёт в `Settings.tsx`, но раздел-массив **Models** редактировал `doc.models` изолированно через `setKey("models", v)` — ничто не согласовывало ссылки `agent.model` / `memory.model` при изменении id записи. `ModelPicker` для default-модели редактируется только вручную, поэтому устаревшая ссылка тихо сохранялась.

## Решение

Добавлен чистый хелпер `applyModelsChange(doc, nextModels)`:

- Распознаёт **переименование на месте** (массив models той же длины, у одной записи изменился `model`).
- Строит карту переименований и переписывает **все** ссылки `agent.model` / `memory.model`, использовавшие старый id, на новый.
- При **добавлении/удалении** модели (длина массива изменилась) ссылки не трогает — удаление используемой модели не должно молча переуказывать ссылку.

Хелпер подключён к `onChange` массива Models в `SettingsSection.tsx`. Позиционное сравнение естественно «следует» за посимвольным вводом `Combobox`, так что default model обновляется вживую по мере правки id.

Изменение только на стороне UI — бэкенд, схема конфига и YAML не затрагиваются; фикс лишь удерживает исходящий конфиг валидным.

## Тесты

- `applyModelsChange.test.ts` — 9 юнит-кейсов (переименование → обновление `agent.model`/`memory.model`; чужие ссылки не трогаются; add/remove не переуказывает; несколько моделей — меняется только совпавшая; пустой id; отсутствие ссылок).
- `SettingsSection.test.tsx` — компонентный тест сквозного сценария: правка id в реальном combobox → `agent.model` обновляется автоматически.
- Весь UI-набор зелёный: **449/449**. Prettier чист. `vite build` + `npm run build:go` (пересборка `go:embed` ассетов) проходят.

## Как проверить вручную

1. Собрать/запустить с UI: `make build TAGS="http ui"` → `./build/coddy http -P 12345`, открыть `http://localhost:12345/`.
2. Settings → **Models** → переименовать id единственной модели.
3. Раздел **ReAct** → «Default model» показывает новый id **без ручного перещёлкивания**.
4. **Save** → сохраняется без ошибки `not found in models list`.

## Файлы

- `external/ui/src/ui/settings/applyModelsChange.ts` (новый)
- `external/ui/src/ui/settings/applyModelsChange.test.ts` (новый)
- `external/ui/src/ui/settings/SettingsSection.tsx`
- `external/ui/src/ui/settings/SettingsSection.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)