### PR TITLE
Escape $ in proxy secrets so they survive config load

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -10,7 +10,7 @@ A machine-readable [JSON Schema](config.schema.json) accompanies this reference.
 
 VS Code (with the YAML extension), IntelliJ, and Zed pick this comment up automatically. The schema is kept in sync with the Go config structs by `TestDocsConfigSchemaMatchesStructs` in `internal/config/docs_schema_test.go`.
 
-Every field is optional unless marked **required**; an empty `config.yaml` (or none at all) is valid and uses built-in defaults. Any string value may reference environment variables with `${VAR_NAME}` (expanded when the file is loaded). `${CODDY_HOME}` and `${CWD}` are expanded by the loader (see [config.md](config.md#environment-variable-references)).
+Every field is optional unless marked **required**; an empty `config.yaml` (or none at all) is valid and uses built-in defaults. Any string value may reference environment variables with `${VAR_NAME}` (expanded when the file is loaded). To keep a **literal `$`** in a value (e.g. a secret like `$2y$10$…`), double it as `$$` — the UI does this automatically for the `proxy` fields. `${CODDY_HOME}` and `${CWD}` are expanded by the loader (see [config.md](config.md#environment-variable-references)).
 
 ## Top-level keys
 
@@ -45,7 +45,7 @@ List of LLM backends (`[]config.ProviderConfig`, `internal/config/providers.go`)
 | `api_base` | string | no | provider SDK default | — | Base URL override. For `type: openai` include `/v1` (e.g. `http://localhost:11434/v1`); for `type: anthropic` an Anthropic-compatible gateway. Ignored for `type: neuraldeep`, which always uses `https://api.neuraldeep.ru/v1`. |
 | `api_key` | string | no | `""` | `NAME_API_KEY` | Literal secret or `"${ENV}"` reference. Empty reads `NAME_API_KEY` at LLM call time (NAME = provider name uppercased, hyphens → underscores; e.g. `deepseek` → `DEEPSEEK_API_KEY`). |
 | `api_key_command` | string | no | `""` | — | Credential-helper command run via the shell when `api_key` is empty; trimmed stdout becomes the key. Falls back to `NAME_API_KEY` on failure. |
-| `proxy` | string | no | direct | — | Per-provider outbound proxy: `http://`, `https://`, `socks5://`, or `socks5h://` URL. |
+| `proxy` | string | no | direct | — | Per-provider outbound proxy: `http://`, `https://`, `socks5://`, or `socks5h://` URL. Treated as a literal URL (no `${VAR}` references); a `$` in the userinfo is auto-escaped to `$$` when saved via the UI. |
 
 Key resolution order: `api_key` → `api_key_command` stdout → `NAME_API_KEY` env var.
 
@@ -233,7 +233,7 @@ Messenger gateways (`config.GatewayConfig`, `internal/config/gateway.go`; `gatew
 |---|---|---|---|---|---|
 | `enabled` | bool | no | `false` | — | Activate the Telegram adapter. |
 | `token` | string | no | `""` | `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather. Empty reads the env var (e.g. via `~/.coddy/.env`). |
-| `proxy` | string | no | direct | — | Outbound proxy: `http`, `https`, `socks5`, `socks5h`. |
+| `proxy` | string | no | direct | — | Outbound proxy: `http`, `https`, `socks5`, `socks5h`. Treated as a literal URL (no `${VAR}` references); a `$` in the userinfo is auto-escaped to `$$` when saved via the UI. |
 | `rich_messages` | bool | no | `false` | — | Bot API 10.1 Rich Messages; falls back to legacy formatting when unsupported. |
 | `admins` | int list | no | `[]` | — | Telegram user IDs with elevated rights; always pass access checks. |
 | `default_access` | string | no | `all` | — | `all`, `admins`, or `group:<name>`. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -364,6 +364,15 @@ Values already in the process environment (e.g. set by the shell, Docker, system
 Any config value can reference environment variables using `${VAR_NAME}` syntax.
 The agent resolves these at startup.
 
+**Literal `$` in a value:** because expansion runs over the raw file, a value that must contain a
+literal dollar sign (e.g. a proxy or API-key secret like `$2y$10$…`) has to double it as `$$` — `$$`
+expands back to a single `$`, exactly like docker-compose / envsubst. Without this, fragments such as
+`$2y` or `$10` are treated as environment-variable references and resolve to empty strings, silently
+corrupting the secret. The Settings UI does this automatically for the `proxy` fields
+(`providers[].proxy` and `gateways.telegram.proxy`), which are always treated as literal URLs and do
+**not** support `${VAR}` references; for a literal `$` in `api_key` (which does support `${VAR}`),
+write `$$` by hand.
+
 Special variables in YAML (before parse) and in path strings:
 
 - **`${CODDY_HOME}`** - resolved `CODDY_HOME` directory

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,7 @@ func readConfigFile(paths Paths, explicitFile bool) (*Config, error) {
 	}
 
 	originalData := append([]byte(nil), data...)
-	expanded := os.ExpandEnv(ExpandPathVars(string(data), paths))
+	expanded := expandEnvEscaped(ExpandPathVars(string(data), paths))
 
 	cfg, err := parseValidateYAMLBytes(expanded, paths)
 	if err != nil {

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// expandEnvEscaped expands ${VAR} and $VAR references from the process environment,
+// like os.ExpandEnv, but treats "$$" as an escape for a literal "$". This lets secrets
+// that contain a dollar sign (e.g. a proxy password like "$2y$10$...") survive the
+// load-time expansion pass instead of having their "$WORD"/"$N" fragments resolved to
+// empty environment variables. Values are written to disk with "$" doubled to "$$"
+// (see escapeYAMLDollar) and read back here as a single literal "$".
+func expandEnvEscaped(s string) string {
+	return os.Expand(s, func(name string) string {
+		// os.Expand yields name == "$" for the "$$" sequence (via isShellSpecialVar).
+		if name == "$" {
+			return "$"
+		}
+		return os.Getenv(name)
+	})
+}
+
+// escapeYAMLDollar doubles every "$" so that expandEnvEscaped restores the exact literal
+// on the next load. Applied to always-literal secret fields (proxy URLs) before they are
+// serialized to disk, so a value never gets mangled by environment-variable expansion.
+func escapeYAMLDollar(s string) string {
+	return strings.ReplaceAll(s, "$", "$$")
+}

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -1,0 +1,44 @@
+package config
+
+import "testing"
+
+// TestExpandEnvEscaped covers the "$$" literal escape alongside normal ${VAR}/$VAR expansion,
+// the mechanism that lets secrets containing "$" (e.g. a proxy password) survive config load.
+func TestExpandEnvEscaped(t *testing.T) {
+	t.Setenv("CODDY_EXPAND_TEST", "value")
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "double dollar is literal", in: "a$$b", want: "a$b"},
+		{name: "braced ref still expands", in: "x${CODDY_EXPAND_TEST}y", want: "xvaluey"},
+		{name: "escaped braced ref is literal", in: "x$${CODDY_EXPAND_TEST}y", want: "x${CODDY_EXPAND_TEST}y"},
+		{name: "bare ref still expands", in: "$CODDY_EXPAND_TEST", want: "value"},
+		{name: "unset ref is empty", in: "a${CODDY_UNSET_XYZ}b", want: "ab"},
+		{name: "bcrypt-style password", in: "$$2y$$10$$abcdEF", want: "$2y$10$abcdEF"},
+		{name: "escaped proxy url", in: "http://u:$$2y$$10$$abcd@127.0.0.1:3128", want: "http://u:$2y$10$abcd@127.0.0.1:3128"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandEnvEscaped(tt.in); got != tt.want {
+				t.Errorf("expandEnvEscaped(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEscapeYAMLDollarRoundTrip proves the on-disk escape and the load-time unescape are inverses:
+// a literal secret survives escapeYAMLDollar -> expandEnvEscaped verbatim.
+func TestEscapeYAMLDollarRoundTrip(t *testing.T) {
+	for _, s := range []string{
+		"http://user:$2y$10$abcd@proxy:3128",
+		"socks5h://user:p$$w0rd@127.0.0.1:1080",
+		"no-dollars-here",
+		"$1$2$3",
+	} {
+		if got := expandEnvEscaped(escapeYAMLDollar(s)); got != s {
+			t.Errorf("round-trip for %q = %q", s, got)
+		}
+	}
+}

--- a/internal/config/jsondto.go
+++ b/internal/config/jsondto.go
@@ -352,9 +352,27 @@ func ParseAndValidateConfigJSON(data []byte, paths Paths) (*Config, error) {
 }
 
 // MarshalConfigYAML serializes cfg to YAML bytes for disk (Paths is omitted via yaml:"-" on field).
+// Always-literal secret fields (proxy URLs) are "$"-escaped so the load-time expansion pass restores
+// them verbatim instead of resolving "$WORD"/"$N" fragments to empty environment variables.
 func MarshalConfigYAML(cfg *Config) ([]byte, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
-	return yaml.Marshal(cfg)
+	return yaml.Marshal(escapeYAMLSecrets(cfg))
+}
+
+// escapeYAMLSecrets returns a copy of cfg with always-literal proxy URLs "$"-escaped for disk.
+// It copies only what it mutates (the Providers slice and the gateway proxy string), leaving the
+// caller's in-memory *Config untouched — the live config keeps the real, unescaped values.
+func escapeYAMLSecrets(cfg *Config) *Config {
+	out := *cfg
+	if len(cfg.Providers) > 0 {
+		out.Providers = make([]ProviderConfig, len(cfg.Providers))
+		copy(out.Providers, cfg.Providers)
+		for i := range out.Providers {
+			out.Providers[i].Proxy = escapeYAMLDollar(out.Providers[i].Proxy)
+		}
+	}
+	out.Gateways.Telegram.Proxy = escapeYAMLDollar(cfg.Gateways.Telegram.Proxy)
+	return &out
 }

--- a/internal/config/providers_proxy_test.go
+++ b/internal/config/providers_proxy_test.go
@@ -1,10 +1,99 @@
 package config_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/EvilFreelancer/coddy-agent/internal/config"
 )
+
+// TestProviderProxyDollarPasswordSurvivesSaveLoad is the regression for the reported bug:
+// a proxy password containing "$" (e.g. bcrypt-style "$2y$10$...") used to be mangled on load
+// because the whole YAML file was run through os.ExpandEnv, resolving "$2y"/"$10"/etc. to empty
+// environment variables. The save path must "$"-escape the proxy so the load path restores it.
+func TestProviderProxyDollarPasswordSurvivesSaveLoad(t *testing.T) {
+	const proxy = "http://user:$2y$10$abcdEF@127.0.0.1:3128"
+	body := `{
+		"providers": [
+			{"name": "openai", "type": "openai", "api_key": "sk-x", "proxy": "` + proxy + `"}
+		],
+		"models": [
+			{"model": "openai/gpt-4o", "max_tokens": 4096, "temperature": 0.1, "multimodal": true}
+		],
+		"agent": {"model": "openai/gpt-4o", "max_turns": 35}
+	}`
+
+	// Simulate the HTTP PUT save path: parse JSON -> marshal YAML -> write to disk.
+	cfg, err := config.ParseAndValidateConfigJSON([]byte(body), config.Paths{})
+	if err != nil {
+		t.Fatalf("ParseAndValidateConfigJSON: %v", err)
+	}
+	if got := cfg.Providers[0].Proxy; got != proxy {
+		t.Fatalf("parsed proxy = %q, want %q", got, proxy)
+	}
+	yb, err := config.MarshalConfigYAML(cfg)
+	if err != nil {
+		t.Fatalf("MarshalConfigYAML: %v", err)
+	}
+	if !strings.Contains(string(yb), "$$2y$$10$$abcdEF") {
+		t.Fatalf("serialized YAML missing $-escaped proxy:\n%s", yb)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, yb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reload through the expanding loader; the password must come back verbatim.
+	reloaded, err := config.LoadWithPaths(config.Paths{Home: dir, CWD: dir, ConfigPath: path})
+	if err != nil {
+		t.Fatalf("LoadWithPaths: %v", err)
+	}
+	if got := reloaded.Providers[0].Proxy; got != proxy {
+		t.Fatalf("reloaded proxy = %q, want %q", got, proxy)
+	}
+}
+
+// TestTelegramGatewayProxyDollarPasswordSurvivesSaveLoad is the same regression for the
+// gateways.telegram.proxy field, which is also an always-literal URL.
+func TestTelegramGatewayProxyDollarPasswordSurvivesSaveLoad(t *testing.T) {
+	const proxy = "socks5h://user:$2b$12$Zz@127.0.0.1:1080"
+	body := `{
+		"providers": [
+			{"name": "openai", "type": "openai", "api_key": "sk-x"}
+		],
+		"models": [
+			{"model": "openai/gpt-4o", "max_tokens": 4096, "temperature": 0.1, "multimodal": true}
+		],
+		"agent": {"model": "openai/gpt-4o", "max_turns": 35},
+		"gateways": {"telegram": {"enabled": true, "token": "t", "proxy": "` + proxy + `"}}
+	}`
+
+	cfg, err := config.ParseAndValidateConfigJSON([]byte(body), config.Paths{})
+	if err != nil {
+		t.Fatalf("ParseAndValidateConfigJSON: %v", err)
+	}
+	yb, err := config.MarshalConfigYAML(cfg)
+	if err != nil {
+		t.Fatalf("MarshalConfigYAML: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, yb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := config.LoadWithPaths(config.Paths{Home: dir, CWD: dir, ConfigPath: path})
+	if err != nil {
+		t.Fatalf("LoadWithPaths: %v", err)
+	}
+	if got := reloaded.Gateways.Telegram.Proxy; got != proxy {
+		t.Fatalf("reloaded telegram proxy = %q, want %q", got, proxy)
+	}
+}
 
 func TestProviderConfigValidateProxy(t *testing.T) {
 	t.Parallel()

--- a/internal/config/recovery.go
+++ b/internal/config/recovery.go
@@ -110,7 +110,7 @@ func tryRecoverFromBackup(paths Paths) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	expanded := os.ExpandEnv(ExpandPathVars(string(raw), paths))
+	expanded := expandEnvEscaped(ExpandPathVars(string(raw), paths))
 	cfg, err := parseValidateYAMLBytes(expanded, paths)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

Config load runs the **entire raw `config.yaml`** through `os.ExpandEnv` (`internal/config/config.go` and the backup-recovery path in `internal/config/recovery.go`). That resolves every `${VAR}` and bare `$WORD`/`$N` fragment against the process environment.

A proxy secret that legitimately contains `$` — e.g. a bcrypt-style password in the userinfo:

```
http://user:$2y$10$abcdEF@127.0.0.1:3128
```

gets **silently corrupted** on load: `$2y`, `$10`, etc. are treated as undefined environment variables and expand to empty strings, so the proxy password is mangled and the proxy stops authenticating. This affects the two always-literal proxy fields: `providers[].proxy` and `gateways.telegram.proxy`.

## Solution

Introduce a `$$` escape convention (the same one docker-compose / envsubst use): `$$` expands back to a single literal `$`.

- **Load path** — new `internal/config/expand.go` adds `expandEnvEscaped`, a drop-in for `os.ExpandEnv` that honors `$$` → literal `$` while still expanding real `${VAR}`/`$VAR` references. Both load sites (`config.go`, `recovery.go`) now use it.
- **Save path** — `MarshalConfigYAML` now routes through `escapeYAMLSecrets`, which `$`-doubles the two proxy fields on the way to disk. It copies only what it mutates (the `Providers` slice and the gateway proxy string), so the caller's live in-memory `*Config` keeps the real, unescaped values.

Round-trip: a real `$` in a proxy URL is written as `$$` and read back as `$`, surviving the expansion pass verbatim. Other fields (e.g. `api_key`) keep supporting `${VAR}` and can opt into a literal `$` by hand-writing `$$`.

## Tests

- `internal/config/expand_test.go` — `$$`→`$`, braced/bare expansion, escaped-ref-stays-literal, unset→empty, bcrypt-style password, and the `escapeYAMLDollar → expandEnvEscaped` round-trip.
- `internal/config/providers_proxy_test.go` — two regressions that drive the real HTTP save path (`ParseAndValidateConfigJSON` → `MarshalConfigYAML` → write to disk → `LoadWithPaths`) and assert a `$`-containing proxy password comes back verbatim, for both `providers[].proxy` and `gateways.telegram.proxy`.

`go test ./internal/config/...`, `go vet`, and `go build ./...` all pass.

## Docs

`docs/config-reference.md` and `docs/config.md` document the `$$` escape and note that the two `proxy` fields are always-literal (no `${VAR}` refs) and auto-escaped by the Settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
