### PR TITLE
fix(textenc): decode short mixed-encoding files via the system code page

### DIFF
--- a/features/prompt_attachment_encoding.feature
+++ b/features/prompt_attachment_encoding.feature
@@ -78,6 +78,28 @@ Feature: Prompt attachments in non-UTF-8 encodings
       }
       """
 
+  @windows
+  Scenario: Attaching a Windows-1251 file whose only Cyrillic is one short comment
+    Given a workspace file "short.go" encoded in windows-1251 with content:
+      """
+      package main
+
+      func main() {
+          // Готово
+      }
+      """
+    When I attach "short.go" to the prompt "проверь @short.go"
+    Then the prompt has a resource for "short.go"
+    And the resource mime type is "text/plain; charset=utf-8"
+    And the resource text is:
+      """
+      package main
+
+      func main() {
+          // Готово
+      }
+      """
+
   Scenario: Attaching a UTF-8 file still hydrates it unchanged
     Given a workspace file "utf8.md" encoded in utf-8 with content:
       """

--- a/internal/platform/output_windows.go
+++ b/internal/platform/output_windows.go
@@ -36,8 +36,8 @@ func DecodeOutput(b []byte) string {
 
 // DecodeANSI converts bytes in the system ANSI code page (1251 on a Russian
 // install, 1252 on a Western one) to a Go string, reporting the code page it
-// used. It is the last-resort reading for a file a local editor saved without a
-// byte-order mark; ok is false when there is no usable code page.
+// used. It is the local-editor reading for a file saved without a byte-order
+// mark; ok is false when there is no usable code page.
 func DecodeANSI(b []byte) (text string, codePage uint32, ok bool) {
 	if len(b) == 0 {
 		return "", 0, false

--- a/internal/session/bdd_attachment_encoding_test.go
+++ b/internal/session/bdd_attachment_encoding_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/text/encoding/charmap"
 
 	"github.com/EvilFreelancer/coddy-agent/internal/acp"
+	"github.com/EvilFreelancer/coddy-agent/internal/platform"
 	"github.com/EvilFreelancer/coddy-agent/internal/session"
 )
 
@@ -187,16 +188,30 @@ func (s *attachmentEncodingState) soleResourceURI() (string, error) {
 	return uris[0], nil
 }
 
+// systemANSIReadsCyrillic reports whether the machine's ANSI code page reads
+// single-byte Cyrillic. Scenarios tagged @windows lean on that code page to
+// resolve a file too short for statistical detection, so they only hold on a
+// Cyrillic Windows install; everywhere else - other platforms, a Western ANSI
+// page - they are filtered out rather than failed.
+func systemANSIReadsCyrillic() bool {
+	text, _, ok := platform.DecodeANSI([]byte{0xCF, 0xF0, 0xE8})
+	return ok && text == "При"
+}
+
 func TestPromptAttachmentEncodingFeature(t *testing.T) {
+	opts := &godog.Options{
+		Format:   "pretty",
+		Paths:    []string{"../../features/prompt_attachment_encoding.feature"},
+		TestingT: t,
+		Strict:   true,
+	}
+	if !systemANSIReadsCyrillic() {
+		opts.Tags = "~@windows"
+	}
 	suite := godog.TestSuite{
 		Name:                "prompt-attachment-encoding",
 		ScenarioInitializer: initializeAttachmentEncodingScenario,
-		Options: &godog.Options{
-			Format:   "pretty",
-			Paths:    []string{"../../features/prompt_attachment_encoding.feature"},
-			TestingT: t,
-			Strict:   true,
-		},
+		Options:             opts,
 	}
 	if suite.Run() != 0 {
 		t.Fatal("prompt attachment encoding feature suite failed")

--- a/internal/textenc/prefer_ansi_test.go
+++ b/internal/textenc/prefer_ansi_test.go
@@ -1,0 +1,115 @@
+package textenc
+
+import "testing"
+
+// The system ANSI code page is a no-op outside Windows, so the end-to-end path
+// through DecodeToUTF8 cannot exercise this choice on Linux CI. These tests feed
+// the decision the two readings directly, which keeps the heuristic covered
+// everywhere: a regression in it would otherwise only surface on Windows.
+func TestPreferSystemANSI(t *testing.T) {
+	tests := []struct {
+		name     string
+		detected string
+		ansi     string
+		want     bool
+	}{
+		{
+			name:     "one short cyrillic comment in ascii source",
+			detected: "package main\n\nfunc main() {\n\t// Ãîòîâî\n}\n",
+			ansi:     "package main\n\nfunc main() {\n\t// Готово\n}\n",
+			want:     true,
+		},
+		{
+			name:     "cyrillic value in a json field",
+			detected: "{\n  \"id\": 1,\n  \"title\": \"Îò÷¸ò\"\n}\n",
+			ansi:     "{\n  \"id\": 1,\n  \"title\": \"Отчёт\"\n}\n",
+			want:     true,
+		},
+		{
+			name:     "detection already found a non-latin script",
+			detected: "# Итоги\nready\n",
+			ansi:     "# Ниогй\nready\n",
+			want:     false,
+		},
+		{
+			name:     "ansi reading is latin too",
+			detected: "Café au lait\n",
+			ansi:     "Café au lait\n",
+			want:     false,
+		},
+		{
+			name:     "french accents are isolated marks inside ascii words",
+			detected: "naïve résumé\nfrom the café\n",
+			ansi:     "naпve rйsumй\nfrom the cafй\n",
+			want:     false,
+		},
+		{
+			name:     "german umlaut inside an ascii word",
+			detected: "Müller GmbH\naddress: Berlin\n",
+			ansi:     "Mьller GmbH\naddress: Berlin\n",
+			want:     false,
+		},
+		{
+			name:     "accented word standing alone stays latin",
+			detected: "il va à Paris\ndemain matin\n",
+			ansi:     "il va а Paris\ndemain matin\n",
+			want:     false,
+		},
+		{
+			name:     "run too short to read as mis-decoded text",
+			detected: "answer: Äà\nnext: no\n",
+			ansi:     "answer: Да\nnext: no\n",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := preferSystemANSI(tt.detected, tt.ansi); got != tt.want {
+				t.Fatalf("preferSystemANSI(%q, %q) = %v, want %v", tt.detected, tt.ansi, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxNonASCIIRun(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want int
+	}{
+		{name: "pure ascii", text: "hello world\n", want: 0},
+		{name: "isolated accents", text: "naïve résumé", want: 1},
+		{name: "mis-decoded cyrillic word", text: "// Ãîòîâî", want: 6},
+		{name: "run broken by a space", text: "Ãî òîâî", want: 4},
+		{name: "symbols count toward the run", text: "Îò÷¸ò", want: 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maxNonASCIIRun(tt.text); got != tt.want {
+				t.Fatalf("maxNonASCIIRun(%q) = %d, want %d", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasMixedScriptWord(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "pure ascii", text: "hello world", want: false},
+		{name: "pure cyrillic word among ascii", text: "answer: Готово", want: false},
+		{name: "latin accents", text: "naïve résumé", want: false},
+		{name: "ascii word carrying a cyrillic letter", text: "rйsumй", want: true},
+		{name: "mixed word at the very end", text: "value: Mьller", want: true},
+		{name: "digits do not join letters into one word", text: "Отчёт2024", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasMixedScriptWord(tt.text); got != tt.want {
+				t.Fatalf("hasMixedScriptWord(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/textenc/textenc.go
+++ b/internal/textenc/textenc.go
@@ -48,6 +48,10 @@ const (
 	// minUTF16SniffBytes is the shortest input worth testing for the interleaved
 	// byte pattern of BOM-less UTF-16; below it the parity ratio is meaningless.
 	minUTF16SniffBytes = 8
+	// minMojibakeRun is the shortest run of consecutive non-ASCII characters that
+	// reads as non-Latin text mis-decoded through a Latin code page. Below it a
+	// detected Latin reading is taken as genuine accented Western text.
+	minMojibakeRun = 3
 	// minUTF16FillerRatio is the share of one parity class that must be control
 	// bytes for the input to read as UTF-16. Real UTF-16 puts the code point's
 	// high byte there, which is 0x00 for Latin text and 0x04 for Cyrillic.
@@ -84,16 +88,102 @@ func DecodeToUTF8(data []byte) (text string, charset string, err error) {
 	if isBinary(data) {
 		return "", "", ErrUndecodable
 	}
-	if text, charset, ok := decodeDetected(data); ok {
-		return text, charset, nil
+	detected, detectedOK := decodeDetectedCandidate(data)
+	// A file written by a local editor on Windows is usually in the machine's ANSI
+	// code page (1251 on a Russian install), which is exactly the case chardet is
+	// least sure about when the file is short. That reading is therefore consulted
+	// both when detection failed outright and when it produced a Latin reading
+	// carrying the shape of mis-decoded non-Latin text.
+	ansi, ansiOK := decodeSystemANSICandidate(data)
+	if ansiOK && (!detectedOK || preferSystemANSI(detected.text, ansi.text)) {
+		return ansi.text, ansi.charset, nil
 	}
-	// Last resort on Windows: a file written by a local editor is usually in the
-	// machine's ANSI code page (1251 on a Russian install), which is exactly the
-	// case chardet is least sure about when the file is short.
-	if text, charset, ok := decodeSystemANSI(data); ok {
-		return text, charset, nil
+	if detectedOK {
+		return detected.text, detected.charset, nil
 	}
 	return "", "", ErrUndecodable
+}
+
+// preferSystemANSI reports whether the system ANSI reading should overrule the
+// detected one.
+//
+// A short file whose non-ASCII bytes are a small minority - source code with one
+// Russian comment, the everyday case on a Russian Windows install - starves the
+// statistical model twice over: ISO-8859-1 fits any byte sequence so it wins the
+// whole-input pass, and the concentrated pass of decodeDetected sees too few
+// bytes to score. Detection then returns a confident Latin reading and the file
+// silently decodes to mojibake. The ANSI reading takes over only when it makes a
+// positive claim the detected one did not, and neither reading looks mis-decoded.
+func preferSystemANSI(detected, ansi string) bool {
+	if hasNonLatinLetters(detected) || !hasNonLatinLetters(ansi) {
+		return false
+	}
+	// Non-Latin text read through a Latin code page comes out as an unbroken run
+	// of non-ASCII characters. Genuine Western text carries accents as isolated
+	// marks inside otherwise ASCII words, so a short run means the detected
+	// reading is the real one and the ANSI page would be the mistake.
+	if maxNonASCIIRun(detected) < minMojibakeRun {
+		return false
+	}
+	// The mirror image: Western text read through a Cyrillic page splits a word
+	// into an ASCII part and a non-Latin one ("resume" with its accents becomes
+	// "rйsumй"). A word that mixes scripts means the ANSI reading is the wrong one.
+	return !hasMixedScriptWord(ansi)
+}
+
+// maxNonASCIIRun returns the length of the longest run of consecutive non-ASCII,
+// non-space characters.
+func maxNonASCIIRun(text string) int {
+	best, run := 0, 0
+	for _, r := range text {
+		if r > unicode.MaxASCII && !unicode.IsSpace(r) {
+			run++
+			if run > best {
+				best = run
+			}
+			continue
+		}
+		run = 0
+	}
+	return best
+}
+
+// hasMixedScriptWord reports whether any run of letters mixes ASCII letters with
+// letters outside the Latin script.
+func hasMixedScriptWord(text string) bool {
+	ascii, nonLatin := false, false
+	mixed := func() bool {
+		got := ascii && nonLatin
+		ascii, nonLatin = false, false
+		return got
+	}
+	for _, r := range text {
+		if !unicode.IsLetter(r) {
+			if mixed() {
+				return true
+			}
+			continue
+		}
+		switch {
+		case r <= unicode.MaxASCII:
+			ascii = true
+		case !unicode.Is(unicode.Latin, r):
+			nonLatin = true
+		}
+	}
+	return mixed()
+}
+
+// decodeDetectedCandidate wraps decodeDetected in the candidate shape.
+func decodeDetectedCandidate(data []byte) (candidate, bool) {
+	text, charset, ok := decodeDetected(data)
+	return candidate{text: text, charset: charset}, ok
+}
+
+// decodeSystemANSICandidate wraps decodeSystemANSI in the candidate shape.
+func decodeSystemANSICandidate(data []byte) (candidate, bool) {
+	text, charset, ok := decodeSystemANSI(data)
+	return candidate{text: text, charset: charset}, ok
 }
 
 // decodeBOM handles the byte-order marks that identify an encoding outright.

--- a/internal/textenc/textenc_windows_test.go
+++ b/internal/textenc/textenc_windows_test.go
@@ -1,0 +1,86 @@
+//go:build windows
+
+package textenc_test
+
+import (
+	"testing"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/platform"
+	"github.com/EvilFreelancer/coddy-agent/internal/textenc"
+)
+
+// requireCyrillicANSI skips a test unless the machine's ANSI code page reads
+// single-byte Cyrillic. These cases are about the code page standing in for
+// statistical detection, so on a Western Windows install there is nothing to
+// stand in with and the expectation would not hold.
+func requireCyrillicANSI(t *testing.T) {
+	t.Helper()
+	text, _, ok := platform.DecodeANSI([]byte{0xCF, 0xF0, 0xE8})
+	if !ok || text != "При" {
+		t.Skip("system ANSI code page is not Cyrillic")
+	}
+}
+
+// TestDecodeToUTF8ShortMixedFilesUseSystemANSI covers the files chardet cannot
+// call: mostly ASCII with a minority of Cyrillic, too little evidence for the
+// statistical model either over the whole input or over its non-ASCII lines.
+// ISO-8859-1 fits any byte sequence and wins on confidence, so without the ANSI
+// code page these decode to mojibake with no error raised.
+func TestDecodeToUTF8ShortMixedFilesUseSystemANSI(t *testing.T) {
+	requireCyrillicANSI(t)
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "go comment", want: "package main\n\nfunc main() {\n\t// Готово\n}\n"},
+		{name: "ini comment", want: "name=test\nport=80\n# Имя\n"},
+		{name: "markdown heading", want: "# Report\n\nsee table below\n\n## Итоги\n\n- one\n- two\n"},
+		{name: "json value", want: "{\n  \"id\": 1,\n  \"title\": \"Отчёт\"\n}\n"},
+		{name: "log line", want: "2026-08-02 12:00:01 INFO  started\n2026-08-02 12:00:02 ERROR ошибка\n"},
+		{name: "csv cell", want: "id,name,city\n1,alpha,Москва\n2,beta,london\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, charset, err := textenc.DecodeToUTF8(mustEncode(t, charmap.Windows1251, tt.want))
+			if err != nil {
+				t.Fatalf("DecodeToUTF8: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("text = %q, want %q (charset %q)", got, tt.want, charset)
+			}
+		})
+	}
+}
+
+// TestDecodeToUTF8KeepsWesternReadings pins the other side of the choice: a
+// Western file on a Cyrillic Windows install must keep the detected reading
+// rather than being re-read through the ANSI code page.
+func TestDecodeToUTF8KeepsWesternReadings(t *testing.T) {
+	requireCyrillicANSI(t)
+	tests := []struct {
+		name string
+		enc  encoding.Encoding
+		want string
+	}{
+		{name: "french", enc: charmap.ISO8859_1, want: "Café au lait\nprice: 5 EUR\nthanks\n"},
+		{name: "german", enc: charmap.ISO8859_1, want: "Müller GmbH\naddress: Berlin\nphone: 123\n"},
+		{name: "french accents", enc: charmap.ISO8859_1, want: "naïve résumé\nfrom the café\n"},
+		{name: "spanish", enc: charmap.ISO8859_1, want: "El niño come mañana\nen la playa\n"},
+		{name: "standalone accented word", enc: charmap.ISO8859_1, want: "il va à Paris\ndemain matin\n"},
+		{name: "nordic", enc: charmap.ISO8859_1, want: "Blåbær og rødgrød\nsmager godt\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, charset, err := textenc.DecodeToUTF8(mustEncode(t, tt.enc, tt.want))
+			if err != nil {
+				t.Fatalf("DecodeToUTF8: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("text = %q, want %q (charset %q)", got, tt.want, charset)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Проблема

Добивка пункта из «Что осталось за рамками» в #81 — того самого, который автор не смог проверить, потому что ему было нечем проверять на Windows. **Проверил на Windows 10, ACP 1251: баг реальный.**

Короткий файл, где кириллица — меньшинство (исходник с одним русским комментарием, самый обычный случай на русской винде), голодает статистическую модель дважды:

- проход по всему файлу: `ISO-8859-1` подходит под любую последовательность байт и выигрывает по уверенности (conf=40 при пороге 30);
- концентрированный проход по не-ASCII строкам: байт слишком мало, `Shift_JIS` conf=10 при пороге 20 — пас.

`decodeDetected` возвращает уверенное латинское чтение, `decodeSystemANSI` не зовётся вообще, потому что стоял только на полном провале детекции. Файл молча, без ошибки, уезжает в промпт мохибейкой:

```
// Готово   ->   // Ãîòîâî
```

Замер по корпусу из семи коротких cp1251 файлов (комментарий в Go, комментарий в ini, заголовок markdown, значение в JSON, строка лога, ячейка CSV) — **шесть из семи декодировались в мохибейку**.

## Решение

Системная ANSI-кодовая страница спущена с «последнего шанса» до полноценного кандидата, который может перебить детекцию. Чтобы западный файл на той же машине не перевербовался в 1251, переключение закрыто тремя условиями сразу (`preferSystemANSI`):

1. **ANSI утверждает то, чего не утвердила детекция** — нелатинское письмо. Переиспользуется существующий `hasNonLatinLetters`, тот же приём, что уже стоит на концентрированном проходе.
2. **В латинском чтении есть сплошная цепочка не-ASCII символов** (≥3). Кириллица через латинскую страницу даёт сплошняк (`Ãîòîâî` = 6); настоящий западный текст носит диакритику одиночными знаками внутри ASCII-слов (`café` = 1). Это условие держит случай вроде `il va à Paris`, где акцентированное слово стоит отдельно.
3. **В ANSI-чтении нет слова, смешивающего письменности.** Западный текст через кириллическую страницу рвёт слово именно так: `résumé` → `rйsumй`. Значит, мохибейка — это ANSI-чтение, и брать его нельзя.

Отдельной проверки номера кодовой страницы не нужно: если ACP латинская (1252), условие 1 ложно само по себе.

## Совместимость

Вне Windows `platform.DecodeANSI` — заглушка, кандидат не появляется, поведение бит в бит прежнее. Порядок ступеней (BOM → быстрый UTF-8 → бинарный guard → детекция) не тронут.

## Тесты

- **`internal/textenc/prefer_ansi_test.go`** — решение вынесено в чистую функцию и покрыто табличным тестом **на готовых строках**, без обращения к платформе. Идёт на Linux CI: иначе регресс в эвристике был бы виден только на Windows. Плюс тесты на оба хелпера.
- **`internal/textenc/textenc_windows_test.go`** (`//go:build windows`) — end-to-end через `DecodeToUTF8` на обоих половинах корпуса: шесть коротких cp1251 файлов возвращаются байт в байт, шесть западных (`café`, `Müller`, `niño`, `Blåbær`, `à Paris`, `naïve résumé`) сохраняют латинское чтение. Пропускается, если ANSI-страница машины не кириллическая.
- **`features/prompt_attachment_encoding.feature`** — сценарий по правилам репозитория (happy path багфикса), тег `@windows`; до правки падал ровно на `// Ãîòîâî`. Харнесс фильтрует `~@windows`, когда системная ANSI-страница не кириллическая — так сценарий не ломает ни Linux CI, ни западную винду.

## Проверка

- `make lint` — 0 issues.
- Вся матрица тегов зелёная. `make test` останавливается на первом же шаге из-за `TestStopReachesASurvivorByItsRecordedGroup` и `TestReapSurvivorsKillsAndRecordsThem` в `internal/bgtask` — **проверено, что эти два падают и на чистом `main` на Windows** (те же самые, о которых предупреждает #81). Матрица прогнана вручную с исключением `internal/bgtask`: `memory`, `http`, `http,memory`, `scheduler`, `scheduler,memory`, `ui-build`, `http,ui`, `http,ui,memory`, `http,scheduler`, `http,scheduler,memory`, `http,scheduler,ui`, `http,scheduler,ui,memory` — все зелёные.

## Вне области изменений

- Файл, где вся кириллица — слова длиной ≤2 символа (`answer: Да`): цепочка = 2, порог не берётся. Снижать порог до 2 рискованно — растёт шанс перевербовать западный текст с двумя диакритиками подряд, а случай маргинальный: достаточно одного русского слова из 3+ букв в любом месте файла.
- Короткий польский ISO-8859-2 определяется как ISO-8859-1 и сейчас — ограничение chardet, не регрессия; правило его не меняет и не усугубляет.
- `read` / `edit` / `patch` — как и в #81, не тронуты: они пишут файл обратно, молчаливое транскодирование потеряло бы исходную кодировку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
