### PR TITLE
Load nested AGENTS.md only for directories the agent touches

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -23,11 +23,15 @@ When `rules.auto_discover` is true (default), Coddy scans:
 | Cursor | `.cursor/rules/` |
 | Claude | `.claude/rules/` |
 | Codex | `.codex/rules/` (markdown only in v1) |
-| Agents | nested `**/AGENTS.md` ([agents.md](https://agents.md/) convention; hidden dirs, `node_modules`, `vendor` skipped) |
+| Agents | nested `**/AGENTS.md` ([agents.md](https://agents.md/) convention; hidden dirs, `node_modules`, `vendor` skipped) — discovered eagerly, **loaded on demand** (see Activation) |
 
 Duplicate rule files (same basename) resolve with precedence: **coddy > cursor > claude > codex > agents**. Nested `AGENTS.md` files are keyed by full path, so they never collapse into each other.
 
-Nested `AGENTS.md` files are always-loaded: no frontmatter, no globs, active immediately. The **root** `AGENTS.md` is not part of this set — it already enters the prompt unconditionally as a project docs preamble (below).
+Nested `AGENTS.md` files are **directory-scoped**. Discovery finds them all, but a body enters **`{{.Rules}}`** only the first time a filesystem tool call or an attached `file://` path targets its directory or anything below it — then it **sticks** for the rest of the session. Every `AGENTS.md` on the ancestor chain of a touched path activates together, so reading `a/b/c/f.go` pulls in `a/AGENTS.md`, `a/b/AGENTS.md`, and `a/b/c/AGENTS.md`. `run_command` does not activate anything: a shell string cannot be attributed to a directory reliably.
+
+This is what keeps a repo with vendored sibling checkouts usable — 45 nested files loaded unconditionally cost ~131k tokens of system prompt before the first question. Bodies over 256 KB are truncated, as with the project docs preamble.
+
+The **root** `AGENTS.md` is not part of this set — it already enters the prompt unconditionally as a project docs preamble (below).
 
 CLI: `coddy rules list [--cwd DIR]` prints the discovered catalog.
 
@@ -35,10 +39,11 @@ CLI: `coddy rules list [--cwd DIR]` prints the discovered catalog.
 
 | Frontmatter | Behavior |
 |-------------|----------|
-| `alwaysApply: true` + `globs` / `paths` | Body enters **`{{.Rules}}`** only after the first glob match on a turn (from `file://` context or tool paths). Then **sticks** for the rest of the session |
+| `alwaysApply: true` + `globs` / `paths` | Body enters **`{{.Rules}}`** only after the first glob match on a turn (from `file://` context in the user message). Then **sticks** for the rest of the session |
 | `alwaysApply: true` without globs | Active immediately for the session |
 | `alwaysApply: false` | **Never** auto-included, even if globs would match. Body only when **`@ruleName`** appears in the user message |
 | No frontmatter | Treated as auto; active immediately |
+| Nested `AGENTS.md` (no frontmatter) | Directory-scoped. Body enters **`{{.Rules}}`** after the first filesystem tool call or `file://` path inside its directory, then **sticks** for the session |
 
 Mention-only rules use **`@name`** (file stem). They are **not** slash commands and do not appear in the skills catalog.
 
@@ -74,4 +79,5 @@ rules:
 - [Cursor Rules](https://cursor.com/docs/rules)
 - [Claude `.claude/rules`](https://code.claude.com/docs/en/memory#organize-rules-with-clauderules)
 - [Codex Rules](https://developers.openai.com/codex/rules)
-- Implementation: `internal/rules/*`, wiring in `internal/session`, `internal/agent/system_prompt.go`
+- Implementation: `internal/rules/*` (directory scoping in `scope.go`), wiring in `internal/session`, `internal/agent/system_prompt.go`; tool-path activation in `internal/agent/rules_activation.go` and `internal/tools/fs/toolpaths.go`
+- Spec: `features/agents_md_scoping.feature`

--- a/features/agents_md_scoping.feature
+++ b/features/agents_md_scoping.feature
@@ -1,0 +1,15 @@
+Feature: Nested AGENTS.md loads only for directories the agent touches
+  A project can carry dozens of nested AGENTS.md files — vendored checkouts,
+  monorepo packages — and loading them all costs six figures of tokens before
+  the first question is answered. Each nested file is scoped to its own
+  directory: it enters the system prompt the first time a filesystem tool
+  targets that directory or anything below it, then stays for the session.
+  The root AGENTS.md is unconditional and always present.
+
+  Scenario: A nested AGENTS.md enters the prompt after a tool touches its directory
+    Given a project with a root AGENTS.md and nested AGENTS.md files under "internal/agent" and "external/httpserver"
+    And a coddy agent session in that project
+    When the model reads "internal/agent/react.go" and then answers
+    Then the first request carries the root AGENTS.md but neither nested one
+    And every request after the read carries the "internal/agent" AGENTS.md
+    And no request carries the "external/httpserver" AGENTS.md

--- a/internal/agent/bdd_agents_scope_test.go
+++ b/internal/agent/bdd_agents_scope_test.go
@@ -1,0 +1,245 @@
+package agent
+
+// Godog harness for features/agents_md_scoping.feature: drives the real
+// Agent.Run against a fake LLM provider that reads one file and then answers,
+// and inspects the system message of every request the provider received. The
+// system prompt is what the spec is about, so the provider's view of it is the
+// only honest assertion surface.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/acp"
+	"github.com/EvilFreelancer/coddy-agent/internal/config"
+	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
+)
+
+const (
+	bddRootAgentsToken    = "ROOT_AGENTS_MD_TOKEN"
+	bddNestedAgentsToken  = "NESTED_AGENTS_MD_TOKEN"
+	bddSiblingAgentsToken = "SIBLING_AGENTS_MD_TOKEN"
+)
+
+// bddReadThenAnswerProvider requests a single read on its first call, then answers.
+type bddReadThenAnswerProvider struct {
+	readPath string
+	seen     [][]llm.Message
+}
+
+func (p *bddReadThenAnswerProvider) Complete(context.Context, []llm.Message, []llm.ToolDefinition) (*llm.Response, error) {
+	return nil, fmt.Errorf("Complete must not be used by the AGENTS.md scoping suite")
+}
+
+func (p *bddReadThenAnswerProvider) Stream(_ context.Context, messages []llm.Message, _ []llm.ToolDefinition, onChunk func(llm.StreamChunk)) (*llm.Response, error) {
+	p.seen = append(p.seen, append([]llm.Message(nil), messages...))
+	if len(p.seen) == 1 {
+		tc := llm.ToolCall{
+			ID:        "call_read_1",
+			Name:      "read",
+			InputJSON: fmt.Sprintf(`{"path":%q}`, p.readPath),
+		}
+		onChunk(llm.StreamChunk{ToolCall: &tc})
+		return &llm.Response{ToolCalls: []llm.ToolCall{tc}, StopReason: "tool_use"}, nil
+	}
+	const answer = "Read it; here is the summary."
+	onChunk(llm.StreamChunk{TextDelta: answer})
+	return &llm.Response{Content: answer, StopReason: "end_turn"}, nil
+}
+
+type agentsScopeFeatureState struct {
+	tmpDirs  []string
+	cwd      string
+	st       *session.State
+	ag       *Agent
+	provider *bddReadThenAnswerProvider
+}
+
+func (s *agentsScopeFeatureState) reset() error {
+	s.close()
+	s.provider = nil
+	return nil
+}
+
+func (s *agentsScopeFeatureState) close() {
+	for _, d := range s.tmpDirs {
+		_ = os.RemoveAll(d)
+	}
+	s.tmpDirs = nil
+	s.cwd = ""
+	s.st = nil
+	s.ag = nil
+}
+
+func (s *agentsScopeFeatureState) tempDir() (string, error) {
+	d, err := os.MkdirTemp("", "coddy-bdd-agents-scope-*")
+	if err != nil {
+		return "", err
+	}
+	s.tmpDirs = append(s.tmpDirs, d)
+	return d, nil
+}
+
+func (s *agentsScopeFeatureState) projectWithNestedAgentsFiles(nested, sibling string) error {
+	cwd, err := s.tempDir()
+	if err != nil {
+		return err
+	}
+	s.cwd = cwd
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte(bddRootAgentsToken), 0o644); err != nil {
+		return err
+	}
+	for dir, token := range map[string]string{nested: bddNestedAgentsToken, sibling: bddSiblingAgentsToken} {
+		full := filepath.Join(cwd, filepath.FromSlash(dir))
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(full, "AGENTS.md"), []byte(token), 0o644); err != nil {
+			return err
+		}
+	}
+	// The file the model will read.
+	return os.WriteFile(filepath.Join(cwd, filepath.FromSlash(nested), "react.go"), []byte("package agent\n"), 0o644)
+}
+
+func (s *agentsScopeFeatureState) agentSessionInThatProject() error {
+	if s.cwd == "" {
+		return fmt.Errorf("no project prepared")
+	}
+	sessionDir, err := s.tempDir()
+	if err != nil {
+		return err
+	}
+	s.st = &session.State{
+		ID:         "sess_bdd_agents_scope",
+		CWD:        s.cwd,
+		Mode:       session.ModeAgent,
+		SessionDir: sessionDir,
+	}
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{{Name: "fake", Type: "openai", APIKey: "test"}},
+		Models:    []config.ModelEntry{{Model: "fake/model", MaxTokens: 100}},
+		Agent:     config.Agent{Model: "fake/model", MaxTurns: 6},
+	}
+	cfg.Prompts.ApplyDefaults()
+	s.st.ReplaceRulesCatalog(session.DiscoverRules(cfg, s.cwd))
+	s.ag = NewAgent(cfg, s.st, resumePermissionSender{}, nil)
+	return nil
+}
+
+func (s *agentsScopeFeatureState) modelReadsFileThenAnswers(path string) error {
+	if s.ag == nil {
+		return fmt.Errorf("no agent prepared")
+	}
+	s.provider = &bddReadThenAnswerProvider{readPath: path}
+	s.ag.providerFactory = func(llm.ProviderInput) (llm.Provider, error) { return s.provider, nil }
+	stop, err := s.ag.Run(context.Background(), []acp.ContentBlock{{Type: "text", Text: "summarize the agent loop"}})
+	if err != nil {
+		return fmt.Errorf("run failed: %w", err)
+	}
+	if stop != string(acp.StopReasonEndTurn) {
+		return fmt.Errorf("stop reason = %q, want end_turn", stop)
+	}
+	if len(s.provider.seen) < 2 {
+		return fmt.Errorf("expected at least 2 requests (read, then answer), got %d", len(s.provider.seen))
+	}
+	return nil
+}
+
+// systemPrompt returns the system message of the nth request (0-based).
+func (s *agentsScopeFeatureState) systemPrompt(n int) (string, error) {
+	if n >= len(s.provider.seen) {
+		return "", fmt.Errorf("request %d was never made (%d total)", n, len(s.provider.seen))
+	}
+	msgs := s.provider.seen[n]
+	if len(msgs) == 0 || msgs[0].Role != llm.RoleSystem {
+		return "", fmt.Errorf("request %d does not start with a system message", n)
+	}
+	return msgs[0].Content, nil
+}
+
+func (s *agentsScopeFeatureState) firstRequestHasRootOnly() error {
+	sp, err := s.systemPrompt(0)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(sp, bddRootAgentsToken) {
+		return fmt.Errorf("the root AGENTS.md is missing from the first request")
+	}
+	for _, tok := range []string{bddNestedAgentsToken, bddSiblingAgentsToken} {
+		if strings.Contains(sp, tok) {
+			return fmt.Errorf("a nested AGENTS.md (%s) was loaded before any tool touched its directory", tok)
+		}
+	}
+	return nil
+}
+
+func (s *agentsScopeFeatureState) requestsAfterReadCarryNested(dir string) error {
+	for n := 1; n < len(s.provider.seen); n++ {
+		sp, err := s.systemPrompt(n)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(sp, bddNestedAgentsToken) {
+			return fmt.Errorf("request %d is missing the %q AGENTS.md after the read", n, dir)
+		}
+		if !strings.Contains(sp, bddRootAgentsToken) {
+			return fmt.Errorf("request %d lost the root AGENTS.md", n)
+		}
+	}
+	return nil
+}
+
+func (s *agentsScopeFeatureState) noRequestCarriesSibling(dir string) error {
+	for n := range s.provider.seen {
+		sp, err := s.systemPrompt(n)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(sp, bddSiblingAgentsToken) {
+			return fmt.Errorf("request %d loaded the untouched %q AGENTS.md", n, dir)
+		}
+	}
+	return nil
+}
+
+func initializeAgentsScopeScenario(sc *godog.ScenarioContext) {
+	s := &agentsScopeFeatureState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		return ctx, s.reset()
+	})
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		s.close()
+		return ctx, nil
+	})
+
+	sc.Step(`^a project with a root AGENTS\.md and nested AGENTS\.md files under "([^"]*)" and "([^"]*)"$`, s.projectWithNestedAgentsFiles)
+	sc.Step(`^a coddy agent session in that project$`, s.agentSessionInThatProject)
+	sc.Step(`^the model reads "([^"]*)" and then answers$`, s.modelReadsFileThenAnswers)
+	sc.Step(`^the first request carries the root AGENTS\.md but neither nested one$`, s.firstRequestHasRootOnly)
+	sc.Step(`^every request after the read carries the "([^"]*)" AGENTS\.md$`, s.requestsAfterReadCarryNested)
+	sc.Step(`^no request carries the "([^"]*)" AGENTS\.md$`, s.noRequestCarriesSibling)
+}
+
+func TestAgentsMDScopingFeature(t *testing.T) {
+	suite := godog.TestSuite{
+		Name:                "agents-md-scoping",
+		ScenarioInitializer: initializeAgentsScopeScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/agents_md_scoping.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("AGENTS.md scoping feature suite failed")
+	}
+}

--- a/internal/agent/react.go
+++ b/internal/agent/react.go
@@ -758,6 +758,12 @@ func (a *Agent) executeToolCall(ctx context.Context, tc llm.ToolCall, env *tools
 	env.ToolCallID = strings.TrimSpace(tc.ID)
 	defer func() { env.ToolCallID = "" }()
 
+	// Touching a directory pulls its nested AGENTS.md into the prompt. Done up
+	// front so it holds regardless of the outcome below (permission denial,
+	// tool error), and so both callers — the ReAct loop and the resume-after-
+	// permission path — are covered without threading state through.
+	a.activateScopedRulesForToolCall(tc.Name, tc.InputJSON, env.CWD)
+
 	sessionDir := ""
 	if st := sessionStatePtr(a.state); st != nil {
 		sessionDir = strings.TrimSpace(st.GetPersistedSessionDir())
@@ -1101,11 +1107,29 @@ func extractContextFiles(blocks []acp.ContentBlock) []string {
 		if b.Type == "resource" && b.Resource != nil {
 			uri := b.Resource.URI
 			if strings.HasPrefix(uri, "file://") {
-				files = append(files, strings.TrimPrefix(uri, "file://"))
+				files = append(files, fileURIPath(uri))
 			}
 		}
 	}
 	return files
+}
+
+// fileURIPath turns a file:// URI into a filesystem path. On Windows the
+// authority-less form is file:///C:/proj/x.go, whose leading slash must go —
+// "/C:/proj/x.go" matches no rule scope and no glob. A POSIX path that merely
+// contains a colon (/a:b) keeps its slash: the drive form requires a separator
+// after the colon, or nothing at all.
+func fileURIPath(uri string) string {
+	p := strings.TrimPrefix(uri, "file://")
+	if len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' &&
+		(len(p) == 3 || p[3] == '/' || p[3] == '\\') {
+		p = p[1:]
+	}
+	return p
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 // toolKind maps a tool name to an ACP tool call kind.

--- a/internal/agent/rules_activation.go
+++ b/internal/agent/rules_activation.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"github.com/EvilFreelancer/coddy-agent/internal/rules"
+	toolfs "github.com/EvilFreelancer/coddy-agent/internal/tools/fs"
+)
+
+// activateScopedRulesForToolCall marks directory-scoped rules (nested AGENTS.md)
+// active once a filesystem tool call targets a path inside their directory.
+// Activation is sticky for the rest of the session, matching how auto rules
+// behave after their first glob match, and the next system prompt rebuild
+// (once per ReAct turn) picks the rule up.
+func (a *Agent) activateScopedRulesForToolCall(toolName, argsJSON, cwd string) {
+	st := sessionStatePtr(a.state)
+	if st == nil {
+		return
+	}
+	catalog := st.GetRulesCatalog()
+	if len(catalog) == 0 {
+		return
+	}
+	newly := rules.MatchScoped(catalog, toolfs.ToolCallPaths(toolName, argsJSON, cwd))
+	if len(newly) == 0 {
+		return
+	}
+	st.SetActiveAutoRules(rules.UnionStable(st.GetActiveAutoRules(), newly))
+}

--- a/internal/agent/rules_activation_test.go
+++ b/internal/agent/rules_activation_test.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/acp"
+	"github.com/EvilFreelancer/coddy-agent/internal/config"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
+)
+
+// scopedRulesProject writes a root AGENTS.md plus one nested AGENTS.md per dir
+// (slash-separated, relative to the project root) and returns a wired agent.
+func scopedRulesProject(t *testing.T, dirs ...string) (*Agent, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("ROOT_AGENTS_TOKEN"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range dirs {
+		full := filepath.Join(tmp, filepath.FromSlash(d))
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		token := "NESTED_TOKEN_" + strings.ToUpper(strings.NewReplacer("/", "_", "-", "_").Replace(d))
+		if err := os.WriteFile(filepath.Join(full, "AGENTS.md"), []byte(token), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st := &session.State{ID: "t", CWD: tmp, Mode: session.ModeAgent}
+	st.ReplaceRulesCatalog(session.DiscoverRules(&config.Config{}, tmp))
+	cfg := &config.Config{}
+	cfg.Agent.ApplyDefaults()
+	cfg.Prompts.ApplyDefaults()
+	return NewAgent(cfg, st, nil, nil), tmp
+}
+
+func nestedToken(dir string) string {
+	return "NESTED_TOKEN_" + strings.ToUpper(strings.NewReplacer("/", "_", "-", "_").Replace(dir))
+}
+
+func TestScopedAgentsRuleHiddenUntilToolTouchesItsDirectory(t *testing.T) {
+	a, tmp := scopedRulesProject(t, "internal/agent", "external/httpserver")
+
+	before := a.buildSystemPrompt("agent", nil, nil, "", nil)
+	if !strings.Contains(before, "ROOT_AGENTS_TOKEN") {
+		t.Fatal("root AGENTS.md must always be in the prompt")
+	}
+	for _, d := range []string{"internal/agent", "external/httpserver"} {
+		if strings.Contains(before, nestedToken(d)) {
+			t.Fatalf("nested AGENTS.md for %s leaked before any tool touched it", d)
+		}
+	}
+
+	a.activateScopedRulesForToolCall("read", `{"path":"internal/agent/react.go"}`, tmp)
+
+	after := a.buildSystemPrompt("agent", nil, nil, "", nil)
+	if !strings.Contains(after, nestedToken("internal/agent")) {
+		t.Fatal("nested AGENTS.md missing after a read inside its directory")
+	}
+	if strings.Contains(after, nestedToken("external/httpserver")) {
+		t.Fatal("an untouched sibling directory's AGENTS.md must stay out of the prompt")
+	}
+}
+
+func TestScopedAgentsRuleStaysActiveOnLaterTurns(t *testing.T) {
+	a, tmp := scopedRulesProject(t, "internal/agent")
+
+	a.activateScopedRulesForToolCall("edit", `{"path":"internal/agent/react.go","oldString":"a","newString":"b"}`, tmp)
+	if !strings.Contains(a.buildSystemPrompt("agent", nil, nil, "", nil), nestedToken("internal/agent")) {
+		t.Fatal("rule missing right after activation")
+	}
+	// A later turn working elsewhere must not drop it.
+	a.activateScopedRulesForToolCall("read", `{"path":"docs/rules.md"}`, tmp)
+	later := a.buildSystemPrompt("agent", nil, nil, "", []string{filepath.Join(tmp, "docs", "rules.md")})
+	if !strings.Contains(later, nestedToken("internal/agent")) {
+		t.Fatal("activation must stick for the rest of the session")
+	}
+}
+
+func TestScopedAgentsRuleActivatesFromAttachedContextFile(t *testing.T) {
+	a, tmp := scopedRulesProject(t, "internal/agent")
+
+	prompt := a.buildSystemPrompt("agent", nil, nil, "", []string{filepath.Join(tmp, "internal", "agent", "react.go")})
+	if !strings.Contains(prompt, nestedToken("internal/agent")) {
+		t.Fatal("an attached file:// path inside the directory must activate its AGENTS.md")
+	}
+}
+
+func TestScopedAgentsRuleNotActivatedByRunCommand(t *testing.T) {
+	a, tmp := scopedRulesProject(t, "internal/agent")
+
+	a.activateScopedRulesForToolCall("run_command", `{"command":"go test ./internal/agent"}`, tmp)
+	if strings.Contains(a.buildSystemPrompt("agent", nil, nil, "", nil), nestedToken("internal/agent")) {
+		t.Fatal("run_command must not activate scoped rules")
+	}
+}
+
+func TestScopedAgentsRuleAncestorChain(t *testing.T) {
+	a, tmp := scopedRulesProject(t, "a", "a/b", "a/b/c", "a/other")
+
+	a.activateScopedRulesForToolCall("read", `{"path":"a/b/c/f.go"}`, tmp)
+	prompt := a.buildSystemPrompt("agent", nil, nil, "", nil)
+	for _, d := range []string{"a", "a/b", "a/b/c"} {
+		if !strings.Contains(prompt, nestedToken(d)) {
+			t.Fatalf("ancestor AGENTS.md for %q must activate too", d)
+		}
+	}
+	if strings.Contains(prompt, nestedToken("a/other")) {
+		t.Fatal("a sibling of the touched directory must not activate")
+	}
+}
+
+func TestScopedAgentsRuleMoveActivatesBothEnds(t *testing.T) {
+	a, tmp := scopedRulesProject(t, "src", "dst")
+
+	a.activateScopedRulesForToolCall("mv", `{"src":"src/x.go","dst":"dst/x.go"}`, tmp)
+	prompt := a.buildSystemPrompt("agent", nil, nil, "", nil)
+	for _, d := range []string{"src", "dst"} {
+		if !strings.Contains(prompt, nestedToken(d)) {
+			t.Fatalf("mv must activate the AGENTS.md of %q", d)
+		}
+	}
+}
+
+func TestExtractContextFilesStripsWindowsDriveSlash(t *testing.T) {
+	blocks := []acp.ContentBlock{
+		{Type: "resource", Resource: &acp.Resource{URI: "file:///C:/proj/x.go"}},
+		{Type: "resource", Resource: &acp.Resource{URI: "file:///home/u/y.go"}},
+		// A POSIX path that merely contains a colon is not a drive path.
+		{Type: "resource", Resource: &acp.Resource{URI: "file:///a:b/z.go"}},
+	}
+	got := extractContextFiles(blocks)
+	want := []string{"C:/proj/x.go", "/home/u/y.go", "/a:b/z.go"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/rules/agents.go
+++ b/internal/rules/agents.go
@@ -13,7 +13,10 @@ var agentsSkipDirs = map[string]bool{
 }
 
 // AgentsProvider discovers nested **/AGENTS.md files (https://agents.md/)
-// under the project root and injects them as always-loaded rules.
+// under the project root and injects them as directory-scoped rules: each one
+// enters the prompt only once a context path targets its directory or anything
+// below it (see Rule.ScopeDir and MatchAuto). Loading them all unconditionally
+// costs six figures of tokens on a repo with vendored sibling checkouts.
 // The root AGENTS.md is excluded: it already enters the prompt
 // unconditionally as a project docs preamble (see LoadProjectDocs).
 type AgentsProvider struct{}
@@ -59,6 +62,9 @@ func (p *AgentsProvider) Load(root string) ([]*Rule, error) {
 		if content == "" {
 			return nil
 		}
+		if len(content) > projectDocMaxBytes {
+			content = content[:projectDocMaxBytes] + "\n\n...(truncated)"
+		}
 		rel, err := filepath.Rel(root, path)
 		if err != nil {
 			rel = path
@@ -71,6 +77,7 @@ func (p *AgentsProvider) Load(root string) ([]*Rule, error) {
 			AlwaysApply: true,
 			ApplyMode:   ApplyAuto,
 			Content:     content,
+			ScopeDir:    filepath.Dir(path),
 		})
 		return nil
 	})

--- a/internal/rules/list.go
+++ b/internal/rules/list.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -24,11 +25,16 @@ func ListCatalog(cwd string, f *Factory, systems []Source) error {
 	}
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(table.Row{"SOURCE", "NAME", "APPLY", "ALWAYS", "GLOBS", "DESCRIPTION"})
+	t.AppendHeader(table.Row{"SOURCE", "NAME", "APPLY", "ALWAYS", "ACTIVATES ON", "DESCRIPTION"})
 	for _, r := range rules {
-		globs := strings.Join(r.Globs, ", ")
-		if len(globs) > 60 {
-			globs = globs[:57] + "..."
+		// A directory-scoped rule (nested AGENTS.md) has no globs: what gates it
+		// is its own subtree, so show that instead of an empty column.
+		activates := strings.Join(r.Globs, ", ")
+		if r.ScopeDir != "" {
+			activates = scopeDirLabel(cwd, r.ScopeDir) + "/**"
+		}
+		if len(activates) > 60 {
+			activates = activates[:57] + "..."
 		}
 		desc := r.Description
 		if len(desc) > 50 {
@@ -39,7 +45,7 @@ func ListCatalog(cwd string, f *Factory, systems []Source) error {
 			r.CanonicalName(),
 			string(r.ApplyMode),
 			fmt.Sprintf("%v", r.AlwaysApply),
-			globs,
+			activates,
 			desc,
 		})
 	}
@@ -49,4 +55,16 @@ func ListCatalog(cwd string, f *Factory, systems []Source) error {
 	t.Render()
 	fmt.Printf("\n%d rule(s) under %s\n", len(rules), cwd)
 	return nil
+}
+
+// scopeDirLabel renders a rule's ScopeDir relative to cwd, slash-separated.
+func scopeDirLabel(cwd, scopeDir string) string {
+	rel, err := filepath.Rel(cwd, scopeDir)
+	if err != nil {
+		return filepath.ToSlash(scopeDir)
+	}
+	if rel == "." {
+		return "."
+	}
+	return filepath.ToSlash(rel)
 }

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -37,6 +37,11 @@ type Rule struct {
 	AlwaysApply bool
 	ApplyMode   ApplyMode
 	Content     string
+	// ScopeDir, when non-empty, restricts an auto rule to a directory subtree.
+	// The rule enters the prompt on the first turn a context path is ScopeDir
+	// itself or lives under it, then sticks for the session (see UnionStable).
+	// Set by AgentsProvider for nested AGENTS.md; empty for every other source.
+	ScopeDir string
 }
 
 // CanonicalName is the @mention identifier (file stem).

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -126,13 +126,42 @@ func TestDiscoverNestedAgentsMD(t *testing.T) {
 			t.Fatalf("source = %q, want agents", r.Source)
 		}
 		if !r.AlwaysApply || r.ApplyMode != rules.ApplyAuto || len(r.Globs) != 0 {
-			t.Fatalf("AGENTS.md rule must be always-loaded: %+v", r)
+			t.Fatalf("AGENTS.md rule must be an auto rule without globs: %+v", r)
+		}
+		if r.ScopeDir != filepath.Dir(r.FilePath) {
+			t.Fatalf("AGENTS.md rule must be scoped to its own directory: ScopeDir=%q FilePath=%q", r.ScopeDir, r.FilePath)
 		}
 	}
 	names := []string{got[0].CanonicalName(), got[1].CanonicalName()}
 	sort.Strings(names)
 	if names[0] != "external/httpserver/AGENTS.md" || names[1] != "internal/agent/AGENTS.md" {
 		t.Fatalf("names = %v", names)
+	}
+}
+
+func TestDiscoverNestedAgentsMDTruncatesOversizedFile(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A scoped rule enters the prompt in one shot, so an oversized file must be
+	// capped the same way the project docs preamble is.
+	big := strings.Repeat("x", 300*1024)
+	if err := os.WriteFile(filepath.Join(tmp, "sub", "AGENTS.md"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := rules.DefaultFactory().Discover(tmp, rules.ParseSystems([]string{"agents"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(got))
+	}
+	if len(got[0].Content) >= len(big) {
+		t.Fatalf("content not capped: %d bytes", len(got[0].Content))
+	}
+	if !strings.HasSuffix(got[0].Content, "...(truncated)") {
+		t.Fatal("capped content must be marked as truncated")
 	}
 }
 

--- a/internal/rules/scope.go
+++ b/internal/rules/scope.go
@@ -1,0 +1,70 @@
+package rules
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// PathUnderDir reports whether p is dir itself or lives inside dir.
+// Both sides are normalized for separators and, on Windows, for case.
+// Neither side is made absolute: a relative path would resolve against the
+// process working directory rather than the session one, so callers resolve
+// paths themselves before calling.
+func PathUnderDir(dir, p string) bool {
+	d := normalizeScopePath(dir)
+	q := normalizeScopePath(p)
+	if d == "" || q == "" {
+		return false
+	}
+	if d == q {
+		return true
+	}
+	// The trailing separator is what keeps "internal/agent" from matching
+	// "internal/agentx/f.go".
+	return strings.HasPrefix(q, d+string(filepath.Separator))
+}
+
+// PathsUnderDir reports whether any of paths is dir itself or lives inside dir.
+func PathsUnderDir(dir string, paths []string) bool {
+	for _, p := range paths {
+		if PathUnderDir(dir, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchScoped returns directory-scoped auto rules whose ScopeDir contains any
+// of paths. Glob-based and unscoped rules are ignored on purpose: callers that
+// feed tool-call paths would otherwise re-match the whole always-on set on
+// every single tool call.
+func MatchScoped(catalog []*Rule, paths []string) []*Rule {
+	if len(paths) == 0 {
+		return nil
+	}
+	var out []*Rule
+	for _, r := range catalog {
+		if r == nil || r.ScopeDir == "" || r.ApplyMode != ApplyAuto || !r.AlwaysApply {
+			continue
+		}
+		if PathsUnderDir(r.ScopeDir, paths) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// normalizeScopePath cleans a path for prefix comparison. filepath.Rel is
+// deliberately avoided: it errors across Windows drive letters.
+func normalizeScopePath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	p = filepath.Clean(filepath.FromSlash(p))
+	if runtime.GOOS == "windows" {
+		p = strings.ToLower(p)
+	}
+	return p
+}

--- a/internal/rules/scope_test.go
+++ b/internal/rules/scope_test.go
@@ -1,0 +1,171 @@
+package rules_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/rules"
+)
+
+func scopedRule(id, dir, content string) *rules.Rule {
+	return &rules.Rule{
+		ID:          id,
+		Name:        id,
+		FilePath:    filepath.Join(dir, "AGENTS.md"),
+		Source:      rules.SourceAgents,
+		AlwaysApply: true,
+		ApplyMode:   rules.ApplyAuto,
+		Content:     content,
+		ScopeDir:    dir,
+	}
+}
+
+func TestMatchAutoScopedAgentsRule(t *testing.T) {
+	scope := filepath.Join("/proj", "internal", "agent")
+	r := scopedRule("agents:internal/agent", scope, "AGENT_SCOPE_TOKEN")
+	catalog := []*rules.Rule{r}
+
+	cases := []struct {
+		name  string
+		files []string
+		want  int
+	}{
+		{"no context at all", nil, 0},
+		{"file deep under the scope", []string{filepath.Join(scope, "sub", "react.go")}, 1},
+		{"file directly in the scope", []string{filepath.Join(scope, "react.go")}, 1},
+		{"the scope directory itself", []string{scope}, 1},
+		{"sibling directory", []string{filepath.Join("/proj", "internal", "session", "state.go")}, 0},
+		{"parent directory", []string{filepath.Join("/proj", "internal")}, 0},
+		// The trailing separator in the prefix check is what makes this 0.
+		{"prefix collision", []string{filepath.Join("/proj", "internal", "agentx", "f.go")}, 0},
+		{"one of several paths matches", []string{
+			filepath.Join("/proj", "docs", "x.md"),
+			filepath.Join(scope, "react.go"),
+		}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := len(rules.MatchAuto(catalog, tc.files)); got != tc.want {
+				t.Fatalf("MatchAuto(%v) = %d matches, want %d", tc.files, got, tc.want)
+			}
+			if got := len(rules.MatchScoped(catalog, tc.files)); got != tc.want {
+				t.Fatalf("MatchScoped(%v) = %d matches, want %d", tc.files, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchScopedIgnoresUnscopedRules(t *testing.T) {
+	always := &rules.Rule{
+		ID: "coddy:always", Name: "always",
+		AlwaysApply: true, ApplyMode: rules.ApplyAuto, Content: "always body",
+	}
+	globbed := &rules.Rule{
+		ID: "cursor:go", Name: "go",
+		AlwaysApply: true, ApplyMode: rules.ApplyAuto,
+		Globs:       []string{"**/*.go"},
+		Content:     "glob body",
+	}
+	catalog := []*rules.Rule{always, globbed}
+	if got := rules.MatchScoped(catalog, []string{filepath.Join("/proj", "main.go")}); len(got) != 0 {
+		t.Fatalf("MatchScoped must ignore unscoped rules, got %d", len(got))
+	}
+	// MatchAuto keeps its existing semantics for both.
+	if got := rules.MatchAuto(catalog, []string{filepath.Join("/proj", "main.go")}); len(got) != 2 {
+		t.Fatalf("MatchAuto = %d, want 2", len(got))
+	}
+}
+
+func TestMatchAutoScopedMentionRuleNeverMatches(t *testing.T) {
+	r := scopedRule("agents:sub", filepath.Join("/proj", "sub"), "body")
+	r.AlwaysApply = false
+	r.ApplyMode = rules.ApplyMention
+	catalog := []*rules.Rule{r}
+	if got := rules.MatchAuto(catalog, []string{filepath.Join("/proj", "sub", "x.go")}); len(got) != 0 {
+		t.Fatalf("mention rule must not auto-match, got %d", len(got))
+	}
+}
+
+func TestScopedRuleStaysStickyAfterMatch(t *testing.T) {
+	scope := filepath.Join("/proj", "internal", "agent")
+	catalog := []*rules.Rule{scopedRule("agents:a", scope, "body")}
+
+	sticky := rules.UnionStable(nil, rules.MatchAuto(catalog, []string{filepath.Join(scope, "react.go")}))
+	if len(sticky) != 1 {
+		t.Fatalf("sticky len %d after match, want 1", len(sticky))
+	}
+	// A later turn touching an unrelated directory must not drop it.
+	sticky = rules.UnionStable(sticky, rules.MatchAuto(catalog, []string{filepath.Join("/proj", "docs", "x.md")}))
+	if len(sticky) != 1 {
+		t.Fatalf("sticky len %d after unrelated turn, want 1", len(sticky))
+	}
+}
+
+func TestPathUnderDir(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		path string
+		want bool
+	}{
+		{"identical", filepath.Join("/proj", "a"), filepath.Join("/proj", "a"), true},
+		{"child", filepath.Join("/proj", "a"), filepath.Join("/proj", "a", "b.go"), true},
+		{"grandchild", filepath.Join("/proj", "a"), filepath.Join("/proj", "a", "b", "c.go"), true},
+		{"sibling", filepath.Join("/proj", "a"), filepath.Join("/proj", "b", "c.go"), false},
+		{"prefix collision", filepath.Join("/proj", "a"), filepath.Join("/proj", "ax", "c.go"), false},
+		{"parent", filepath.Join("/proj", "a"), "/proj", false},
+		{"empty dir", "", filepath.Join("/proj", "a"), false},
+		{"empty path", filepath.Join("/proj", "a"), "", false},
+		{"blank path", filepath.Join("/proj", "a"), "   ", false},
+		{"trailing separator on dir", filepath.Join("/proj", "a") + string(filepath.Separator), filepath.Join("/proj", "a", "b.go"), true},
+		{"slash-form path against native dir", filepath.Join("/proj", "a"), "/proj/a/b.go", true},
+		{"unclean path", filepath.Join("/proj", "a"), filepath.Join("/proj", "a", "..", "a", "b.go"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rules.PathUnderDir(tc.dir, tc.path); got != tc.want {
+				t.Fatalf("PathUnderDir(%q, %q) = %v, want %v", tc.dir, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPathUnderDirWindowsCaseInsensitive(t *testing.T) {
+	dir := filepath.Join("C:", "Proj", "Internal", "Agent")
+	path := filepath.Join("c:", "proj", "internal", "agent", "react.go")
+	got := rules.PathUnderDir(dir, path)
+	want := runtime.GOOS == "windows"
+	if got != want {
+		t.Fatalf("PathUnderDir(%q, %q) = %v, want %v on %s", dir, path, got, want, runtime.GOOS)
+	}
+}
+
+func TestPathsUnderDir(t *testing.T) {
+	dir := filepath.Join("/proj", "a")
+	if rules.PathsUnderDir(dir, nil) {
+		t.Fatal("no paths must not match")
+	}
+	if !rules.PathsUnderDir(dir, []string{"/other", filepath.Join(dir, "x.go")}) {
+		t.Fatal("one matching path is enough")
+	}
+	if rules.PathsUnderDir(dir, []string{"/other", "/elsewhere"}) {
+		t.Fatal("unrelated paths must not match")
+	}
+}
+
+func TestPromptOmitsScopedRuleUntilMatched(t *testing.T) {
+	tmp := t.TempDir()
+	scope := filepath.Join(tmp, "internal", "agent")
+	catalog := []*rules.Rule{scopedRule("agents:a", scope, "SCOPED_BODY_TOKEN")}
+
+	out := rules.RenderPrompt(tmp, rules.MatchAuto(catalog, nil), nil)
+	if strings.Contains(out, "SCOPED_BODY_TOKEN") {
+		t.Fatalf("untouched scoped rule leaked into the prompt: %q", out)
+	}
+	out = rules.RenderPrompt(tmp, rules.MatchAuto(catalog, []string{filepath.Join(scope, "react.go")}), nil)
+	if !strings.Contains(out, "SCOPED_BODY_TOKEN") {
+		t.Fatalf("touched scoped rule missing from the prompt: %q", out)
+	}
+}

--- a/internal/rules/select.go
+++ b/internal/rules/select.go
@@ -8,19 +8,25 @@ import (
 var atMentionRE = regexp.MustCompile(`(?:^|[\s(\[{])@([a-zA-Z0-9][a-zA-Z0-9_-]*)`)
 
 // MatchAuto returns rules newly matched this turn (alwaysApply true only).
-// Rules with globs require a context file match; rules without globs match immediately.
+// Directory-scoped rules require a context path inside their subtree; rules with
+// globs require a context file match; rules with neither match immediately.
 func MatchAuto(catalog []*Rule, contextFiles []string) []*Rule {
 	var out []*Rule
 	for _, r := range catalog {
 		if r == nil || r.ApplyMode != ApplyAuto || !r.AlwaysApply {
 			continue
 		}
-		if len(r.Globs) == 0 {
+		switch {
+		case r.ScopeDir != "":
+			if PathsUnderDir(r.ScopeDir, contextFiles) {
+				out = append(out, r)
+			}
+		case len(r.Globs) == 0:
 			out = append(out, r)
-			continue
-		}
-		if matchesRuleGlobs(r, contextFiles) {
-			out = append(out, r)
+		default:
+			if matchesRuleGlobs(r, contextFiles) {
+				out = append(out, r)
+			}
 		}
 	}
 	return out

--- a/internal/tools/fs/toolpaths.go
+++ b/internal/tools/fs/toolpaths.go
@@ -1,0 +1,61 @@
+package fs
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
+
+// ToolCallPaths returns the filesystem paths a built-in fs tool call targets,
+// resolved against cwd. It returns nil for every other tool, including
+// run_command, whose free-form shell string cannot be attributed to a
+// directory reliably.
+//
+// Argument names are kept in sync with the *Args structs in this package.
+func ToolCallPaths(toolName, argsJSON, cwd string) []string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" || strings.TrimSpace(argsJSON) == "" {
+		return nil
+	}
+	switch toolName {
+	case "read", "glob", "grep", "print_tree", "edit", "write", "apply_patch",
+		"mkdir", "rmdir", "touch", "rm":
+		var a struct {
+			Path string `json:"path"`
+		}
+		if json.Unmarshal([]byte(argsJSON), &a) != nil {
+			return nil
+		}
+		// glob and grep declare path as optional; an empty value is skipped
+		// rather than defaulted to cwd.
+		return absPaths(cwd, a.Path)
+	case "mv":
+		var a struct {
+			Src string `json:"src"`
+			Dst string `json:"dst"`
+		}
+		if json.Unmarshal([]byte(argsJSON), &a) != nil {
+			return nil
+		}
+		return absPaths(cwd, a.Src, a.Dst)
+	default:
+		return nil
+	}
+}
+
+// absPaths resolves non-empty paths against cwd and makes them absolute.
+func absPaths(cwd string, paths ...string) []string {
+	var out []string
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		abs, err := filepath.Abs(ResolvePath(p, cwd))
+		if err != nil {
+			continue
+		}
+		out = append(out, abs)
+	}
+	return out
+}

--- a/internal/tools/fs/toolpaths_test.go
+++ b/internal/tools/fs/toolpaths_test.go
@@ -1,0 +1,88 @@
+package fs
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestToolCallPaths(t *testing.T) {
+	cwd := filepath.Join(string(filepath.Separator)+"proj", "repo")
+	abs := func(parts ...string) string {
+		p, err := filepath.Abs(filepath.Join(append([]string{cwd}, parts...)...))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cases := []struct {
+		name string
+		tool string
+		args string
+		want []string
+	}{
+		{"read", "read", `{"path":"internal/agent/react.go"}`, []string{abs("internal", "agent", "react.go")}},
+		{"glob", "glob", `{"pattern":"**/*.go","path":"internal"}`, []string{abs("internal")}},
+		{"grep", "grep", `{"pattern":"func","path":"internal/rules"}`, []string{abs("internal", "rules")}},
+		{"print_tree", "print_tree", `{"path":"docs","depth":2}`, []string{abs("docs")}},
+		{"edit", "edit", `{"path":"a.go","oldString":"x","newString":"y"}`, []string{abs("a.go")}},
+		{"write", "write", `{"path":"a.go","content":"x"}`, []string{abs("a.go")}},
+		{"apply_patch", "apply_patch", `{"path":"a.go","patch":"..."}`, []string{abs("a.go")}},
+		{"mkdir", "mkdir", `{"path":"newdir"}`, []string{abs("newdir")}},
+		{"rmdir", "rmdir", `{"path":"olddir"}`, []string{abs("olddir")}},
+		{"touch", "touch", `{"path":"a.go"}`, []string{abs("a.go")}},
+		{"rm", "rm", `{"path":"a.go"}`, []string{abs("a.go")}},
+		{"mv both ends", "mv", `{"src":"a/x.go","dst":"b/x.go"}`, []string{abs("a", "x.go"), abs("b", "x.go")}},
+		{"mv src only", "mv", `{"src":"a/x.go"}`, []string{abs("a", "x.go")}},
+
+		// glob and grep declare path as optional.
+		{"glob without path", "glob", `{"pattern":"**/*.go"}`, nil},
+		{"grep with blank path", "grep", `{"pattern":"func","path":"   "}`, nil},
+
+		// Not filesystem tools.
+		{"run_command", "run_command", `{"command":"go test ./internal/rules"}`, nil},
+		{"mcp tool", "server__do_thing", `{"path":"a.go"}`, nil},
+		{"unknown tool", "coddy_todo_write", `{"path":"a.go"}`, nil},
+
+		// Malformed or missing input.
+		{"malformed json", "read", `{"path":`, nil},
+		{"empty args", "read", ``, nil},
+		{"missing path", "read", `{}`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ToolCallPaths(tc.tool, tc.args, cwd)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ToolCallPaths(%q, %q) = %v, want %v", tc.tool, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToolCallPathsKeepsAbsoluteAndNeedsCWD(t *testing.T) {
+	absPath, err := filepath.Abs(filepath.Join(string(filepath.Separator)+"elsewhere", "x.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := ToolCallPaths("read", `{"path":`+quote(absPath)+`}`, filepath.Join(string(filepath.Separator)+"proj", "repo"))
+	if len(got) != 1 || got[0] != absPath {
+		t.Fatalf("absolute path not preserved: %v, want [%s]", got, absPath)
+	}
+	if got := ToolCallPaths("read", `{"path":"a.go"}`, ""); got != nil {
+		t.Fatalf("without cwd a relative path cannot be resolved, got %v", got)
+	}
+}
+
+// quote renders s as a JSON string literal (paths carry backslashes on Windows).
+func quote(s string) string {
+	var b []byte
+	b = append(b, '"')
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' || s[i] == '"' {
+			b = append(b, '\\')
+		}
+		b = append(b, s[i])
+	}
+	return string(append(b, '"'))
+}


### PR DESCRIPTION
## Проблема

`AgentsProvider.Load` превращал **каждый** вложенный `AGENTS.md` в правило с `AlwaysApply: true`, `ApplyMode: ApplyAuto`, `Globs: nil`. `rules.MatchAuto` пускает auto-правила без globs в промпт сразу — значит все они попадали в `{{.Rules}}` на каждом ходу, навсегда.

Замерено на реальном проекте (`foxxy-agent`, 53 файла `AGENTS.md` на диске, 45 попадали в промпт — те, что под dot-директориями вроде `.claude/worktrees/`, уже отсекались обходом):

| | блок rules до первого вызова тула |
|---|---|
| До | 563 KB (~141k токенов) |
| После | 95 KB (~24k токенов) |

Большая часть — вендоренные соседние чекауты (`kilocode/`, `opencode-dev/`, `codex-main/`), к которым агент не прикасается.

## Решение

Каждый вложенный `AGENTS.md` теперь **привязан к своей директории** через новое поле `Rule.ScopeDir`. Тело попадает в `{{.Rules}}` в первый раз, когда вызов файлового тула или приложенный `file://` путь указывает на эту директорию или что-то внутри неё — и дальше **остаётся** до конца сессии, как любое другое auto-правило.

- **Цепочка родителей активируется целиком**: чтение `a/b/c/f.go` подтягивает `a/AGENTS.md`, `a/b/AGENTS.md` и `a/b/c/AGENTS.md`.
- **Корневой `AGENTS.md` не изменился** — он и раньше входил безусловно как project docs preamble (`LoadProjectDocs`) плюс через `session.LoadInstructions`.
- **`run_command` не активирует ничего**: строку shell-команды нельзя надёжно сопоставить с директорией.
- Дискаверинг не изменился — правила по-прежнему находятся все сразу, изменился только момент попадания в промпт.

### Как это устроено

- `internal/rules/scope.go` — сопоставление по префиксу пути, независимое от разделителей и (на Windows) от регистра. Завершающий разделитель в префиксе — это то, что не даёт `internal/agent` матчиться на `internal/agentx/f.go`.
- `MatchAuto` (`internal/rules/select.go`) получил ветку для scope перед glob-логикой, поэтому приложенный `file://` путь тоже активирует scoped-правило. Globbed-правила cursor/claude/codex не затронуты — у них `ScopeDir` пустой.
- `internal/tools/fs/toolpaths.go` — `ToolCallPaths` вытаскивает целевые пути из вызовов файловых тулов (`path`, плюс `src`/`dst` для `mv`). Живёт здесь, потому что схемы аргументов определены в этом же пакете.
- `internal/agent/rules_activation.go` + одна строка в начале `executeToolCall` — единственной воронки для всех вызовов тулов. Так покрыты и основной ReAct-цикл, и путь resume-after-permission, без изменения сигнатур. Системный промпт пересобирается раз в ход, поэтому правило, активированное во время выполнения тула, попадает в следующий запрос к LLM.

Рассматривал альтернативу — протащить мутабельный аккумулятор `contextFiles` через `runReActLoop`. Отказался: нужны изменения сигнатур в пяти местах вызова `buildSystemPrompt`, путь resume-after-permission молча теряется, и `contextFiles` (сейчас это «пути, приложенные пользователем к промпту») перегружается, что меняет вход `FilterSkillsForContext`.

## Попутно

- **Ограничение 256 KB на тело вложенного `AGENTS.md`**, как у project docs preamble. Раз тело теперь приезжает одним куском, один раздутый файл мог бы выстрелить в промпт целиком.
- **Фикс `extractContextFiles` на Windows**: превращал `file:///C:/proj/x.go` в `/C:/proj/x.go`, что не матчится ни на scope, ни на glob. Баг был и до этого — он уже ломал glob-матчинг.
- **`coddy rules list`**: колонка `GLOBS` у scoped-правил была пустой, что читалось как «всегда включено». Переименована в `ACTIVATES ON` и показывает поддерево:

  ```
  │ agents │ kilocode/packages/core/src/tool/AGENTS.md │ auto │ true │ kilocode/packages/core/src/tool/** │
  │ cursor │ workflow                                  │ auto │ true │                                   │
  ```

- **`docs/rules.md`** утверждал, что globbed-правила активируются «from `file://` context **or tool paths**». Половина про tool paths никогда не была реализована, а этот PR направляет пути тулов через `MatchScoped`, который globbed-правила игнорирует по замыслу. Поправил документацию, а не поведение — см. ниже.

> Обрати внимание: `coddy rules list` показывает все 65 правил (45 из них — вложенные AGENTS.md), и так и должно быть — дискаверинг не изменился, изменился момент попадания в промпт.

## Проверка

- `make test` зелёный (все 12 комбинаций тегов), `make lint` — 0 issues.
- Спека `features/agents_md_scoping.feature` гоняет настоящий `Agent.Run` против фейкового провайдера и проверяет системное сообщение каждого запроса. Убедился, что она краснеет, если не выставлять `ScopeDir`.
- Граничные случаи — обычными юнит-тестами: коллизии префиксов, цепочки родителей, оба конца `mv`, `run_command`, регистр на Windows, битые аргументы.
- Собрал `make build TAGS="http ui"` и поднял сервер на `foxxy-agent`: `GET /` → 200 (встроенный SPA), `GET /v1/models` → 200.

## Осознанно вне скоупа

- Сделать утверждение про «tool paths» правдой для globbed-правил — это замена `MatchScoped` на `MatchAuto` в хуке, но basename-fallback внутри `MatchesAny` означает, что `globs: ['**/*.go']` начнёт срабатывать на первом чтении любого `.go`-файла где угодно. Это молча меняет содержимое промпта у существующих пользователей cursor/claude и заслуживает отдельного решения (и, вероятно, сначала фикса обработки `**`).
- Корневой `AGENTS.md` попадает в промпт дважды — как `### AGENTS.md` внутри `{{.Rules}}` и как `## Project instructions` через `session.LoadInstructions` (`internal/config/instructions.go` по умолчанию `["AGENTS.md"]`).
- `skills.FilterForContext` (`internal/skills/loader.go`) — заглушка, возвращающая всё как есть.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
