### PR TITLE
feat(zcode): auto-attach .cursor/rules by glob via SessionStart/PreToolUse hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ Thumbs.db
 
 # Codex cross-review local state
 .codex-review/
+
+# ZCode local session state (plans, transcripts). Shared, versioned config
+# (.zcode/config.json, .zcode/hooks/) is added to git explicitly.
+.zcode/plans/
+.zcode/sessions/

--- a/.zcode/config.json
+++ b/.zcode/config.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "enabled": true,
+    "events": {
+      "SessionStart": [
+        {
+          "matcher": "startup|resume|clear|compact",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python \"${ZCODE_PROJECT_DIR}/.zcode/hooks/attach_rules.py\"",
+              "timeout": 10,
+              "statusMessage": "Loading always-on project rules"
+            }
+          ]
+        }
+      ],
+      "PreToolUse": [
+        {
+          "matcher": "^(Edit|Write|MultiEdit|ApplyPatch)$",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python \"${ZCODE_PROJECT_DIR}/.zcode/hooks/attach_rules.py\"",
+              "timeout": 10,
+              "statusMessage": "Attaching rules for edited files"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/.zcode/hooks/attach_rules.py
+++ b/.zcode/hooks/attach_rules.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Attach `.cursor/rules/*.mdc` to ZCode sessions deterministically.
+
+ZCode has no glob-based rule attachment: its instruction file (`AGENTS.md`) is
+resolved once per session from the working directory up to the project root, so
+nested instruction files never load, and there is no equivalent of the `globs`
+field in `.cursor/rules/*.mdc`. Asking the model to "read the relevant rule
+file" is advisory and gets skipped.
+
+This hook restores Cursor's behaviour by reading the frontmatter of the rule
+files directly:
+
+  SessionStart -> inject every rule with `alwaysApply: true`
+  PreToolUse   -> inject rules whose `globs` match the file paths a tool is
+                  about to touch, at most once per rule per session
+
+`.cursor/rules/` stays the single source of truth; nothing is duplicated here.
+The hook fails open: any unexpected input exits 0 with no output, so a broken
+rule file can never block an edit.
+
+Wired up in `.zcode/config.json` under `hooks.events.{SessionStart,PreToolUse}`.
+Unlike the Codex sibling (`.codex/hooks/attach_rules.py`) the edited file paths
+arrive as JSON fields of the tool payload (`tool_input.file_path`, `.path`, ...),
+not as an embedded `*** Update File:` patch, so this variant extracts them from
+those fields instead of parsing a patch blob.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# The repository root is two levels up from this script:
+# .zcode/hooks/attach_rules.py -> repo root.
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parents[1]
+RULES_DIR = Path(os.environ.get("ZCODE_RULES_DIR") or (REPO_ROOT / ".cursor" / "rules"))
+STATE_DIR = Path(os.environ.get("ZCODE_RULES_STATE_DIR") or (Path(tempfile.gettempdir()) / "zcode-coddy-rules"))
+
+# Field names inside a ZCode tool payload that carry a file path. The matcher is
+# intentionally permissive: it also walks nested structures, so a path nested
+# deeper than these keys is still found. The known names keep the walk focused
+# and avoid treating arbitrary string values as paths.
+PATH_FIELDS = frozenset(
+    {
+        "file_path",
+        "path",
+        "notebook_path",
+        "source",
+        "destination",
+        "new_path",
+        "old_path",
+        "old_string_path",
+        "filePath",
+        "fileName",
+        "directory",
+    }
+)
+
+
+class Rule:
+    def __init__(self, path: Path, description: str, globs: list[str], always: bool, body: str):
+        self.path = path
+        self.description = description
+        self.globs = globs
+        self.always = always
+        self.body = body
+
+    @property
+    def rel(self) -> str:
+        return self.path.relative_to(REPO_ROOT).as_posix()
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a Cursor glob into a regex.
+
+    `fnmatch` is unusable here because its `*` also crosses `/`, which makes
+    `external/httpserver/**/*.go` miss `external/httpserver/server.go`.
+    """
+    out: list[str] = []
+    i, n = 0, len(pattern)
+    while i < n:
+        if pattern.startswith("**/", i):
+            out.append("(?:.*/)?")
+            i += 3
+        elif pattern.startswith("**", i):
+            out.append(".*")
+            i += 2
+        elif pattern[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif pattern[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(pattern[i]))
+            i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def parse_rule(path: Path) -> Rule | None:
+    """Read one `.mdc` file. Frontmatter is flat, so no YAML dependency."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end < 0:
+        return None
+    head = text[3:end]
+    body = text[end + 4 :].strip()
+
+    description, globs, always = "", [], False
+    for line in head.splitlines():
+        key, sep, value = line.partition(":")
+        if not sep:
+            continue
+        key, value = key.strip(), value.strip()
+        if key == "description":
+            description = value
+        elif key == "globs":
+            globs = [g.strip() for g in value.split(",") if g.strip()]
+        elif key == "alwaysApply":
+            always = value.lower() == "true"
+    return Rule(path, description, globs, always, body)
+
+
+def load_rules() -> list[Rule]:
+    rules = []
+    for path in sorted(RULES_DIR.glob("*.mdc")):
+        rule = parse_rule(path)
+        if rule and rule.body:
+            rules.append(rule)
+    return rules
+
+
+def state_file(session_id: str) -> Path:
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", session_id or "unknown")[:120]
+    return STATE_DIR / f"{safe}.json"
+
+
+def load_sent(session_id: str) -> set[str]:
+    try:
+        return set(json.loads(state_file(session_id).read_text(encoding="utf-8")))
+    except Exception:
+        return set()
+
+
+def save_sent(session_id: str, sent: set[str]) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        state_file(session_id).write_text(json.dumps(sorted(sent)), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def collect_target_paths(tool_input: object) -> list[str]:
+    """Collect repo-relative file paths from a ZCode tool payload.
+
+    ZCode hands the hook a JSON object whose fields depend on the tool
+    (`file_path` for Edit/Write, `path`/`notebook_path`/... for others). We walk
+    the structure and keep the string values found under known path-carrying
+    keys, so an absolute or nested path is still matched once normalised.
+    """
+    found: list[str] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in PATH_FIELDS and isinstance(value, str) and value:
+                    found.append(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(tool_input)
+
+    rel: list[str] = []
+    for raw in found:
+        path = Path(raw)
+        if path.is_absolute():
+            try:
+                path = path.relative_to(REPO_ROOT)
+            except ValueError:
+                continue
+        rel.append(path.as_posix())
+    return rel
+
+
+def render(rules: list[Rule], preamble: str) -> str:
+    chunks = [preamble]
+    for rule in rules:
+        chunks.append(f"<!-- from {rule.rel} -->\n\n{rule.body}")
+    return "\n\n".join(chunks)
+
+
+def emit(event: str, context: str) -> None:
+    json.dump(
+        {"hookSpecificOutput": {"hookEventName": event, "additionalContext": context}},
+        sys.stdout,
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    event = payload.get("hook_event_name") or os.environ.get("ZCODE_HOOK_EVENT", "")
+    session_id = payload.get("session_id", "")
+
+    try:
+        rules = load_rules()
+    except Exception:
+        return 0
+    if not rules:
+        return 0
+
+    if event == "SessionStart":
+        if payload.get("source") == "clear":
+            state_file(session_id).unlink(missing_ok=True)
+        always = [r for r in rules if r.always]
+        if not always:
+            return 0
+        save_sent(session_id, {r.rel for r in always})
+        emit(
+            event,
+            render(
+                always,
+                "Project rules for this repository, always in force. They are"
+                " authoritative; `.cursor/rules/` is their single source of truth."
+                " More rules are attached automatically when you edit files they"
+                " cover.",
+            ),
+        )
+        return 0
+
+    if event != "PreToolUse":
+        return 0
+
+    paths = collect_target_paths(payload.get("tool_input"))
+    if not paths:
+        return 0
+
+    sent = load_sent(session_id)
+    matched: list[Rule] = []
+    for rule in rules:
+        if rule.always or rule.rel in sent or not rule.globs:
+            continue
+        patterns = [glob_to_regex(g) for g in rule.globs]
+        if any(p.match(path) for path in paths for p in patterns):
+            matched.append(rule)
+
+    if not matched:
+        return 0
+
+    save_sent(session_id, sent | {r.rel for r in matched})
+    touched = ", ".join(sorted(set(paths))[:8])
+    emit(
+        event,
+        render(
+            matched,
+            f"Project rules that cover the files you are editing ({touched})."
+            " Apply them to this change before continuing.",
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Fail open: never block an edit because of this hook.
+        sys.exit(0)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,9 @@ Human prose for HTTP lives in **`docs/http-api.md`**. Visual spec for SPA lives 
 
 All **code comments** plus **technical markdown authored for this repo** (including `docs/`, `DESIGN.md`, `AGENTS.md`) stay **English** unless an operator explicitly asks for another natural language.
 
-## Codex, OpenCode, and Cursor rules
+## Codex, OpenCode, Cursor and ZCode rules
 
-Codex uses this **`AGENTS.md`** file as its repo instruction entrypoint. The detailed project rules live in **`.cursor/rules/*.mdc`**, which is their single source of truth. Do not copy rules into `.codex/` or `.claude/` by hand.
+Codex uses this **`AGENTS.md`** file as its repo instruction entrypoint, and ZCode resolves its `AGENTS.md` chain the same way. The detailed project rules live in **`.cursor/rules/*.mdc`**, which is their single source of truth. Do not copy rules into `.codex/`, `.claude/`, or `.zcode/` by hand.
 
 Codex resolves its `AGENTS.md` chain once per session, walking from the repository root down to the launch directory, so nested instruction files never load for a session started at the root. A lifecycle hook covers that gap and delivers the Cursor rules deterministically instead of asking the model to fetch them:
 
@@ -54,6 +54,12 @@ Codex resolves its `AGENTS.md` chain once per session, walking from the reposito
 Codex requires explicit approval for hooks and tracks them by content hash. Run **`/hooks`** once per clone, and again after editing `attach_rules.py`, otherwise the hook is skipped silently. Project-local hooks also load only when the `.codex/` layer is trusted. **`.codex/rules.md`** keeps the human-readable index of the rule files; the full guide, including how to probe the hook by hand, is **`docs/codex-hooks.md`**.
 
 When working in OpenCode, the project plugin **`.opencode/plugins/project-rules.js`** delivers the same rule set without copying it. It injects `alwaysApply: true` rules into every model request, activates scoped rules when a tool touches a path covered by their `globs`, and preserves the active set through compaction. If a write tool is the first operation to reveal a new scoped rule, the plugin rejects that one call so OpenCode can retry with the rule in its model context. See **`docs/opencode-hooks.md`** and run **`make test-opencode-rules`** after changing the plugin.
+
+ZCode loads its `AGENTS.md` chain the same way and has the same gap, so a parallel hook delivers the Cursor rules there too:
+
+- **`.zcode/config.json`** wires **`.zcode/hooks/attach_rules.py`** to `SessionStart` and to `PreToolUse` on `Edit` / `Write` / `MultiEdit` / `ApplyPatch`, under `hooks.events` with `hooks.enabled: true`.
+- The behaviour matches the Codex hook (always-on rules at session start, scoped rules per edit, once per rule per session, fail open). The single difference is how edited paths are recovered: ZCode carries them as JSON fields of `tool_input` (`file_path`, `path`, ...), so this variant walks those fields instead of parsing an `apply_patch` blob.
+- Configuration-file hooks need no per-hook approval: a workspace config with `enabled: true` runs unconditionally. The command invokes `python` (not `python3`) because the `python3` name is a no-op Microsoft Store stub on Windows. The full guide, including how to probe the hook by hand and the Windows interpreter note, is **`docs/zcode-hooks.md`**.
 
 ## Code Review Rules
 

--- a/docs/zcode-hooks.md
+++ b/docs/zcode-hooks.md
@@ -1,0 +1,77 @@
+# ZCode hooks for project rules
+
+This page is about **contributors running the ZCode client against this repository**. It is the ZCode counterpart of [Codex hooks for project rules](codex-hooks.md); both deliver the same `.cursor/rules/*.mdc` files to the model, each through its own client's hook mechanism.
+
+## Why a hook is needed
+
+ZCode loads its instruction file (`AGENTS.md`) once per session, searching from the working directory up to the project root. Two consequences mirror the Codex case:
+
+- a session started at the repository root never loads a nested `AGENTS.md`;
+- there is no glob-based attachment. ZCode has no equivalent of the `globs` field in `.cursor/rules/*.mdc`, so scope can only be expressed by where a file sits in the tree.
+
+This repository keeps its detailed rules in `.cursor/rules/*.mdc`. Pointing the model at a rule file and asking it to read it is advisory and gets skipped.
+
+`.zcode/hooks/attach_rules.py` closes the gap by injecting rule bodies into the session directly, so compliance no longer depends on the model choosing to read a file.
+
+## What fires when
+
+| Event | Matcher | What is injected |
+|---|---|---|
+| `SessionStart` | `startup\|resume\|clear\|compact` | every rule whose frontmatter has `alwaysApply: true` |
+| `PreToolUse` | `^(Edit\|Write\|MultiEdit\|ApplyPatch)$` | rules whose `globs` cover a file in the pending tool call |
+
+Configuration lives in `.zcode/config.json` under `hooks.events`. Configuration-file hooks are disabled by default, so the config sets `hooks.enabled: true`. Both handlers run the same script; it branches on `hook_event_name` from the hook payload. The `ApplyPatch` alias is included in the `PreToolUse` matcher because ZCode aliases `Write`/`Edit` ← `ApplyPatch`.
+
+For this repository, `architecture`, `code-style`, `testing`, and `workflow` arrive at session start (the `alwaysApply: true` rules), and the remaining six attach on demand. An edit touching `external/httpserver/server.go` pulls in `api-layer` and `implementation-order`; one touching `external/ui/src/` pulls in `ui-spa` and `ui-verification`.
+
+## How it works
+
+The script parses the `.mdc` frontmatter itself (`description`, `globs`, `alwaysApply`), so `.cursor/rules/` stays the single source of truth and a new rule file needs no wiring. Points worth knowing:
+
+- **Glob matching is hand-rolled.** `fnmatch` is unusable because its `*` also crosses `/`, which makes `external/httpserver/**/*.go` miss `external/httpserver/server.go`. The script translates globs to a regex where `**/` becomes "zero or more directories", `*` stays inside one segment, and a bare `**` spans anything.
+- **Paths come from the tool payload, not a patch blob.** Unlike the Codex sibling (which scans for `*** Update File:` lines inside an `apply_patch` command), ZCode hands the hook a JSON object. The script walks `tool_input` and keeps the string values found under known path-carrying keys (`file_path`, `path`, `notebook_path`, `source`, `destination`, `new_path`, `old_path`, ...), so a nested or absolute path is still matched once normalised.
+- **Each rule is injected at most once per session.** State is a JSON file under `<tempdir>/zcode-coddy-rules/<session_id>.json`, keyed by the session id from the payload (also available as `${CLAUDE_SESSION_ID}`), so re-editing the same area does not re-send the same rule. A `SessionStart` with `source: "clear"` drops the dynamic history and reseeds it with the always-on set.
+- **It fails open.** Malformed JSON on stdin, an unparsable rule file, or an unwritable state directory all exit 0 with no output. A broken rule can never block an edit.
+
+## Enabling
+
+ZCode configuration-file hooks are disabled until `hooks.enabled: true` is set, so the committed `.zcode/config.json` already turns the runner on. Unlike Codex, there is no per-hook trust gate: a workspace config with `enabled: true` runs unconditionally, which is the intended behaviour for a repository-shared setup. Open the repository in ZCode and the two handlers are active; nothing else is required.
+
+## Windows interpreter
+
+The hook command invokes `python`, not `python3`. On Windows the `python3` name is often a Microsoft Store stub that prints nothing and exits non-zero, while the real interpreter is `python` (or the `py` launcher). On Unix-like systems `python` is typically present as well; if a system only provides `python3`, point the command in `.zcode/config.json` at it. The `${ZCODE_PROJECT_DIR}` template variable expands to the repository root inside the ZCode session.
+
+## Verifying and debugging
+
+Drive the script by hand with a synthetic payload. It reads JSON on stdin and writes JSON on stdout, so no ZCode session is needed:
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Edit","session_id":"probe","tool_input":{"file_path":"external/httpserver/server.go"}}' | python .zcode/hooks/attach_rules.py
+```
+
+Session-start behaviour:
+
+```bash
+echo '{"hook_event_name":"SessionStart","session_id":"probe","source":"startup"}' | python .zcode/hooks/attach_rules.py
+```
+
+Empty output is a valid answer and means one of three things: no glob matched, the rule was already sent in this session, or the input was not understood. Clear the dedup state to re-test:
+
+```bash
+rm -rf "${TMPDIR:-/tmp}/zcode-coddy-rules"
+```
+
+To probe against a throwaway rules directory and state without touching the session-shared defaults, set `ZCODE_RULES_DIR` and `ZCODE_RULES_STATE_DIR`.
+
+## Adding or changing a rule
+
+Edit `.cursor/rules/*.mdc` as before. The hook needs no change, but two things do:
+
+- a rule is only reachable from ZCode if its frontmatter carries `globs` or `alwaysApply: true`;
+- the index in `.codex/rules.md` and the bridge sections in `AGENTS.md` are refreshed in the same change that adds, renames, or removes a rule file.
+
+## Relationship to the Codex hook
+
+This script and `.codex/hooks/attach_rules.py` share the same goal and most of their logic (`parse_rule`, `glob_to_regex`, per-session state, the `SessionStart`/`PreToolUse` split, fail-open). They differ in one place: how the edited file paths are recovered. The Codex variant parses an embedded `apply_patch` blob (`*** Update File:` lines); this ZCode variant walks the `tool_input` JSON fields. Keep the two in sync when changing shared logic, and test both after edits.
+
+Upstream reference: ZCode hooks and configuration live under `~/.zcode/cli/config.json` (user scope) and `<repo>/.zcode/config.json` (workspace scope); the supported events are `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PostToolUseFailure`, and `Stop`.


### PR DESCRIPTION
## Summary

ZCode, like Codex, loads its `AGENTS.md` chain once per session and has no glob-based rule attachment, so the detailed rules in `.cursor/rules/*.mdc` never reach the model unless it chooses to open them — which is advisory and gets skipped. This adds a workspace-scoped ZCode hook that delivers those rules deterministically, mirroring the existing Codex bridge (`.codex/hooks/attach_rules.py`, `docs/codex-hooks.md`). `.cursor/rules/` stays the single source of truth.

## What fires when

| Event | Matcher | What is injected |
|---|---|---|
| `SessionStart` | `startup\|resume\|clear\|compact` | every rule whose frontmatter has `alwaysApply: true` |
| `PreToolUse` | `^(Edit\|Write\|MultiEdit\|ApplyPatch)$` | rules whose `globs` cover a file in the pending tool call |

For this repo, `architecture` / `code-style` / `testing` / `workflow` arrive at session start; the other six attach on demand. Editing `external/httpserver/server.go` pulls in `api-layer` + `implementation-order`; editing `external/ui/src/` pulls in `ui-spa` + `ui-verification`.

## Changes

- **`.zcode/hooks/attach_rules.py`** — `SessionStart` injects `alwaysApply: true` rules; `PreToolUse` injects rules whose `globs` match the edited files, once per rule per session. **Key difference from the Codex sibling:** edited paths are recovered from the `tool_input` JSON fields (`file_path` / `path` / `notebook_path` / …), not from an embedded `apply_patch` blob, because that's how ZCode hands paths to hooks. Hand-rolled glob→regex (`fnmatch` is unusable — its `*` crosses `/`), per-session dedup under `<tmp>/zcode-coddy-rules/<session_id>.json`, fail-open on any error. `ZCODE_RULES_DIR` / `ZCODE_RULES_STATE_DIR` override for testing.
- **`.zcode/config.json`** — `hooks.enabled: true` (configuration-file hooks are disabled by default); `SessionStart` + `PreToolUse` handlers. Command uses `python` (not `python3` — on Windows `python3` is a no-op Microsoft Store stub) and `${ZCODE_PROJECT_DIR}` for the repo root. `ApplyPatch` is in the matcher because ZCode aliases `Write`/`Edit` ← `ApplyPatch`.
- **`docs/zcode-hooks.md`** — full guide (mirrors `docs/codex-hooks.md`): triggers, how it works, the Windows interpreter note, how to probe by hand, relationship to the Codex hook.
- **`AGENTS.md`** — rename the section to "Codex, Cursor and ZCode rules"; add a ZCode paragraph parallel to the Codex one.
- **`.gitignore`** — ignore local ZCode session state (`.zcode/plans/`, `.zcode/sessions/`) so shared config under `.zcode/` can be versioned without dragging in per-developer transcripts.

## Why a separate script vs. one shared with Codex

`parse_rule`, `glob_to_regex`, per-session state, the `SessionStart`/`PreToolUse` split, and fail-open are identical. The one real divergence is path recovery (JSON fields vs. patch blob), and the two clients' hook config formats differ (Codex `.codex/hooks.json` vs. ZCode `.zcode/config.json` under `hooks.events` with `enabled: true`). Keeping them separate avoids coupling two clients' I/O contracts; the docs call out that shared logic should be kept in sync.

## Validation

No ZCode session needed — the script reads JSON on stdin and writes JSON on stdout. Verified by hand with synthetic payloads:

- `PreToolUse` on `external/httpserver/server.go` → attaches `api-layer` + `implementation-order` ✅
- file outside any glob → empty output ✅
- repeat call, same session → no-op (dedup state) ✅
- `SessionStart` (`startup`) → `architecture` / `code-style` / `testing` / `workflow` ✅
- `SessionStart` (`clear`) → drops dynamic history, reseeds with always-on set ✅
- corrupt stdin, empty stdin, broken `.mdc` → exit 0, no output, never blocks ✅
- `ApplyPatch` alias and nested path field (`tool_input.commands[].file_path`) handled ✅
- `python -m json.tool .zcode/config.json` valid; `py_compile` on the script passes ✅

## Out of scope

- Does not touch `.codex/` (Codex side unchanged).
- Does not touch `.cursor/rules/` (source of truth).
- No Go code/tests — this is outside the Go build (script + JSON + docs), so the pre-commit lint gate is skipped per `scripts/checks.sh`.