### PR TITLE
chore(codex): attach .cursor rules to Codex sessions via lifecycle hooks

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,33 @@
+{
+  "description": "Deterministic delivery of .cursor/rules/*.mdc to Codex sessions.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/attach_rules.py\"",
+            "statusMessage": "Loading always-on project rules",
+            "timeout": 10,
+            "additionalContextLimit": 8000
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^(apply_patch|Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/attach_rules.py\"",
+            "statusMessage": "Attaching rules for edited files",
+            "timeout": 10,
+            "additionalContextLimit": 6000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/attach_rules.py
+++ b/.codex/hooks/attach_rules.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Attach `.cursor/rules/*.mdc` to Codex sessions deterministically.
+
+Codex has no glob-based rule attachment. Its `AGENTS.md` chain is resolved once
+per session, walking from the repository root down to the launch directory, so
+nested instruction files never load when Codex starts at the root. Telling the
+model to "read the relevant rule file" is advisory and gets skipped.
+
+This hook restores Cursor's behaviour by reading the frontmatter of the rule
+files directly:
+
+  SessionStart -> inject every rule with `alwaysApply: true`
+  PreToolUse   -> inject rules whose `globs` match the paths an `apply_patch`
+                  call is about to touch, at most once per rule per session
+
+`.cursor/rules/` stays the single source of truth; nothing is duplicated here.
+The hook fails open: any unexpected input exits 0 with no output, so a broken
+rule file can never block an edit.
+
+Wired up in `.codex/hooks.json`. Requires `/hooks` approval in Codex once, and
+again after every change to this file (Codex tracks hooks by content hash).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_DIR = REPO_ROOT / ".cursor" / "rules"
+STATE_DIR = Path(tempfile.gettempdir()) / "codex-coddy-rules"
+
+# `*** Add File: path`, `*** Update File: path`, `*** Delete File: path`
+PATCH_FILE_RE = re.compile(r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$", re.M)
+# `*** Move to: path` carries the destination of a rename
+PATCH_MOVE_RE = re.compile(r"^\*\*\*\s+Move to:\s*(.+?)\s*$", re.M)
+
+
+class Rule:
+    def __init__(self, path: Path, description: str, globs: list[str], always: bool, body: str):
+        self.path = path
+        self.description = description
+        self.globs = globs
+        self.always = always
+        self.body = body
+
+    @property
+    def rel(self) -> str:
+        return self.path.relative_to(REPO_ROOT).as_posix()
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a Cursor glob into a regex.
+
+    `fnmatch` is unusable here because its `*` also crosses `/`, which makes
+    `external/httpserver/**/*.go` miss `external/httpserver/server.go`.
+    """
+    out: list[str] = []
+    i, n = 0, len(pattern)
+    while i < n:
+        if pattern.startswith("**/", i):
+            out.append("(?:.*/)?")
+            i += 3
+        elif pattern.startswith("**", i):
+            out.append(".*")
+            i += 2
+        elif pattern[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif pattern[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(pattern[i]))
+            i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def parse_rule(path: Path) -> Rule | None:
+    """Read one `.mdc` file. Frontmatter is flat, so no YAML dependency."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end < 0:
+        return None
+    head = text[3:end]
+    body = text[end + 4 :].strip()
+
+    description, globs, always = "", [], False
+    for line in head.splitlines():
+        key, sep, value = line.partition(":")
+        if not sep:
+            continue
+        key, value = key.strip(), value.strip()
+        if key == "description":
+            description = value
+        elif key == "globs":
+            globs = [g.strip() for g in value.split(",") if g.strip()]
+        elif key == "alwaysApply":
+            always = value.lower() == "true"
+    return Rule(path, description, globs, always, body)
+
+
+def load_rules() -> list[Rule]:
+    rules = []
+    for path in sorted(RULES_DIR.glob("*.mdc")):
+        rule = parse_rule(path)
+        if rule and rule.body:
+            rules.append(rule)
+    return rules
+
+
+def state_file(session_id: str) -> Path:
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", session_id or "unknown")[:120]
+    return STATE_DIR / f"{safe}.json"
+
+
+def load_sent(session_id: str) -> set[str]:
+    try:
+        return set(json.loads(state_file(session_id).read_text(encoding="utf-8")))
+    except Exception:
+        return set()
+
+
+def save_sent(session_id: str, sent: set[str]) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        state_file(session_id).write_text(json.dumps(sorted(sent)), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def patched_paths(tool_input: object) -> list[str]:
+    """Collect repo-relative paths from an apply_patch payload."""
+    blobs: list[str] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, str):
+            blobs.append(node)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+        elif isinstance(node, dict):
+            for item in node.values():
+                walk(item)
+
+    walk(tool_input)
+
+    found: list[str] = []
+    for blob in blobs:
+        for raw in PATCH_FILE_RE.findall(blob) + PATCH_MOVE_RE.findall(blob):
+            path = Path(raw)
+            if path.is_absolute():
+                try:
+                    path = path.relative_to(REPO_ROOT)
+                except ValueError:
+                    continue
+            found.append(path.as_posix())
+    return found
+
+
+def render(rules: list[Rule], preamble: str) -> str:
+    chunks = [preamble]
+    for rule in rules:
+        chunks.append(f"<!-- from {rule.rel} -->\n\n{rule.body}")
+    return "\n\n".join(chunks)
+
+
+def emit(event: str, context: str) -> None:
+    json.dump(
+        {"hookSpecificOutput": {"hookEventName": event, "additionalContext": context}},
+        sys.stdout,
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    event = payload.get("hook_event_name") or os.environ.get("CODEX_HOOK_EVENT", "")
+    session_id = payload.get("session_id", "")
+
+    try:
+        rules = load_rules()
+    except Exception:
+        return 0
+    if not rules:
+        return 0
+
+    if event == "SessionStart":
+        if payload.get("source") == "clear":
+            state_file(session_id).unlink(missing_ok=True)
+        always = [r for r in rules if r.always]
+        if not always:
+            return 0
+        save_sent(session_id, {r.rel for r in always})
+        emit(
+            event,
+            render(
+                always,
+                "Project rules for this repository, always in force. They are"
+                " authoritative; `.cursor/rules/` is their single source of truth."
+                " More rules are attached automatically when you edit files they"
+                " cover.",
+            ),
+        )
+        return 0
+
+    if event != "PreToolUse":
+        return 0
+
+    paths = patched_paths(payload.get("tool_input"))
+    if not paths:
+        return 0
+
+    sent = load_sent(session_id)
+    matched: list[Rule] = []
+    for rule in rules:
+        if rule.always or rule.rel in sent or not rule.globs:
+            continue
+        patterns = [glob_to_regex(g) for g in rule.globs]
+        if any(p.match(path) for path in paths for p in patterns):
+            matched.append(rule)
+
+    if not matched:
+        return 0
+
+    save_sent(session_id, sent | {r.rel for r in matched})
+    touched = ", ".join(sorted(set(paths))[:8])
+    emit(
+        event,
+        render(
+            matched,
+            f"Project rules that cover the files you are editing ({touched})."
+            " Apply them to this change before continuing.",
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Fail open: never block an edit because of this hook.
+        sys.exit(0)

--- a/.codex/rules.md
+++ b/.codex/rules.md
@@ -1,22 +1,49 @@
 # Codex bridge for Cursor rules
 
-This repository keeps detailed project rules in `.cursor/rules/*.mdc`. Codex agents should treat those files as repo rules and read the relevant entries before changing matching files.
+This repository keeps detailed project rules in `.cursor/rules/*.mdc`, and that directory
+is their single source of truth. Codex does not read `.mdc` files on its own, so
+`.codex/hooks/attach_rules.py` delivers them.
+
+## How delivery works
+
+| Trigger | What is attached |
+|---------|------------------|
+| `SessionStart` | every rule with `alwaysApply: true` |
+| `PreToolUse` on `apply_patch` / `Edit` / `Write` | rules whose `globs` cover the files in the patch, once per rule per session |
+
+The hook parses `.mdc` frontmatter (`description`, `globs`, `alwaysApply`) directly, so a
+new rule file is picked up with no wiring. It fails open: a malformed rule exits quietly
+instead of blocking an edit. Configuration lives in `.codex/hooks.json`; the full guide,
+including trust, context budget, and debugging, is [docs/codex-hooks.md](../docs/codex-hooks.md).
+
+Codex tracks hooks by content hash and skips untrusted ones without a hard error. Run
+`/hooks` once per clone, and again after any edit to `attach_rules.py`. Project-local
+hooks load only when the `.codex/` layer is trusted.
+
+To see what a given patch would pull in:
+
+```bash
+echo '{"hook_event_name":"PreToolUse","session_id":"probe","tool_input":{"command":"*** Begin Patch\n*** Update File: external/httpserver/server.go\n*** End Patch"}}' | python3 .codex/hooks/attach_rules.py
+```
 
 ## Rule index
 
-| Cursor rule | Applies to |
-|-------------|------------|
-| [architecture.mdc](../.cursor/rules/architecture.mdc) | Go architecture, layers, optional build tags |
-| [api-layer.mdc](../.cursor/rules/api-layer.mdc) | HTTP API handlers, OpenAPI, HTTP docs |
-| [code-style.mdc](../.cursor/rules/code-style.mdc) | Go formatting, linting, code comments |
-| [core-modules.mdc](../.cursor/rules/core-modules.mdc) | Main `internal/*` package boundaries |
-| [gateway.mdc](../.cursor/rules/gateway.mdc) | Messenger gateway: session store, Telegram adapter, Sender streaming, proxy |
-| [implementation-order.mdc](../.cursor/rules/implementation-order.mdc) | Layered implementation order for new behavior |
-| [testing.mdc](../.cursor/rules/testing.mdc) | Go test commands, tags, and conventions |
-| [ui-spa.mdc](../.cursor/rules/ui-spa.mdc) | Embedded UI source and SPA behavior |
-| [ui-verification.mdc](../.cursor/rules/ui-verification.mdc) | UI verification and screenshots |
-| [workflow.mdc](../.cursor/rules/workflow.mdc) | BDD/TDD workflow and final checks |
+| Cursor rule | Applies to | Attachment |
+|-------------|------------|------------|
+| [architecture.mdc](../.cursor/rules/architecture.mdc) | Go architecture, layers, optional build tags | always |
+| [code-style.mdc](../.cursor/rules/code-style.mdc) | Go formatting, linting, code comments | always |
+| [testing.mdc](../.cursor/rules/testing.mdc) | Go test commands, tags, and conventions | always |
+| [workflow.mdc](../.cursor/rules/workflow.mdc) | BDD/TDD workflow and final checks | always |
+| [api-layer.mdc](../.cursor/rules/api-layer.mdc) | HTTP API handlers, OpenAPI, HTTP docs | `external/httpserver/**/*.go` |
+| [core-modules.mdc](../.cursor/rules/core-modules.mdc) | Main `internal/*` package boundaries | `internal/**/*.go` |
+| [gateway.mdc](../.cursor/rules/gateway.mdc) | Messenger gateway: session store, Telegram adapter, Sender streaming, proxy | `external/gateway/**/*.go`, `internal/config/gateway.go` |
+| [implementation-order.mdc](../.cursor/rules/implementation-order.mdc) | Layered implementation order for new behavior | `cmd`, `internal`, `external`, `lib`, `tools` |
+| [ui-spa.mdc](../.cursor/rules/ui-spa.mdc) | Embedded UI source and SPA behavior | `external/ui/**/*` |
+| [ui-verification.mdc](../.cursor/rules/ui-verification.mdc) | UI verification and screenshots | `external/ui/**/*` |
 
 ## Operating rule
 
-Keep `.cursor/rules/` as the single source of truth. When a Cursor rule is added, renamed, or removed, update this index and the `AGENTS.md` bridge section in the same change.
+Keep `.cursor/rules/` as the single source of truth. The hook needs no update when rules
+change, but this index and the `AGENTS.md` bridge section do: refresh both in the same
+change that adds, renames, or removes a rule file. A rule is only reachable from Codex if
+its frontmatter carries `globs` or `alwaysApply: true`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,14 +41,36 @@ All **code comments** plus **technical markdown authored for this repo** (includ
 
 ## Codex and Cursor rules
 
-Codex uses this **`AGENTS.md`** file as its repo instruction entrypoint. This repository also keeps the detailed project rules in **`.cursor/rules/*.mdc`**.
+Codex uses this **`AGENTS.md`** file as its repo instruction entrypoint. The detailed project rules live in **`.cursor/rules/*.mdc`**, which is their single source of truth. Do not copy rules into `.codex/` or `.claude/` by hand.
 
-When working in Codex:
+Codex resolves its `AGENTS.md` chain once per session, walking from the repository root down to the launch directory, so nested instruction files never load for a session started at the root. A lifecycle hook covers that gap and delivers the Cursor rules deterministically instead of asking the model to fetch them:
 
-- Treat **`.cursor/rules/*.mdc`** as authoritative project rules, not Cursor-only metadata.
-- Read the relevant Cursor rule files before changing code or docs covered by their `globs`.
-- Start with **`.codex/rules.md`** for the Cursor rules index.
-- Do not copy Cursor rules into `.codex/`; keep **`.cursor/rules/`** as the single source of truth and update the index if rule files are added, renamed, or removed.
+- **`.codex/hooks.json`** wires **`.codex/hooks/attach_rules.py`** to `SessionStart` and to `PreToolUse` on `apply_patch` / `Edit` / `Write`.
+- On session start the hook injects every rule with `alwaysApply: true`.
+- Before each patch it injects the rules whose `globs` cover the files being touched, at most once per rule per session.
+- The hook parses `.mdc` frontmatter directly, so adding, renaming, or removing a rule file needs no change here. It fails open, and a malformed rule never blocks an edit.
+
+Codex requires explicit approval for hooks and tracks them by content hash. Run **`/hooks`** once per clone, and again after editing `attach_rules.py`, otherwise the hook is skipped silently. Project-local hooks also load only when the `.codex/` layer is trusted. **`.codex/rules.md`** keeps the human-readable index of the rule files; the full guide, including how to probe the hook by hand, is **`docs/codex-hooks.md`**.
+
+## Code Review Rules
+
+Codex code review reads this section and applies it to changed files. Keep entries behavioural and repository-specific; formatting and lint stay in CI, where the pre-commit gate already runs **`make lint`**.
+
+### HTTP surface
+
+- Do not change routes, request or response shapes, or status codes in `external/httpserver/server.go` without updating `external/httpserver/openapi.go` in the same change. The served spec is what `/docs/` and generated clients consume, so drift is a silent API break. Safe path: update both, then reconcile `docs/http-api.md`.
+
+### Build tags
+
+- Do not let a package that builds by default import one that lives behind the `http`, `ui`, `scheduler`, `memory`, or `gateway` tags. Plain `make build` must keep compiling with the lean dependency set. Safe path: put the new code behind the same tag, or invert the dependency into an interface owned by the core package.
+
+### Project-local configuration
+
+- Do not read, merge, or execute project-local configuration (`.coddy/mcp.json`, MCP server definitions, hook scripts) without routing it through `TrustGate` in `internal/mcp`. Opening an untrusted checkout must not by itself grant code execution. Safe path: gate the read on the workspace trust decision and persist the approval through `TrustStore`.
+
+### Embedded UI
+
+- Do not treat a UI change as complete when only `external/ui/src/` moved. The binary serves `go:embed` assets, so unrebuilt sources ship the previous SPA. Safe path: run `make build TAGS="http ui"` and include the regenerated assets in the change.
 
 ## HTTP API development flow
 

--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ See [Architecture docs](docs/architecture.md) for full details.
 - [DESIGN.md](DESIGN.md) - UI tokens and layout (English)
 - [AGENTS.md](AGENTS.md) - repo map and contributor notes for automation
 - [Rules](docs/rules.md) - project rules (`.cursor/rules`, `.coddy/rules`, …)
+- [Codex hooks](docs/codex-hooks.md) - how `.cursor/rules/*.mdc` reach a Codex CLI session working on this repo
 - [Skills](docs/skills.md) - slash commands and **`skills.dirs`**
 - [Background tasks](docs/background-tasks.md) - detached commands, the task pool, timeouts, and program-wide permission grants
 - [MCP Integration](docs/mcp-integration.md) - MCP server integration guide

--- a/docs/codex-hooks.md
+++ b/docs/codex-hooks.md
@@ -1,0 +1,99 @@
+# Codex hooks for project rules
+
+This page is about **contributors running the Codex CLI against this repository**. It is not about Coddy's own rules discovery, which is a product feature documented in [Rules](rules.md) - that one describes how the `coddy` binary injects `{{.Rules}}` into its system prompt.
+
+## Why a hook is needed
+
+Codex resolves its instruction chain **once per session**, walking from the repository root down to the directory it was launched in, and concatenating at most one `AGENTS.md` per directory. Two consequences matter here:
+
+- a session started at the repository root never loads a nested `AGENTS.md`, no matter which files it goes on to edit;
+- there is no glob-based attachment. Codex has no equivalent of the `globs` field in `.cursor/rules/*.mdc`, so scope can only be expressed by where a file sits in the tree.
+
+This repository keeps its detailed rules in `.cursor/rules/*.mdc`. The previous arrangement pointed Codex at `.codex/rules.md` and asked it to open the relevant rule file before editing. That is advisory, and it gets skipped.
+
+`.codex/hooks/attach_rules.py` closes the gap by injecting rule bodies into the session directly, so compliance no longer depends on the model choosing to read a file.
+
+## What fires when
+
+| Event | Matcher | What is injected |
+|---|---|---|
+| `SessionStart` | `startup\|resume\|clear\|compact` | every rule whose frontmatter has `alwaysApply: true` |
+| `PreToolUse` | `^(apply_patch\|Edit\|Write)$` | rules whose `globs` cover a file in the pending patch |
+
+Configuration lives in `.codex/hooks.json`. Both handlers run the same script; it branches on `hook_event_name` from the hook payload.
+
+For this repository that currently means `architecture`, `code-style`, `testing` and `workflow` arrive at session start (about 9.5 KB total), and the remaining six attach on demand. A patch touching `external/httpserver/server.go` pulls in `api-layer` and `implementation-order`; one touching `external/ui/src/` pulls in `ui-spa` and `ui-verification`.
+
+## How it works
+
+The script parses the `.mdc` frontmatter itself (`description`, `globs`, `alwaysApply`), so `.cursor/rules/` stays the single source of truth and a new rule file needs no wiring. Points worth knowing:
+
+- **Glob matching is hand-rolled.** `fnmatch` is unusable because its `*` also crosses `/`, which makes `external/httpserver/**/*.go` miss `external/httpserver/server.go`. The script translates globs to a regex where `**/` becomes "zero or more directories", `*` stays inside one segment, and a bare `**` spans anything.
+- **Paths come from the patch itself.** `*** Add File:`, `*** Update File:`, `*** Delete File:` and the `*** Move to:` destination are all read, and absolute paths are made repo-relative before matching.
+- **Each rule is injected at most once per session.** State is a JSON file under `<tempdir>/codex-coddy-rules/<session_id>.json`, so re-editing the same area does not re-send the same 3 KB. A `SessionStart` with `source: "clear"` resets it.
+- **It fails open.** Malformed JSON on stdin, an unparsable rule file, or an unwritable state directory all exit 0 with no output. A broken rule can never block an edit.
+
+## Context budget
+
+Codex caps model-visible hook output at roughly 2500 tokens by default, then **spills** the remainder to `<temp_dir>/hook_outputs/` and shows the model a head-and-tail preview instead. Both handlers therefore raise `additionalContextLimit`, to 8000 at session start and 6000 per patch. Those are ceilings, not reservations; the real payloads sit well under them.
+
+Keep this in mind when adding rules. The budget is shared with every other hook and plugin in the session, and oversized always-on context degrades the model rather than helping it.
+
+## Trust
+
+Codex requires explicit approval before a non-managed command hook can run, and records that approval against the **hash of the hook definition**. An unapproved hook is skipped without a hard error, which looks exactly like a hook that is not firing.
+
+- Run `/hooks` once per clone to review and trust both handlers.
+- Run it again after **any** edit to `attach_rules.py` or `hooks.json`.
+- Project-local hooks load only when the `.codex/` layer is trusted. In an untrusted checkout Codex still loads user and system hooks, but not these.
+
+This mirrors the workspace trust gate Coddy applies to project-local `.coddy/mcp.json` (see [MCP Integration](mcp-integration.md)): opening a repository must not by itself grant it code execution.
+
+## Verifying and debugging
+
+Drive the script by hand with a synthetic payload. It reads JSON on stdin and writes JSON on stdout, so no Codex session is needed:
+
+```bash
+echo '{"hook_event_name":"PreToolUse","session_id":"probe","tool_input":{"command":"*** Begin Patch\n*** Update File: external/httpserver/server.go\n*** End Patch"}}' | python3 .codex/hooks/attach_rules.py
+```
+
+Session-start behaviour:
+
+```bash
+echo '{"hook_event_name":"SessionStart","session_id":"probe","source":"startup"}' | python3 .codex/hooks/attach_rules.py
+```
+
+Empty output is a valid answer and means one of three things: no glob matched, the rule was already sent in this session, or the input was not understood. Clear the dedup state to re-test:
+
+```bash
+rm -rf "${TMPDIR:-/tmp}/codex-coddy-rules"
+```
+
+If a hook produces nothing inside a real session, check `/hooks` first. Trust is the usual cause.
+
+## Adding or changing a rule
+
+Edit `.cursor/rules/*.mdc` as before. The hook needs no change, but two things do:
+
+- a rule is only reachable from Codex if its frontmatter carries `globs` or `alwaysApply: true`;
+- the index in `.codex/rules.md` and the bridge section in `AGENTS.md` are refreshed in the same change that adds, renames, or removes a rule file.
+
+## Not to be confused with Codex `.rules`
+
+Codex uses the word "rules" for a second, unrelated mechanism: `.rules` files written in Starlark under a `rules/` directory next to an active config layer, which decide **which shell commands may run outside the sandbox**. Those are an execution policy, not instructions, and they are validated with:
+
+```bash
+codex execpolicy check --pretty --rules ~/.codex/rules/default.rules -- go test ./...
+```
+
+This repository ships no `.codex/rules/` directory; command policy is a per-developer concern and lives in `~/.codex/rules/`. Note that Codex only decomposes a `bash -lc` script into separate commands when it is a plain chain of words joined by `&&`, `||`, `;` or `|`. A script containing `VAR=x`, `$(...)`, a wildcard, or control flow is matched as one opaque invocation, which is why auto-recorded allow-list entries tend to be unusable on any later command.
+
+## Equivalent setups in other agents
+
+| Agent | Always-on rules | Scoped rules |
+|---|---|---|
+| Cursor | `alwaysApply: true` in `.cursor/rules/*.mdc` | `globs` in the same frontmatter |
+| Claude Code | `CLAUDE.md` (symlinked to `AGENTS.md` here) | `.claude/rules/*.md` referenced from it |
+| Codex | `AGENTS.md` plus the `SessionStart` hook | `PreToolUse` hook, this page |
+
+Upstream reference: [Hooks](https://developers.openai.com/codex/hooks) and [Custom instructions with AGENTS.md](https://developers.openai.com/codex/guides/agents-md).


### PR DESCRIPTION
## Problem

Codex resolves its `AGENTS.md` chain **once per session**, walking from the repository root down to the launch directory. Two consequences:

- a session started at the repo root never loads a nested `AGENTS.md`, whatever it goes on to edit;
- there is no glob-based attachment, so nothing in Codex corresponds to the `globs` field in `.cursor/rules/*.mdc`.

The previous arrangement pointed Codex at `.codex/rules.md` and asked it to open the relevant rule file before editing. That is advisory, and it gets skipped.

## Change

`.codex/hooks/attach_rules.py` injects rule bodies into the session directly.

| Event | Matcher | Injected |
|---|---|---|
| `SessionStart` | `startup\|resume\|clear\|compact` | every rule with `alwaysApply: true` |
| `PreToolUse` | `^(apply_patch\|Edit\|Write)$` | rules whose `globs` cover a file in the pending patch |

The script parses `.mdc` frontmatter itself, so `.cursor/rules/` stays the single source of truth and a new rule file needs no wiring here. Notable details:

- glob matching is hand-rolled because `fnmatch`'s `*` crosses `/`, which makes `external/httpserver/**/*.go` miss `external/httpserver/server.go`;
- paths come from the patch (`*** Add/Update/Delete File:` plus the `*** Move to:` destination), absolute ones normalised against the repo root;
- each rule is sent at most once per session, state keyed by `session_id` under the temp dir;
- it fails open, so a malformed rule file exits 0 with no output and can never block an edit.

Also adds a `## Code Review Rules` section to `AGENTS.md`, which Codex cloud review reads. Four repository-specific footguns, each with a safe path: `openapi.go` drifting from the handlers, a default-build package importing one behind `http`/`ui`/`scheduler`/`memory`/`gateway`, project-local config read outside `TrustGate`, and `go:embed` assets left unrebuilt after an `external/ui/src/` change.

## Verification

Simulated end to end against real repository paths:

```
1. session start          -> architecture, code-style, testing, workflow
2. external/gateway/*.go  -> gateway, implementation-order
3. ui/src + internal/*    -> core-modules, ui-spa, ui-verification
4. same patch again       -> nothing (dedup)
5. malformed stdin        -> nothing, exit 0
```

No Go code changed; the pre-commit gate skipped the lint run accordingly.

## Operator action required

Codex tracks hooks by content hash and silently skips untrusted ones. Each clone needs `/hooks` run once to approve both handlers, and again after any edit to `attach_rules.py` or `hooks.json`. Project-local hooks also load only when the `.codex/` layer is trusted.

## Docs

`docs/codex-hooks.md`, linked from `README.md`, `AGENTS.md` and `.codex/rules.md`. It opens by disambiguating itself from `docs/rules.md`, which documents Coddy's own `{{.Rules}}` discovery rather than the Codex CLI working on this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)