### PR TITLE
Disable duplicate LLM SDK retries

### DIFF
--- a/features/llm_retry_ownership.feature
+++ b/features/llm_retry_ownership.feature
@@ -14,3 +14,5 @@ Feature: Coddy owns LLM retries
       | openai    | streaming     |
       | anthropic | non-streaming |
       | anthropic | streaming     |
+      | codex     | non-streaming |
+      | codex     | streaming     |

--- a/features/llm_retry_ownership.feature
+++ b/features/llm_retry_ownership.feature
@@ -1,0 +1,16 @@
+Feature: Coddy owns LLM retries
+  Coddy's configured retry limit is the single source of truth for upstream
+  request attempts. Provider SDKs must not add hidden HTTP retries.
+
+  Scenario Outline: One configured retry sends exactly two upstream requests
+    Given a "<provider>" provider using "<mode>" requests with one configured retry
+    When the upstream responds with a retryable server error
+    Then the provider call fails
+    And exactly 2 upstream requests are sent
+
+    Examples:
+      | provider  | mode          |
+      | openai    | non-streaming |
+      | openai    | streaming     |
+      | anthropic | non-streaming |
+      | anthropic | streaming     |

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -22,7 +22,7 @@ type anthropicProvider struct {
 }
 
 func newAnthropicProvider(model, apiKey, baseURL string, httpClient *http.Client, maxTokens int, temp float64, reasoningEffort string) *anthropicProvider {
-	opts := []option.RequestOption{}
+	opts := []option.RequestOption{option.WithMaxRetries(0)}
 	if apiKey != "" {
 		opts = append(opts, option.WithAPIKey(apiKey))
 	}

--- a/internal/llm/bdd_retry_ownership_test.go
+++ b/internal/llm/bdd_retry_ownership_test.go
@@ -1,0 +1,127 @@
+package llm
+
+// Godog harness for features/llm_retry_ownership.feature: exercises the real
+// OpenAI and Anthropic providers against a request-counting HTTP server.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+type retryOwnershipState struct {
+	server   *httptest.Server
+	provider Provider
+	mode     string
+	requests atomic.Int32
+	callErr  error
+}
+
+func (s *retryOwnershipState) reset() {
+	s.cleanup()
+	s.provider = nil
+	s.mode = ""
+	s.requests.Store(0)
+	s.callErr = nil
+}
+
+func (s *retryOwnershipState) cleanup() {
+	if s.server != nil {
+		s.server.Close()
+		s.server = nil
+	}
+}
+
+func (s *retryOwnershipState) aProviderWithOneConfiguredRetry(providerType, mode string) error {
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		s.requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"temporary failure","type":"server_error"}}`))
+	}))
+
+	provider, err := NewProvider(ProviderInput{
+		Type:          providerType,
+		Model:         "test-model",
+		APIKey:        "test-key",
+		BaseURL:       s.server.URL,
+		RetryMax:      1,
+		RetryBase:     time.Millisecond,
+		RetryMaxDelay: time.Millisecond,
+	})
+	if err != nil {
+		return fmt.Errorf("create %s provider: %w", providerType, err)
+	}
+	s.provider = provider
+	s.mode = mode
+	return nil
+}
+
+func (s *retryOwnershipState) theUpstreamRespondsWithARetryableServerError() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	messages := []Message{{Role: RoleUser, Content: "hello"}}
+	switch s.mode {
+	case "non-streaming":
+		_, s.callErr = s.provider.Complete(ctx, messages, nil)
+	case "streaming":
+		_, s.callErr = s.provider.Stream(ctx, messages, nil, func(StreamChunk) {})
+	default:
+		return fmt.Errorf("unsupported request mode %q", s.mode)
+	}
+	return nil
+}
+
+func (s *retryOwnershipState) theProviderCallFails() error {
+	if s.callErr == nil {
+		return fmt.Errorf("provider call unexpectedly succeeded")
+	}
+	return nil
+}
+
+func (s *retryOwnershipState) exactlyUpstreamRequestsAreSent(want int) error {
+	if got := int(s.requests.Load()); got != want {
+		return fmt.Errorf("upstream requests = %d, want %d", got, want)
+	}
+	return nil
+}
+
+func initializeRetryOwnershipScenario(sc *godog.ScenarioContext) {
+	s := &retryOwnershipState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		s.reset()
+		return ctx, nil
+	})
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		s.cleanup()
+		return ctx, nil
+	})
+
+	sc.Step(`^a "([^"]+)" provider using "([^"]+)" requests with one configured retry$`, s.aProviderWithOneConfiguredRetry)
+	sc.Step(`^the upstream responds with a retryable server error$`, s.theUpstreamRespondsWithARetryableServerError)
+	sc.Step(`^the provider call fails$`, s.theProviderCallFails)
+	sc.Step(`^exactly (\d+) upstream requests are sent$`, s.exactlyUpstreamRequestsAreSent)
+}
+
+func TestLLMRetryOwnershipFeature(t *testing.T) {
+	suite := godog.TestSuite{
+		Name:                "llm-retry-ownership",
+		ScenarioInitializer: initializeRetryOwnershipScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/llm_retry_ownership.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("LLM retry ownership feature suite failed")
+	}
+}

--- a/internal/llm/bdd_retry_ownership_test.go
+++ b/internal/llm/bdd_retry_ownership_test.go
@@ -1,13 +1,18 @@
 package llm
 
 // Godog harness for features/llm_retry_ownership.feature: exercises the real
-// OpenAI and Anthropic providers against a request-counting HTTP server.
+// OpenAI, Anthropic, and Codex providers against a request-counting HTTP server.
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,11 +21,16 @@ import (
 )
 
 type retryOwnershipState struct {
-	server   *httptest.Server
-	provider Provider
-	mode     string
-	requests atomic.Int32
-	callErr  error
+	server    *httptest.Server
+	provider  Provider
+	mode      string
+	requests  atomic.Int32
+	callErr   error
+	// codex wiring: a temp auth.json and the previous CODDY_CODEX_BASE_URL so
+	// NewProvider's codex branch reaches the request-counting server.
+	prevCodexBaseURL string
+	setCodexBaseURL  bool
+	authDir          string
 }
 
 func (s *retryOwnershipState) reset() {
@@ -36,6 +46,14 @@ func (s *retryOwnershipState) cleanup() {
 		s.server.Close()
 		s.server = nil
 	}
+	if s.setCodexBaseURL {
+		_ = os.Setenv(EnvCodexBaseURL, s.prevCodexBaseURL)
+		s.setCodexBaseURL = false
+	}
+	if s.authDir != "" {
+		_ = os.RemoveAll(s.authDir)
+		s.authDir = ""
+	}
 }
 
 func (s *retryOwnershipState) aProviderWithOneConfiguredRetry(providerType, mode string) error {
@@ -46,7 +64,7 @@ func (s *retryOwnershipState) aProviderWithOneConfiguredRetry(providerType, mode
 		_, _ = w.Write([]byte(`{"error":{"message":"temporary failure","type":"server_error"}}`))
 	}))
 
-	provider, err := NewProvider(ProviderInput{
+	in := ProviderInput{
 		Type:          providerType,
 		Model:         "test-model",
 		APIKey:        "test-key",
@@ -54,13 +72,61 @@ func (s *retryOwnershipState) aProviderWithOneConfiguredRetry(providerType, mode
 		RetryMax:      1,
 		RetryBase:     time.Millisecond,
 		RetryMaxDelay: time.Millisecond,
-	})
+	}
+	if providerType == "codex" {
+		authPath, err := s.writeCodexAuthForRetryOwnership()
+		if err != nil {
+			return fmt.Errorf("create %s provider: %w", providerType, err)
+		}
+		// NewProvider's codex branch ignores BaseURL and resolves the endpoint
+		// from CODDY_CODEX_BASE_URL, so point it at the request-counting server.
+		s.prevCodexBaseURL = os.Getenv(EnvCodexBaseURL)
+		s.setCodexBaseURL = true
+		if err := os.Setenv(EnvCodexBaseURL, s.server.URL); err != nil {
+			return fmt.Errorf("create %s provider: set base URL: %w", providerType, err)
+		}
+		in.APIKey = ""
+		in.AuthPath = authPath
+	}
+
+	provider, err := NewProvider(in)
 	if err != nil {
 		return fmt.Errorf("create %s provider: %w", providerType, err)
 	}
 	s.provider = provider
 	s.mode = mode
 	return nil
+}
+
+// writeCodexAuthForRetryOwnership stages a Codex auth.json with a far-future
+// token so the auth source returns the static credential without an OAuth
+// refresh. It mirrors the codex_auth_test.go makeJWT shape without depending
+// on a *testing.T helper.
+func (s *retryOwnershipState) writeCodexAuthForRetryOwnership() (string, error) {
+	dir, err := os.MkdirTemp("", "coddy-retry-ownership-")
+	if err != nil {
+		return "", err
+	}
+	s.authDir = dir
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(
+		`{"exp":` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `}`))
+	auth := codexAuthFile{
+		AuthMode: codexAuthModeChatGPT,
+		Tokens: codexTokens{
+			AccessToken: header + "." + payload + ".sig",
+			AccountID:   "acct-1",
+		},
+	}
+	data, err := json.MarshalIndent(auth, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 func (s *retryOwnershipState) theUpstreamRespondsWithARetryableServerError() error {

--- a/internal/llm/codex.go
+++ b/internal/llm/codex.go
@@ -52,7 +52,10 @@ func (p *codexProvider) responsesClient(ctx context.Context) (responses.Response
 	if err != nil {
 		return responses.ResponseService{}, err
 	}
+	// The OpenAI SDK defaults to two HTTP retries; Coddy owns retry pacing
+	// through resilientProvider, so disable hidden retries here as well.
 	opts := []option.RequestOption{
+		option.WithMaxRetries(0),
 		option.WithBaseURL(p.baseURL),
 		option.WithAPIKey(cred.AccessToken),
 		option.WithHeader("OpenAI-Beta", "responses=experimental"),

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -24,7 +24,7 @@ type openAIProvider struct {
 }
 
 func newOpenAIProvider(model, apiKey, baseURL string, httpClient *http.Client, maxTokens int, temp float64, reasoningEffort string) *openAIProvider {
-	opts := []option.RequestOption{}
+	opts := []option.RequestOption{option.WithMaxRetries(0)}
 	if apiKey != "" {
 		opts = append(opts, option.WithAPIKey(apiKey))
 	}

--- a/internal/llm/resilient_test.go
+++ b/internal/llm/resilient_test.go
@@ -43,11 +43,16 @@ func TestIsRetryableLLMError(t *testing.T) {
 	if !isRetryableLLMError(err429Neuraldeep()) {
 		t.Fatal("429 should be retryable")
 	}
-	if isRetryableLLMError(errors.New("openai stream: 400 Bad Request")) {
-		t.Fatal("400 should not be retryable")
-	}
-	if isRetryableLLMError(context.Canceled) {
-		t.Fatal("cancel should not be retryable")
+	for name, err := range map[string]error{
+		"400":      errors.New("openai stream: 400 Bad Request"),
+		"cancel":   context.Canceled,
+		"deadline": context.DeadlineExceeded,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if isRetryableLLMError(err) {
+				t.Fatalf("%s should not be retryable", name)
+			}
+		})
 	}
 }
 
@@ -75,8 +80,8 @@ func TestResilientProviderRetries429UntilSuccess(t *testing.T) {
 		},
 	}
 	p := wrapResilient(inner, ResilientOptions{
-		RetryMax:   3,
-		RetryBase:  5 * time.Millisecond,
+		RetryMax:      3,
+		RetryBase:     5 * time.Millisecond,
 		RetryMaxDelay: time.Second,
 	})
 	resp, err := p.Stream(context.Background(), nil, nil, nil)


### PR DESCRIPTION
## Summary

- disable automatic retries in the OpenAI and Anthropic SDK clients
- keep retry count, backoff, and pacing under `resilientProvider`
- add request-counting BDD coverage for streaming and non-streaming calls to both providers
- cover deadline errors alongside `400` responses and cancellation as non-retryable

## Root cause

Both SDKs default to two retries. Each Coddy attempt could therefore send three upstream HTTP requests before `resilientProvider` applied `agent.llm_retry_max` again. With one configured retry, a persistent retryable failure produced six requests instead of two.

## Impact

`agent.llm_retry_max` now exactly describes the retries after the initial request for OpenAI and Anthropic providers, including streaming calls. This avoids hidden upstream load and cost during rate limits and transient server failures.

## Validation

- `go test ./internal/llm -count=1`
- `make lint` (`0 issues`)
- `make test` reached and passed `internal/llm`, but the initial `go test ./...` stage was blocked by two unrelated, reproducible Windows process-group failures in `internal/bgtask`: `TestStopReachesASurvivorByItsRecordedGroup` and `TestReapSurvivorsKillsAndRecordsThem`

Fixes #91
