### PR TITLE
fix(shell): make PowerShell output readable and exit codes accurate on Windows

### DIFF
--- a/features/shell_special_characters.feature
+++ b/features/shell_special_characters.feature
@@ -1,0 +1,30 @@
+Feature: Shell commands carry special characters verbatim
+  run_command hands a command to the host shell without the shell re-parsing it as a quoted
+  string, so an agent can pass backticks, quotes, asterisks, parentheses and non-ASCII text
+  straight through. On Windows the command reaches PowerShell as a script file rather than a
+  -Command argument, which is what used to fail with a ParserError; on Linux and macOS the
+  POSIX shell is invoked exactly as before. Commands that fail are still reported as failed.
+
+  Scenario: A command printing shell special characters returns them verbatim
+    Given the host shell detected by the agent
+    When I run a command that prints the literal text:
+      """
+      Expand `agent.qwen.md` from 5 points to **7 structured blocks** (21 items)
+      """
+    Then the command succeeds
+    And the output contains that text verbatim
+
+  Scenario: A command printing non-ASCII text returns it intact
+    Given the host shell detected by the agent
+    When I run a command that prints the literal text:
+      """
+      Русский текст — em dash ✅ 中文
+      """
+    Then the command succeeds
+    And the output contains that text verbatim
+
+  Scenario: A command that exits non-zero is reported as failed with its own exit code
+    Given the host shell detected by the agent
+    When I run a command that exits with code 3
+    Then the command is reported as failed
+    And the failure reports exit code 3

--- a/features/shell_special_characters.feature
+++ b/features/shell_special_characters.feature
@@ -1,9 +1,10 @@
 Feature: Shell commands carry special characters verbatim
-  run_command hands a command to the host shell without the shell re-parsing it as a quoted
-  string, so an agent can pass backticks, quotes, asterisks, parentheses and non-ASCII text
-  straight through. On Windows the command reaches PowerShell as a script file rather than a
-  -Command argument, which is what used to fail with a ParserError; on Linux and macOS the
-  POSIX shell is invoked exactly as before. Commands that fail are still reported as failed.
+  run_command embeds the command text untouched - nothing is escaped, quoted, or stripped -
+  so backticks, quotes, asterisks, parentheses and non-ASCII text keep the meaning the host
+  shell would give them at a prompt. On Windows the command is wrapped in a prologue that
+  switches the output encoding to UTF-8, so results no longer come back in the console OEM
+  code page, and an epilogue that reports the command's own exit code instead of collapsing
+  every failure to 1. On Linux and macOS the POSIX shell is invoked exactly as before.
 
   Scenario: A command printing shell special characters returns them verbatim
     Given the host shell detected by the agent

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.54.0
+	golang.org/x/sys v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -38,6 +39,5 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -88,7 +88,7 @@ func runAPIKeyCommand(command string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(platform.DecodeOutput(out))
 }
 
 // Normalize trims string fields in place.

--- a/internal/platform/output_other.go
+++ b/internal/platform/output_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package platform
+
+// DecodeOutput returns captured child-process output unchanged. Outside Windows
+// there is no console code page to undo: the tooling coddy runs already writes
+// UTF-8.
+func DecodeOutput(b []byte) string {
+	return string(b)
+}

--- a/internal/platform/output_test.go
+++ b/internal/platform/output_test.go
@@ -1,0 +1,19 @@
+package platform
+
+import "testing"
+
+// DecodeOutput must be a no-op for anything already valid UTF-8, on every
+// platform: that is the path all wrapped PowerShell output and all POSIX output
+// takes.
+func TestDecodeOutputPassesThroughUTF8(t *testing.T) {
+	for _, want := range []string{
+		"",
+		"plain ascii output\n",
+		"Русский текст — em dash ✅ 中文\r\n",
+		"Expand `agent.qwen.md` to **7 blocks** (21 items)",
+	} {
+		if got := DecodeOutput([]byte(want)); got != want {
+			t.Fatalf("DecodeOutput(%q) = %q, want it unchanged", want, got)
+		}
+	}
+}

--- a/internal/platform/output_windows.go
+++ b/internal/platform/output_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package platform
+
+import (
+	"fmt"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"golang.org/x/sys/windows"
+)
+
+// DecodeOutput converts captured child-process output to UTF-8.
+//
+// Console programs on Windows write in the console output code page (866 on a
+// Russian install, 437 on a US one), so their bytes are not UTF-8. Commands run
+// through wrapPowerShellCommand switch to UTF-8 themselves, but a PowerShell
+// script that fails to parse never reaches its own prologue, and its parser
+// error still arrives in the legacy code page - that is the output the model has
+// to read to recover. Output that is already valid UTF-8 is returned untouched,
+// which keeps the wrapped case a no-op.
+func DecodeOutput(b []byte) string {
+	if len(b) == 0 || utf8.Valid(b) {
+		return string(b)
+	}
+	codePage, err := windows.GetConsoleOutputCP()
+	if err != nil || codePage == 0 {
+		return string(b)
+	}
+	decoded, err := decodeCodePage(codePage, b)
+	if err != nil {
+		return string(b)
+	}
+	return decoded
+}
+
+// decodeCodePage converts bytes in the given Windows code page to a Go string.
+// dwFlags is 0 rather than MB_ERR_INVALID_CHARS so that a stray invalid byte
+// yields a replacement character instead of discarding the whole message.
+func decodeCodePage(codePage uint32, b []byte) (string, error) {
+	size, err := windows.MultiByteToWideChar(codePage, 0, &b[0], int32(len(b)), nil, 0)
+	if err != nil {
+		return "", err
+	}
+	if size <= 0 {
+		return "", fmt.Errorf("MultiByteToWideChar(%d) reported size %d", codePage, size)
+	}
+	buf := make([]uint16, size)
+	if _, err := windows.MultiByteToWideChar(codePage, 0, &b[0], int32(len(b)), &buf[0], size); err != nil {
+		return "", err
+	}
+	// utf16.Decode rather than windows.UTF16ToString: the latter stops at the
+	// first NUL, and command output is arbitrary bytes.
+	return string(utf16.Decode(buf)), nil
+}

--- a/internal/platform/output_windows_test.go
+++ b/internal/platform/output_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package platform
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// cp866Russian is "Русский" in code page 866, the encoding a Russian Windows
+// console uses. These are the kind of bytes a PowerShell parser error arrives as
+// (the script never runs, so it cannot switch its own output encoding first).
+var cp866Russian = []byte{0x90, 0xE3, 0xE1, 0xE1, 0xAA, 0xA8, 0xA9}
+
+func TestDecodeCodePage866(t *testing.T) {
+	got, err := decodeCodePage(866, cp866Russian)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Русский" {
+		t.Fatalf("decodeCodePage(866, % x) = %q, want %q", cp866Russian, got, "Русский")
+	}
+}
+
+// Whatever the console code page of the machine running the tests, output that
+// is not UTF-8 must not be handed on as mojibake.
+func TestDecodeOutputRepairsNonUTF8(t *testing.T) {
+	got := DecodeOutput(cp866Russian)
+	if !utf8.ValidString(got) {
+		t.Fatalf("DecodeOutput(% x) = %q, which is still not valid UTF-8", cp866Russian, got)
+	}
+}

--- a/internal/platform/powershell.go
+++ b/internal/platform/powershell.go
@@ -1,0 +1,39 @@
+package platform
+
+import "strings"
+
+// PowerShell receives the command as a script rather than as a shell word, so
+// nothing here escapes, quotes, or strips the caller's text: it is embedded
+// verbatim between a prologue and an epilogue.
+//
+// The prologue switches the output encoding to UTF-8. Without it PowerShell and
+// the native tools it spawns write in the console output code page (866 on a
+// Russian Windows install), which reaches us as mojibake and makes error
+// messages unreadable to the model. Assigning [Console]::OutputEncoding fails
+// when the process has no console attached, so it is guarded; $OutputEncoding is
+// set unconditionally because it governs what PowerShell pipes to child
+// processes.
+const powerShellPrologue = "$ProgressPreference = 'SilentlyContinue'\r\n" +
+	"try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false } catch { }\r\n" +
+	"$OutputEncoding = New-Object System.Text.UTF8Encoding $false\r\n"
+
+// The epilogue restores exit-code fidelity. powershell.exe -Command collapses
+// every failure to 1, so `cmd /c exit 3` would be reported as exit status 1.
+// $? is captured first because the following `if` overwrites it.
+const powerShellEpilogue = "\r\n$__coddyOK = $?\r\n" +
+	"if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }\r\n" +
+	"if (-not $__coddyOK) { exit 1 }\r\n" +
+	"exit 0\r\n"
+
+// wrapPowerShellCommand returns command as a PowerShell script with the
+// encoding prologue and exit-code epilogue around it. The command itself is
+// preserved byte for byte, so backticks, quotes, and non-ASCII text keep the
+// meaning PowerShell would give them if typed at a prompt.
+func wrapPowerShellCommand(command string) string {
+	var script strings.Builder
+	script.Grow(len(powerShellPrologue) + len(command) + len(powerShellEpilogue))
+	script.WriteString(powerShellPrologue)
+	script.WriteString(command)
+	script.WriteString(powerShellEpilogue)
+	return script.String()
+}

--- a/internal/platform/powershell_test.go
+++ b/internal/platform/powershell_test.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+)
+
+// sessionBody reproduces the kind of argument that broke run_command in
+// practice: Markdown prose carrying backticks, asterisks, parentheses, an em
+// dash and an emoji.
+const sessionBody = "Expand `agent.qwen.md` to **7 blocks** (21 items) — done ✅"
+
+func TestWrapPowerShellCommandPreservesCommandVerbatim(t *testing.T) {
+	commands := []string{
+		sessionBody,
+		`Write-Output "he said ""hi"""`,
+		"git commit -m 'first line'\n\n'second line'",
+		"@'\nliteral `tick` block\n'@",
+		"",
+	}
+	for _, command := range commands {
+		script := wrapPowerShellCommand(command)
+		if command != "" && !strings.Contains(script, command) {
+			t.Fatalf("wrapped script does not contain the command verbatim\ncommand: %q\nscript:  %q", command, script)
+		}
+		if !strings.HasPrefix(script, powerShellPrologue) {
+			t.Fatalf("wrapped script does not start with the prologue: %q", script)
+		}
+		if !strings.HasSuffix(script, powerShellEpilogue) {
+			t.Fatalf("wrapped script does not end with the epilogue: %q", script)
+		}
+	}
+}
+
+func TestPowerShellPrologueSetsUTF8Output(t *testing.T) {
+	for _, want := range []string{
+		"[Console]::OutputEncoding",
+		"UTF8Encoding",
+		"$OutputEncoding",
+	} {
+		if !strings.Contains(powerShellPrologue, want) {
+			t.Fatalf("prologue %q does not contain %q", powerShellPrologue, want)
+		}
+	}
+	// Assigning [Console]::OutputEncoding throws when no console is attached, so
+	// the assignment must be guarded or a headless run would emit an error.
+	if !strings.Contains(powerShellPrologue, "try {") || !strings.Contains(powerShellPrologue, "catch { }") {
+		t.Fatalf("prologue does not guard the console assignment: %q", powerShellPrologue)
+	}
+}
+
+func TestPowerShellEpiloguePropagatesExitCode(t *testing.T) {
+	// $? must be captured before the first `if`, which would otherwise overwrite
+	// it and mask a failed cmdlet.
+	capture := strings.Index(powerShellEpilogue, "$__coddyOK = $?")
+	firstIf := strings.Index(powerShellEpilogue, "if ")
+	if capture < 0 || firstIf < 0 || capture > firstIf {
+		t.Fatalf("epilogue does not capture $? before branching: %q", powerShellEpilogue)
+	}
+	if !strings.Contains(powerShellEpilogue, "exit $LASTEXITCODE") {
+		t.Fatalf("epilogue does not propagate $LASTEXITCODE: %q", powerShellEpilogue)
+	}
+}
+
+func TestShellCommandPowerShellWrapsScript(t *testing.T) {
+	for _, shell := range []Shell{
+		{Kind: ShellPwsh, Path: "pwsh"},
+		{Kind: ShellPowerShell, Path: "powershell"},
+	} {
+		executable, args := shell.Command(sessionBody)
+		if executable != shell.Path {
+			t.Fatalf("executable = %q, want %q", executable, shell.Path)
+		}
+		if len(args) != 3 || args[0] != "-NoProfile" || args[1] != "-Command" {
+			t.Fatalf("args = %#v, want -NoProfile -Command <script>", args)
+		}
+		if args[2] != wrapPowerShellCommand(sessionBody) {
+			t.Fatalf("args[2] = %q, want the wrapped script", args[2])
+		}
+	}
+}
+
+// The POSIX shells must keep receiving the raw command: the wrapper is a Windows
+// concern only.
+func TestShellCommandPOSIXUnwrapped(t *testing.T) {
+	for _, shell := range []Shell{
+		{Kind: ShellBash, Path: "/bin/bash"},
+		{Kind: ShellSh, Path: "/bin/sh"},
+	} {
+		_, args := shell.Command(sessionBody)
+		if len(args) != 2 || args[0] != "-c" || args[1] != sessionBody {
+			t.Fatalf("args = %#v, want -c %q", args, sessionBody)
+		}
+	}
+}

--- a/internal/platform/shell.go
+++ b/internal/platform/shell.go
@@ -29,10 +29,12 @@ type Shell struct {
 }
 
 // Command converts a command string into executable and argv values for the shell.
+// PowerShell commands are wrapped (see wrapPowerShellCommand) so that output
+// encoding and exit codes survive; the command text itself is never rewritten.
 func (s Shell) Command(command string) (string, []string) {
 	switch s.Kind {
 	case ShellPwsh, ShellPowerShell:
-		return s.Path, []string{"-NoProfile", "-Command", command}
+		return s.Path, []string{"-NoProfile", "-Command", wrapPowerShellCommand(command)}
 	case ShellCmd:
 		return s.Path, []string{"/c", command}
 	default:

--- a/internal/platform/shell_test.go
+++ b/internal/platform/shell_test.go
@@ -56,14 +56,15 @@ func TestDetectShellUnixPriority(t *testing.T) {
 	}
 }
 
+// TestShellCommand covers the shells that pass the command through untouched.
+// The PowerShell forms wrap the command in a script and are asserted in
+// powershell_test.go.
 func TestShellCommand(t *testing.T) {
 	tests := []struct {
 		shell   Shell
 		command string
 		args    []string
 	}{
-		{Shell{Kind: ShellPwsh, Path: "pwsh"}, "Get-ChildItem", []string{"-NoProfile", "-Command", "Get-ChildItem"}},
-		{Shell{Kind: ShellPowerShell, Path: "powershell"}, "Get-Process", []string{"-NoProfile", "-Command", "Get-Process"}},
 		{Shell{Kind: ShellCmd, Path: "cmd.exe"}, "dir", []string{"/c", "dir"}},
 		{Shell{Kind: ShellBash, Path: "/bin/bash"}, "ls", []string{"-c", "ls"}},
 		{Shell{Kind: ShellSh, Path: "/bin/sh"}, "pwd", []string{"-c", "pwd"}},

--- a/internal/tools/shell/bdd_special_characters_test.go
+++ b/internal/tools/shell/bdd_special_characters_test.go
@@ -1,0 +1,153 @@
+package shell
+
+// Godog harness for features/shell_special_characters.feature: drives the
+// run_command tool (executeRunCommandWithShell) against the real host shell and
+// asserts that a command carrying shell special characters or non-ASCII text
+// round-trips verbatim, and that a non-zero exit is still reported as a failure.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/platform"
+	"github.com/EvilFreelancer/coddy-agent/internal/tooling"
+)
+
+type shellSpecialCharsState struct {
+	shell platform.Shell
+
+	// Text staged by the "prints the literal text" step, compared against the
+	// tool output by the "contains that text verbatim" step.
+	want string
+
+	out string
+	err error
+}
+
+func (s *shellSpecialCharsState) reset() {
+	s.shell = platform.Shell{}
+	s.want = ""
+	s.out = ""
+	s.err = nil
+}
+
+func (s *shellSpecialCharsState) hostShell() error {
+	s.shell = platform.CurrentShell()
+	if s.shell.Path == "" {
+		return fmt.Errorf("no host shell detected")
+	}
+	return nil
+}
+
+// printCommand builds a command that writes text verbatim on the host shell.
+// Both forms wrap the text in a single-quoted literal, where every other
+// character (including the backticks and quotes this feature is about) is inert;
+// only an embedded single quote needs escaping, and the two shells spell that
+// escape differently.
+func printCommand(kind platform.ShellKind, text string) (string, error) {
+	switch kind {
+	case platform.ShellPwsh, platform.ShellPowerShell:
+		return "Write-Output '" + strings.ReplaceAll(text, "'", "''") + "'", nil
+	case platform.ShellBash, platform.ShellSh:
+		return "printf '%s\\n' '" + strings.ReplaceAll(text, "'", `'\''`) + "'", nil
+	default:
+		return "", fmt.Errorf("printing literal text is not supported for shell %q", kind)
+	}
+}
+
+func (s *shellSpecialCharsState) runPrinting(doc *godog.DocString) error {
+	command, err := printCommand(s.shell.Kind, doc.Content)
+	if err != nil {
+		return err
+	}
+	s.want = doc.Content
+	return s.run(command)
+}
+
+func (s *shellSpecialCharsState) runExiting(code int) error {
+	return s.run(fmt.Sprintf("exit %d", code))
+}
+
+func (s *shellSpecialCharsState) run(command string) error {
+	args, err := json.Marshal(runCommandArgs{Command: command})
+	if err != nil {
+		return err
+	}
+	s.out, s.err = executeRunCommandWithShell(context.Background(), string(args), &tooling.Env{}, s.shell)
+	return nil
+}
+
+func (s *shellSpecialCharsState) commandSucceeds() error {
+	if s.err != nil {
+		return fmt.Errorf("command returned error %v (output %q)", s.err, s.out)
+	}
+	if strings.Contains(s.out, "command failed:") {
+		return fmt.Errorf("command reported failure: %q", s.out)
+	}
+	return nil
+}
+
+func (s *shellSpecialCharsState) commandFailed() error {
+	if s.err != nil {
+		return nil
+	}
+	if !strings.Contains(s.out, "command failed:") {
+		return fmt.Errorf("command output does not report a failure: %q", s.out)
+	}
+	return nil
+}
+
+func (s *shellSpecialCharsState) failureReportsExitCode(code int) error {
+	want := fmt.Sprintf("exit status %d", code)
+	if !strings.Contains(s.out, want) {
+		return fmt.Errorf("output %q does not report %q", s.out, want)
+	}
+	return nil
+}
+
+func (s *shellSpecialCharsState) outputContainsStagedText() error {
+	if !strings.Contains(s.out, s.want) {
+		return fmt.Errorf("output %q does not contain %q verbatim", s.out, s.want)
+	}
+	return nil
+}
+
+func initializeShellSpecialCharsScenario(sc *godog.ScenarioContext) {
+	s := &shellSpecialCharsState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		s.reset()
+		return ctx, nil
+	})
+
+	sc.Step(`^the host shell detected by the agent$`, s.hostShell)
+	sc.Step(`^I run a command that prints the literal text:$`, s.runPrinting)
+	sc.Step(`^I run a command that exits with code (\d+)$`, s.runExiting)
+	sc.Step(`^the command succeeds$`, s.commandSucceeds)
+	sc.Step(`^the command is reported as failed$`, s.commandFailed)
+	sc.Step(`^the failure reports exit code (\d+)$`, s.failureReportsExitCode)
+	sc.Step(`^the output contains that text verbatim$`, s.outputContainsStagedText)
+}
+
+func TestShellSpecialCharactersFeature(t *testing.T) {
+	if kind := platform.CurrentShell().Kind; kind == platform.ShellCmd {
+		t.Skipf("cmd.exe quoting is out of scope: run_command uses PowerShell on Windows (detected %q)", kind)
+	}
+	suite := godog.TestSuite{
+		Name:                "shell-special-characters",
+		ScenarioInitializer: initializeShellSpecialCharsScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../../features/shell_special_characters.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("shell special characters feature suite failed")
+	}
+}

--- a/internal/tools/shell/run.go
+++ b/internal/tools/shell/run.go
@@ -52,7 +52,10 @@ func RunCommandToolForShell(commandShell platform.Shell) *tooling.Tool {
 func shellDescription(commandShell platform.Shell) string {
 	switch commandShell.Kind {
 	case platform.ShellPwsh, platform.ShellPowerShell:
-		return "Execute a PowerShell command in the working directory. Use native commands such as Get-ChildItem, Select-String, and Get-Process. Returns combined stdout and stderr output."
+		return "Execute a PowerShell command in the working directory. Use native commands such as Get-ChildItem, Select-String, and Get-Process. " +
+			"Multi-line commands are supported. To pass text literally, single-quote it ('...') or use a here-string (@'...'@): inside double quotes PowerShell treats the backtick as an escape character, " +
+			"so a value containing backticks, or Markdown such as `code` or **bold**, is altered or fails to parse. Bash heredocs (<< 'EOF') are not PowerShell syntax; write the text to a file and pass the path instead. " +
+			"Returns combined stdout and stderr output."
 	case platform.ShellCmd:
 		return "Execute a cmd.exe command in the working directory. Use Windows commands such as dir, findstr, and tasklist. Returns combined stdout and stderr output."
 	case platform.ShellBash:
@@ -94,10 +97,10 @@ func executeRunCommandWithShell(ctx context.Context, argsJSON string, env *tooli
 		if cmdCtx.Err() == context.DeadlineExceeded {
 			return "", fmt.Errorf("command timed out after %d seconds", timeout)
 		}
-		return fmt.Sprintf("command failed: %v\n%s", err, out.String()), nil
+		return fmt.Sprintf("command failed: %v\n%s", err, platform.DecodeOutput(out.Bytes())), nil
 	}
 
-	result := out.String()
+	result := platform.DecodeOutput(out.Bytes())
 	if result == "" {
 		return "(no output)", nil
 	}

--- a/internal/tools/shell/run_test.go
+++ b/internal/tools/shell/run_test.go
@@ -15,7 +15,10 @@ func TestRunCommandToolDescriptionMatchesShell(t *testing.T) {
 		shell platform.Shell
 		want  []string
 	}{
-		{platform.Shell{Kind: platform.ShellPwsh, Path: "pwsh"}, []string{"PowerShell", "Get-ChildItem", "Select-String", "Get-Process"}},
+		// The PowerShell description also has to tell the model how to pass literal
+		// text: emitting a backtick inside double quotes is what made run_command
+		// fail in practice.
+		{platform.Shell{Kind: platform.ShellPwsh, Path: "pwsh"}, []string{"PowerShell", "Get-ChildItem", "Select-String", "Get-Process", "here-string", "@'...'@", "backtick", "heredoc"}},
 		{platform.Shell{Kind: platform.ShellCmd, Path: "cmd.exe"}, []string{"cmd.exe", "findstr", "tasklist"}},
 		{platform.Shell{Kind: platform.ShellBash, Path: "/bin/bash"}, []string{"bash", "POSIX"}},
 	}


### PR DESCRIPTION
## Summary

`run_command` on Windows handed PowerShell output to the model as raw bytes in the console **OEM code page** (866 on a Russian install). Anything non-ASCII arrived as mojibake, so when a command failed, the error text the model needed in order to fix itself was unreadable and it retried blindly.

Observed in a real session: the agent tried `gh pr create --body "..."`, got back

```
command failed: exit status 1
? ??????? ???????? ????????????: ".
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : TerminatorExpectedAtEndOfString
```

and spent three turns guessing (including a bash heredoc, which is not PowerShell syntax) before working around it by hand.

## What was actually wrong

Investigating the failure separated it into two different things.

**1. Output encoding — a real bug here.** PowerShell and the native tools it spawns write in the console OEM code page; we read those bytes unchanged.

**2. The `ParserError` itself — not a bug here.** The failing command contained a backtick inside a double-quoted PowerShell string, where the backtick *is* the escape character. Typed at an interactive prompt it fails identically. Verified that Go's `exec` to `powershell -Command` round-trip is clean for embedded quotes, multi-line commands, here-strings and trailing backslashes, so there is no double-parsing layer to remove. This half is addressed as guidance, not as an executor change.

**3. Exit-code fidelity — a bug found along the way.** `powershell.exe -Command` collapses every failure to `1`, so `cmd /c exit 3` was reported as `exit status 1`.

## Changes

- **`internal/platform/powershell.go`** (new) — wraps PowerShell commands in a prologue that sets `[Console]::OutputEncoding` and `$OutputEncoding` to UTF-8, and an epilogue that propagates the real exit code (capturing `$?` before the first `if` overwrites it). The assignment is guarded with `try`/`catch` because it throws when no console is attached. **The command text is embedded verbatim** — nothing is escaped, quoted, or stripped, so backticks and quotes keep the meaning PowerShell would give them at a prompt.
- **`internal/platform/output_windows.go`** / **`output_other.go`** (new) — `platform.DecodeOutput` returns valid UTF-8 untouched and otherwise decodes from the console code page via `MultiByteToWideChar`. This fallback is what makes a **parser error** readable: a script that fails to compile never reaches its own prologue, so its message arrives in the legacy code page no matter what the wrapper does. No-op outside Windows.
- **`internal/tools/shell/run.go`**, **`internal/config/providers.go`** — both captured-output paths go through `DecodeOutput`.
- **`internal/tools/shell/run.go`** — the PowerShell tool description now tells the model to single-quote literal text or use a here-string (`@'...'@`), explains that a backtick inside double quotes alters or breaks the value, and notes that bash heredocs are not PowerShell syntax.

Special characters are **passed through, not stripped**. Stripping them would silently corrupt commit messages, PR bodies and regexes, and would not have fixed the unreadable-error problem that caused the retry loop.

### Rejected alternatives

| Approach | Special chars | Errors readable | Exit code |
|---|---|---|---|
| `-Command` (before) | fine | OEM code page | collapsed to 1 |
| `-EncodedCommand` | fine | **stderr becomes CLIXML** `<S S="Error">` | correct |
| temp `.ps1` + `-File` | fine | fine | **lost, always 0** |
| `-Command` + prologue/epilogue | fine | UTF-8 | correct |

`-EncodedCommand` looks like the obvious fix but flips Windows PowerShell 5.1 into minishell serialization, so error records come back as XML — worse than the bug. A temp script with `-File` swallowed exit codes entirely. The chosen approach needs no temp file, BOM handling, `-ExecutionPolicy` flag, or cleanup.

## Linux and macOS

Unchanged by construction: the POSIX shells still receive `-c <command>` byte for byte, and `DecodeOutput` is the identity function. `TestShellCommandPOSIXUnwrapped` asserts this in code rather than leaving it to review.

## Testing

- **New spec** `features/shell_special_characters.feature` with a godog harness in `internal/tools/shell/bdd_special_characters_test.go`, phrased platform-neutrally so it runs on both Windows and Linux. Confirmed red before the fix: the non-ASCII scenario failed with `output "\x90\xe3\xe1???\xa9 ??\xe1\xe2 - em dash ? ??" does not contain "Русский текст — em dash ✅ 中文"`.
- **Unit tests** in `internal/platform` cover verbatim command embedding, the guarded prologue, `$?`-before-branch ordering in the epilogue, code page 866 decoding, and the POSIX no-change guarantee.
- `make test` green on Windows — all 13 tag combinations.
- `go test ./...` on Linux in Docker (`golang:1.25-bookworm`) across the tag matrix. One unrelated failure surfaced under `http,scheduler,memory`: `TestSavePreservesUpdatedAtWhenMessagesAndActivitySeqUnchanged` in `internal/session`, a pre-existing timing flake (a 1.2 s sleep against second-granularity timestamps) that passes 5/5 in isolation and lives in a package this branch does not touch. Not addressed here.
- `golangci-lint run` clean on the changed packages.
- **End-to-end** against the model from the original session (`qwen3.6-35b-a3b`), in an isolated config and workspace: `— done ✅` round-tripped as UTF-8 through the real tool, and when asked for literal backticks the model chose a single-quoted literal on the first attempt, citing the reason the new description teaches. Output came back as `` Expand `agent.qwen.md` to **7 structured blocks** (21 items) `` verbatim, with no retry and no `ParserError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
