### PR TITLE
Fix reads with offsets beyond end of file

### DIFF
--- a/internal/tools/fs/fs_test.go
+++ b/internal/tools/fs/fs_test.go
@@ -11,6 +11,94 @@ import (
 	"github.com/EvilFreelancer/coddy-agent/internal/tooling"
 )
 
+func TestReadOffsetBeyondEndReturnsError(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "short.txt")
+	if err := os.WriteFile(path, []byte("first\nsecond\nthird"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeRead(context.Background(), `{"path":"short.txt","offset":1200,"limit":200}`, &tooling.Env{CWD: root})
+	if err == nil {
+		t.Fatal("expected an out-of-range offset error")
+	}
+	if !strings.Contains(err.Error(), "offset 1200 is beyond end of file (3 lines)") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSliceLinesBoundaryCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		start   int
+		end     int
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "offset zero is normalized to the first line",
+			content: "first\nsecond\nthird",
+			start:   0,
+			end:     1,
+			want:    "first",
+		},
+		{
+			name:    "offset at the final line is valid",
+			content: "first\nsecond\nthird",
+			start:   3,
+			end:     3,
+			want:    "third",
+		},
+		{
+			name:    "limit extending beyond EOF is clipped",
+			content: "first\nsecond\nthird",
+			start:   2,
+			end:     200,
+			want:    "second\nthird",
+		},
+		{
+			name:    "trailing newline is preserved without creating a phantom line",
+			content: "first\nsecond\nthird\n",
+			start:   3,
+			end:     200,
+			want:    "third\n",
+		},
+		{
+			name:    "offset after a trailing newline reports the real line count",
+			content: "first\nsecond\nthird\n",
+			start:   4,
+			end:     200,
+			wantErr: "offset 4 is beyond end of file (3 lines)",
+		},
+		{
+			name:    "offset into an empty file reports zero lines",
+			content: "",
+			start:   1,
+			end:     1,
+			wantErr: "offset 1 is beyond end of file (0 lines)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sliceLines(tt.content, tt.start, tt.end)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("sliceLines: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("result = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // --- patch.go: unified diff / v4a patch ------------------------------------
 
 func TestApplyUnifiedDiff_hunkZeroOriginDoesNotPanic(t *testing.T) {

--- a/internal/tools/fs/lines.go
+++ b/internal/tools/fs/lines.go
@@ -1,14 +1,32 @@
 package fs
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-func sliceLines(content string, start, end int) string {
+func sliceLines(content string, start, end int) (string, error) {
+	if content == "" {
+		return "", fmt.Errorf("offset %d is beyond end of file (0 lines)", max(start, 1))
+	}
+
 	lines := strings.Split(content, "\n")
+	hasTrailingNewline := lines[len(lines)-1] == ""
+	if hasTrailingNewline {
+		lines = lines[:len(lines)-1]
+	}
 	if start < 1 {
 		start = 1
+	}
+	if start > len(lines) {
+		return "", fmt.Errorf("offset %d is beyond end of file (%d lines)", start, len(lines))
 	}
 	if end < 1 || end > len(lines) {
 		end = len(lines)
 	}
-	return strings.Join(lines[start-1:end], "\n")
+	result := strings.Join(lines[start-1:end], "\n")
+	if hasTrailingNewline && end == len(lines) {
+		result += "\n"
+	}
+	return result, nil
 }

--- a/internal/tools/fs/read.go
+++ b/internal/tools/fs/read.go
@@ -64,11 +64,11 @@ func ReadTool() *tooling.Tool {
 }
 
 type readArgs struct {
-	Path        string `json:"path"`
-	Offset      int    `json:"offset"`
-	Limit       int    `json:"limit"`
-	Recursive   bool   `json:"recursive"`
-	ShowHidden  bool   `json:"show_hidden"`
+	Path       string `json:"path"`
+	Offset     int    `json:"offset"`
+	Limit      int    `json:"limit"`
+	Recursive  bool   `json:"recursive"`
+	ShowHidden bool   `json:"show_hidden"`
 }
 
 func executeRead(_ context.Context, argsJSON string, env *tooling.Env) (string, error) {
@@ -106,7 +106,10 @@ func executeRead(_ context.Context, argsJSON string, env *tooling.Env) (string, 
 		endLine = startLine + args.Limit - 1
 	}
 	if startLine > 1 || endLine > 0 {
-		content = sliceLines(content, startLine, endLine)
+		content, err = sliceLines(content, startLine, endLine)
+		if err != nil {
+			return "", fmt.Errorf("read: %w", err)
+		}
 	}
 
 	return content, nil


### PR DESCRIPTION
## Summary

- validate file read offsets before slicing line windows
- return a descriptive tool error when the offset is beyond EOF
- preserve trailing newlines without counting them as phantom lines
- add regression coverage for `offset: 1200`, EOF clipping, empty files, and trailing newlines

## Root cause

`sliceLines` indexed `lines[start-1:end]` without checking whether `start` exceeded the file's real line count. A read request such as `{"offset":1200,"limit":200}` against a shorter file therefore panicked and stopped the agent instead of returning a tool result.



## Validation

- `go test ./internal/tools/fs -run 'Test(ReadOffsetBeyondEndReturnsError|SliceLinesBoundaryCases)' -count=1`
- `go test ./internal/tools -run 'TestReadFile(Lines)?$' -count=1`
- `make lint` (`0 issues`)
- all unaffected default-tag packages pass

`make test` remains blocked on Windows by existing platform-specific failures in session atomic rename and Unix-path session-store tests; the new filesystem read tests pass.
