### PR TITLE
fix(ui): readable Allow/Allow always buttons in light theme

### DIFF
--- a/external/ui/src/styles.css
+++ b/external/ui/src/styles.css
@@ -6194,7 +6194,7 @@ textarea#composer {
 .permission-prompt-btn--allow {
   background: rgba(147, 51, 234, 0.22);
   border-color: rgba(167, 139, 250, 0.45);
-  color: rgba(233, 213, 255, 0.98);
+  color: var(--coddy-skill-chip-text);
 }
 
 .permission-prompt-btn--allow:hover:not(:disabled) {


### PR DESCRIPTION
## Problem

In the permission prompt, the **Allow** / **Allow always** buttons (`.permission-prompt-btn--allow`) hardcode a pale-lavender text color `rgba(233, 213, 255, 0.98)`. On the **light** theme that sits on a light-purple button background (`rgba(147, 51, 234, 0.22)`), giving roughly **1:1 contrast** — the labels are nearly invisible. Dark themes were unaffected.

## Fix

Replace the hardcoded color with the existing per-theme token `var(--coddy-skill-chip-text)`:

```diff
 .permission-prompt-btn--allow {
   background: rgba(147, 51, 234, 0.22);
   border-color: rgba(167, 139, 250, 0.45);
-  color: rgba(233, 213, 255, 0.98);
+  color: var(--coddy-skill-chip-text);
 }
```

- `--coddy-skill-chip-text` is already defined in every theme block and consumed elsewhere — no new token.
- **Light theme** → `rgba(76, 29, 149, 0.96)` (dark purple).
- **Dark themes** → `rgba(237, 220, 255, 0.96)` ≈ the old value, so they render unchanged.
- Both **Allow** and **Allow always** map to the `--allow` class (any non-`reject` option in `PermissionPromptSection.tsx`), so one line covers both. The `:hover` rule only touches background/border and is left as-is.

## Verification

- Existing light-theme CSS regression tests pass: `lightThemeColorsCss.test.ts`, `toolCallLightContrastCss.test.ts`.
- Live run (server + SPA, light theme, real permission prompt): both buttons compute `color: rgb(76, 29, 149)` over the light-purple background → **7.23:1 contrast (WCAG AAA)**.

Ported from downstream `hijera/foxxy-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)