### PR TITLE
fix(llm): llama.cpp as OpenAI-compatible provider - survive its SSE dialect

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -67,6 +67,15 @@ providers:
     type: codex # use Sign In with ChatGPT in the bundled web UI; no api_key needed
 ```
 
+### llama.cpp as an OpenAI-compatible provider
+
+`llama-server` works as a `type: openai` provider (`api_base: "http://host:8080/v1"`). Recommended launch flags:
+
+- `--jinja` — enables the model's chat template on the server, which is required for **tool calling**. Without it llama.cpp silently ignores the `tools` parameter and the agent loop degrades to plain text answers.
+- `-c <n>` — set the context window large enough for an agent prompt (system prompt plus tool schemas plus history; 16k is a practical minimum, more is better). When a request exceeds the server context, llama.cpp reports `the request exceeds the available context size` — raise `-c` or trim `max_context_tokens`.
+
+llama.cpp builds through 2025 report mid-stream failures with a non-standard SSE `error:` field; Coddy understands both that dialect and the current `data: {"error": ...}` shape and surfaces the server's message in the error.
+
 For `type: codex`, open **Settings → LLM Providers** in the bundled web UI and select **Sign In with ChatGPT**, or run the terminal equivalent for ACP and headless setups:
 
 ```bash

--- a/features/llamacpp_openai_stream.feature
+++ b/features/llamacpp_openai_stream.feature
@@ -1,0 +1,26 @@
+Feature: llama.cpp server works as an OpenAI-compatible streaming provider
+  A "type: openai" provider pointed at a llama.cpp server must survive the
+  llama.cpp SSE dialect: keep-alive comments, empty data frames, and the
+  non-standard "error:" field used for mid-stream errors by 2025-era builds.
+  The real server message must reach the operator instead of the SSE
+  decoder's "unexpected end of JSON input".
+
+  Scenario: Streaming completion survives llama.cpp framing quirks
+    Given an "openai" provider pointed at a stub llama.cpp server streaming a completion with framing quirks
+    When a streaming completion is requested
+    Then the call succeeds with text "Hello from llama.cpp"
+    And the reasoning delta "Thinking." is streamed
+    And the stop reason is "end_turn"
+    And usage reports 12 input and 5 output tokens
+
+  Scenario: Streaming tool call survives llama.cpp framing quirks
+    Given an "openai" provider pointed at a stub llama.cpp server streaming a tool call
+    When a streaming completion is requested
+    Then the call succeeds with a "get_weather" tool call with arguments {"city":"Paris"}
+    And the stop reason is "tool_use"
+
+  Scenario: Mid-stream llama.cpp error frame surfaces the server message
+    Given an "openai" provider pointed at a stub llama.cpp server that fails mid-stream with an "error:" frame
+    When a streaming completion is requested
+    Then the call fails with an error containing "exceeds the available context size"
+    And the error does not contain "unexpected end of JSON input"

--- a/internal/llm/bdd_llamacpp_stream_test.go
+++ b/internal/llm/bdd_llamacpp_stream_test.go
@@ -1,0 +1,231 @@
+package llm
+
+// Godog harness for features/llamacpp_openai_stream.feature: exercises the real
+// OpenAI provider against a stub server replaying SSE captured from llama.cpp
+// builds (b5966 mid-stream "error:" frames, keep-alive comments, empty data
+// frames, b9038-style tool call and usage chunks).
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+// llamaCPPStreamScripts are verbatim SSE payloads in the llama.cpp dialect.
+// Frames were captured from real llama-server builds and trimmed to the
+// fields the provider consumes.
+var llamaCPPStreamScripts = map[string]string{
+	"streaming a completion with framing quirks": ": keep-alive\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null}}],\"created\":1786903885,\"id\":\"chatcmpl-x1\",\"model\":\"qwen3-1.7b\",\"system_fingerprint\":\"b5966-14c28dfc\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: \n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"reasoning_content\":\"Thinking.\"}}],\"created\":1786903885,\"id\":\"chatcmpl-x1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"content\":\"Hello from \"}}],\"created\":1786903885,\"id\":\"chatcmpl-x1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"content\":\"llama.cpp\"}}],\"created\":1786903885,\"id\":\"chatcmpl-x1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"delta\":{}}],\"created\":1786903885,\"id\":\"chatcmpl-x1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[],\"created\":1786903885,\"id\":\"chatcmpl-x1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\",\"usage\":{\"completion_tokens\":5,\"prompt_tokens\":12,\"total_tokens\":17,\"prompt_tokens_details\":{\"cached_tokens\":0}},\"timings\":{\"prompt_n\":12,\"predicted_n\":5}}\n\n" +
+		"data: [DONE]\n\n",
+
+	"streaming a tool call": "data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null}}],\"created\":1786903271,\"id\":\"chatcmpl-t1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]}}],\"created\":1786903271,\"id\":\"chatcmpl-t1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Par\"}}]}}],\"created\":1786903271,\"id\":\"chatcmpl-t1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"is\\\"}\"}}]}}],\"created\":1786903271,\"id\":\"chatcmpl-t1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[{\"finish_reason\":\"tool_calls\",\"index\":0,\"delta\":{}}],\"created\":1786903271,\"id\":\"chatcmpl-t1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"data: {\"choices\":[],\"created\":1786903271,\"id\":\"chatcmpl-t1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\",\"usage\":{\"completion_tokens\":87,\"prompt_tokens\":157,\"total_tokens\":244}}\n\n" +
+		"data: [DONE]\n\n",
+
+	"fails mid-stream with an \"error:\" frame": "data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null}}],\"created\":1786903885,\"id\":\"chatcmpl-e1\",\"model\":\"qwen3-1.7b\",\"object\":\"chat.completion.chunk\"}\n\n" +
+		"error: {\"code\":400,\"message\":\"the request exceeds the available context size. try increasing the context size or enable context shift\",\"type\":\"invalid_request_error\"}\n\n" +
+		"data: [DONE]\n\n",
+}
+
+type llamaCPPStreamState struct {
+	server   *httptest.Server
+	provider Provider
+	chunks   []StreamChunk
+	resp     *Response
+	callErr  error
+}
+
+func (s *llamaCPPStreamState) reset() {
+	s.cleanup()
+	s.provider = nil
+	s.chunks = nil
+	s.resp = nil
+	s.callErr = nil
+}
+
+func (s *llamaCPPStreamState) cleanup() {
+	if s.server != nil {
+		s.server.Close()
+		s.server = nil
+	}
+}
+
+func (s *llamaCPPStreamState) aProviderPointedAtStub(scenario string) error {
+	script, ok := llamaCPPStreamScripts[scenario]
+	if !ok {
+		return fmt.Errorf("unknown stub scenario %q", scenario)
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, script)
+	}))
+	provider, err := NewProvider(ProviderInput{
+		Type:          "openai",
+		Model:         "qwen3-1.7b",
+		BaseURL:       s.server.URL,
+		RetryMax:      1,
+		RetryBase:     time.Millisecond,
+		RetryMaxDelay: time.Millisecond,
+	})
+	if err != nil {
+		return fmt.Errorf("create openai provider: %w", err)
+	}
+	s.provider = provider
+	return nil
+}
+
+func (s *llamaCPPStreamState) aStreamingCompletionIsRequested() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	s.resp, s.callErr = s.provider.Stream(ctx,
+		[]Message{{Role: RoleUser, Content: "hello"}},
+		nil,
+		func(c StreamChunk) { s.chunks = append(s.chunks, c) })
+	return nil
+}
+
+func (s *llamaCPPStreamState) theCallSucceedsWithText(want string) error {
+	if s.callErr != nil {
+		return fmt.Errorf("provider call failed: %v", s.callErr)
+	}
+	if s.resp == nil || s.resp.Content != want {
+		return fmt.Errorf("content = %q, want %q", contentOf(s.resp), want)
+	}
+	return nil
+}
+
+func (s *llamaCPPStreamState) theReasoningDeltaIsStreamed(want string) error {
+	var reasoning strings.Builder
+	for _, c := range s.chunks {
+		reasoning.WriteString(c.ReasoningDelta)
+	}
+	if reasoning.String() != want {
+		return fmt.Errorf("reasoning deltas = %q, want %q", reasoning.String(), want)
+	}
+	return nil
+}
+
+func (s *llamaCPPStreamState) theStopReasonIs(want string) error {
+	if s.resp == nil {
+		return fmt.Errorf("no response (error: %v)", s.callErr)
+	}
+	if s.resp.StopReason != want {
+		return fmt.Errorf("stop reason = %q, want %q", s.resp.StopReason, want)
+	}
+	return nil
+}
+
+func (s *llamaCPPStreamState) usageReports(input, output int) error {
+	if s.resp == nil {
+		return fmt.Errorf("no response (error: %v)", s.callErr)
+	}
+	if s.resp.InputTokens != input || s.resp.OutputTokens != output {
+		return fmt.Errorf("usage = %d/%d, want %d/%d", s.resp.InputTokens, s.resp.OutputTokens, input, output)
+	}
+	return nil
+}
+
+func (s *llamaCPPStreamState) theCallSucceedsWithAToolCall(name, args string) error {
+	if s.callErr != nil {
+		return fmt.Errorf("provider call failed: %v", s.callErr)
+	}
+	if s.resp == nil || len(s.resp.ToolCalls) != 1 {
+		return fmt.Errorf("tool calls = %+v, want exactly one", toolCallsOf(s.resp))
+	}
+	tc := s.resp.ToolCalls[0]
+	if tc.Name != name || tc.InputJSON != args {
+		return fmt.Errorf("tool call = %q(%s), want %q(%s)", tc.Name, tc.InputJSON, name, args)
+	}
+	return nil
+}
+
+func (s *llamaCPPStreamState) theCallFailsWithErrorContaining(want string) error {
+	if s.callErr == nil {
+		return fmt.Errorf("provider call unexpectedly succeeded")
+	}
+	if !strings.Contains(s.callErr.Error(), want) {
+		return fmt.Errorf("error %q does not contain %q", s.callErr.Error(), want)
+	}
+	return nil
+}
+
+func (s *llamaCPPStreamState) theErrorDoesNotContain(text string) error {
+	if s.callErr == nil {
+		return fmt.Errorf("provider call unexpectedly succeeded")
+	}
+	if strings.Contains(s.callErr.Error(), text) {
+		return fmt.Errorf("error %q must not contain %q", s.callErr.Error(), text)
+	}
+	return nil
+}
+
+func contentOf(r *Response) string {
+	if r == nil {
+		return "<nil>"
+	}
+	return r.Content
+}
+
+func toolCallsOf(r *Response) []ToolCall {
+	if r == nil {
+		return nil
+	}
+	return r.ToolCalls
+}
+
+func initializeLlamaCPPStreamScenario(sc *godog.ScenarioContext) {
+	s := &llamaCPPStreamState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		s.reset()
+		return ctx, nil
+	})
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		s.cleanup()
+		return ctx, nil
+	})
+
+	sc.Step(`^an "openai" provider pointed at a stub llama\.cpp server (streaming a completion with framing quirks|streaming a tool call)$`, s.aProviderPointedAtStub)
+	sc.Step(`^an "openai" provider pointed at a stub llama\.cpp server that (fails mid-stream with an "error:" frame)$`, s.aProviderPointedAtStub)
+	sc.Step(`^a streaming completion is requested$`, s.aStreamingCompletionIsRequested)
+	sc.Step(`^the call succeeds with text "([^"]*)"$`, s.theCallSucceedsWithText)
+	sc.Step(`^the reasoning delta "([^"]*)" is streamed$`, s.theReasoningDeltaIsStreamed)
+	sc.Step(`^the stop reason is "([^"]*)"$`, s.theStopReasonIs)
+	sc.Step(`^usage reports (\d+) input and (\d+) output tokens$`, s.usageReports)
+	sc.Step(`^the call succeeds with a "([^"]*)" tool call with arguments (.+)$`, s.theCallSucceedsWithAToolCall)
+	sc.Step(`^the call fails with an error containing "([^"]*)"$`, s.theCallFailsWithErrorContaining)
+	sc.Step(`^the error does not contain "([^"]*)"$`, s.theErrorDoesNotContain)
+}
+
+func TestLlamaCPPOpenAIStreamFeature(t *testing.T) {
+	suite := godog.TestSuite{
+		Name:                "llamacpp-openai-stream",
+		ScenarioInitializer: initializeLlamaCPPStreamScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/llamacpp_openai_stream.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("llama.cpp OpenAI stream feature suite failed")
+	}
+}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -111,6 +111,101 @@ func TestNewProviderNeuralDeepIsSupported(t *testing.T) {
 	}
 }
 
+// streamStubProvider builds an unwrapped openai provider against a server
+// that replays the given SSE body for every request.
+func streamStubProvider(t *testing.T, sse string) (*openAIProvider, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	return newOpenAIProvider("qwen3-1.7b", "", srv.URL, nil, 0, 0, ""), srv.Close
+}
+
+// TestOpenAIStreamSkipsUndecodableFrame verifies that one malformed SSE data
+// frame between valid chunks does not abort the stream (lenient parsing).
+func TestOpenAIStreamSkipsUndecodableFrame(t *testing.T) {
+	p, done := streamStubProvider(t,
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel\"}}]}\n\n"+
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\n\n"+ // truncated JSON
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n"+
+			"data: [DONE]\n\n")
+	defer done()
+
+	resp, err := p.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if resp.Content != "Hello" {
+		t.Errorf("content = %q, want %q", resp.Content, "Hello")
+	}
+}
+
+// TestOpenAIStreamAllFramesUndecodable verifies that a stream yielding no
+// decodable chunk fails with the offending frame preserved in the error.
+func TestOpenAIStreamAllFramesUndecodable(t *testing.T) {
+	p, done := streamStubProvider(t, "data: {\"choices\":[{\"index\n\n"+"data: [DONE]\n\n")
+	defer done()
+
+	_, err := p.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
+	if err == nil {
+		t.Fatal("Stream must fail when no frame decodes")
+	}
+	if !strings.Contains(err.Error(), `{"choices":[{"index`) {
+		t.Errorf("error %q must include the undecodable frame payload", err)
+	}
+}
+
+// TestOpenAIStreamStandardErrorObject verifies that a data frame carrying an
+// {"error": ...} object (llama.cpp b9038+, gateways) surfaces the message.
+func TestOpenAIStreamStandardErrorObject(t *testing.T) {
+	p, done := streamStubProvider(t,
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"}}]}\n\n"+
+			"data: {\"error\":{\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}}\n\n")
+	defer done()
+
+	_, err := p.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
+	if err == nil || !strings.Contains(err.Error(), "slot unavailable") {
+		t.Fatalf("error = %v, want message containing %q", err, "slot unavailable")
+	}
+}
+
+// TestOpenAIStreamCancelKeepsPartial pins the cancellation contract: a stream
+// cancelled after emitting content returns the partial response together with
+// a context.Canceled-wrapped error.
+func TestOpenAIStreamCancelKeepsPartial(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"}}]}\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	p := newOpenAIProvider("qwen3-1.7b", "", srv.URL, nil, 0, 0, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel from inside onChunk so the first delta is observed deterministically
+	// before the context is torn down.
+	resp, err := p.Stream(ctx, []Message{{Role: RoleUser, Content: "hi"}}, nil, func(c StreamChunk) {
+		if c.TextDelta != "" {
+			cancel()
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if resp == nil || resp.Content != "partial" {
+		t.Fatalf("resp = %+v, want partial content preserved", resp)
+	}
+}
+
 // TestOpenAITextOnlyMessageIsString verifies that a user Message without
 // ImageParts still results in a plain string content field.
 func TestOpenAITextOnlyMessageIsString(t *testing.T) {

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestWrappedStreamCancelIsCanceled(t *testing.T) {
@@ -148,23 +149,27 @@ func TestOpenAIStreamUndecodableFrameFails(t *testing.T) {
 // reported inside the SSE stream retry like their pre-stream HTTP
 // equivalents: 5xx retryable, 4xx not.
 func TestOpenAIStreamedErrorRetryClassification(t *testing.T) {
+	const contentChunk = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel\"}}]}\n\n"
 	cases := []struct {
 		name         string
-		frame        string
+		body         string
 		wantRequests int32
+		wantDeltas   int32
 	}{
 		{"streamed 400 is not retried",
-			"error: {\"code\":400,\"message\":\"the request exceeds the available context size\",\"type\":\"invalid_request_error\"}\n\n", 1},
+			"error: {\"code\":400,\"message\":\"the request exceeds the available context size\",\"type\":\"invalid_request_error\"}\n\n", 1, 0},
 		{"streamed 500 is retried once",
-			"error: {\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}\n\n", 2},
+			"error: {\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}\n\n", 2, 0},
+		{"streamed 500 after emitted deltas is not retried",
+			contentChunk + "error: {\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}\n\n", 1, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var requests atomic.Int32
+			var requests, deltas atomic.Int32
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				requests.Add(1)
 				w.Header().Set("Content-Type", "text/event-stream")
-				_, _ = io.WriteString(w, tc.frame)
+				_, _ = io.WriteString(w, tc.body)
 			}))
 			defer srv.Close()
 
@@ -179,14 +184,92 @@ func TestOpenAIStreamedErrorRetryClassification(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewProvider: %v", err)
 			}
-			_, err = prov.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
+			_, err = prov.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(c StreamChunk) {
+				if c.TextDelta != "" {
+					deltas.Add(1)
+				}
+			})
 			if err == nil {
 				t.Fatal("Stream must fail")
 			}
 			if got := requests.Load(); got != tc.wantRequests {
 				t.Errorf("upstream requests = %d, want %d", got, tc.wantRequests)
 			}
+			if got := deltas.Load(); got != tc.wantDeltas {
+				t.Errorf("text deltas delivered = %d, want %d (retries must not replay deltas)", got, tc.wantDeltas)
+			}
 		})
+	}
+}
+
+// TestSSEScannerFrameAssembly pins the lenient scanner's frame handling:
+// SSE-spec behaviors (CRLF, multi-line data join, comments, leading BOM) and
+// the llama.cpp dialect ("error:" field, unterminated final frame).
+func TestSSEScannerFrameAssembly(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []sseFrame
+	}{
+		{"crlf line endings",
+			"data: {\"a\":1}\r\n\r\ndata: [DONE]\r\n\r\n",
+			[]sseFrame{{data: []byte("{\"a\":1}\n")}, {data: []byte("[DONE]\n")}}},
+		{"multiple data lines join with newline",
+			"data: line1\ndata: line2\n\n",
+			[]sseFrame{{data: []byte("line1\nline2\n")}}},
+		{"comment-only frames and blank runs are skipped",
+			": ping\n\n\n\n: pong\n\ndata: x\n\n",
+			[]sseFrame{{data: []byte("x\n")}}},
+		{"unterminated final frame is dispatched",
+			"data: {\"a\":1}\n\ndata: tail",
+			[]sseFrame{{data: []byte("{\"a\":1}\n")}, {data: []byte("tail\n")}}},
+		{"error field is preserved separately",
+			"error: {\"code\":400}\n\n",
+			[]sseFrame{{errData: []byte("{\"code\":400}\n")}}},
+		{"leading BOM is stripped",
+			"\xef\xbb\xbfdata: x\n\n",
+			[]sseFrame{{data: []byte("x\n")}}},
+		{"field without colon or value is harmless",
+			"data\n\ndata: x\n\n",
+			[]sseFrame{{data: []byte("\n")}, {data: []byte("x\n")}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := newSSEScanner(strings.NewReader(tc.input))
+			var got []sseFrame
+			for sc.Next() {
+				f := sc.Frame()
+				got = append(got, sseFrame{
+					data:    append([]byte(nil), f.data...),
+					errData: append([]byte(nil), f.errData...),
+				})
+			}
+			if err := sc.Err(); err != nil {
+				t.Fatalf("scanner error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("frames = %d, want %d (%q)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if string(got[i].data) != string(tc.want[i].data) || string(got[i].errData) != string(tc.want[i].errData) {
+					t.Errorf("frame %d = {data:%q err:%q}, want {data:%q err:%q}",
+						i, got[i].data, got[i].errData, tc.want[i].data, tc.want[i].errData)
+				}
+			}
+		})
+	}
+}
+
+// TestStreamErrorSnippetRuneBoundary verifies the diagnostic snippet never
+// splits a multibyte rune at the truncation point.
+func TestStreamErrorSnippetRuneBoundary(t *testing.T) {
+	payload := strings.Repeat("я", streamErrorSnippetLimit) // 2 bytes per rune
+	got := streamErrorSnippet([]byte(payload))
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("snippet must be truncated with ellipsis")
+	}
+	if !utf8.ValidString(strings.TrimSuffix(got, "...")) {
+		t.Errorf("snippet split a multibyte rune")
 	}
 }
 

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -122,9 +123,11 @@ func streamStubProvider(t *testing.T, sse string) (*openAIProvider, func()) {
 	return newOpenAIProvider("qwen3-1.7b", "", srv.URL, nil, 0, 0, ""), srv.Close
 }
 
-// TestOpenAIStreamSkipsUndecodableFrame verifies that one malformed SSE data
-// frame between valid chunks does not abort the stream (lenient parsing).
-func TestOpenAIStreamSkipsUndecodableFrame(t *testing.T) {
+// TestOpenAIStreamUndecodableFrameFails verifies that a malformed non-empty
+// data frame after valid chunks aborts the stream with the offending payload
+// preserved: silently skipping it would return a truncated response as
+// success.
+func TestOpenAIStreamUndecodableFrameFails(t *testing.T) {
 	p, done := streamStubProvider(t,
 		"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel\"}}]}\n\n"+
 			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\n\n"+ // truncated JSON
@@ -132,12 +135,58 @@ func TestOpenAIStreamSkipsUndecodableFrame(t *testing.T) {
 			"data: [DONE]\n\n")
 	defer done()
 
-	resp, err := p.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
-	if err != nil {
-		t.Fatalf("Stream: %v", err)
+	_, err := p.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
+	if err == nil {
+		t.Fatal("Stream must fail on a malformed non-empty data frame")
 	}
-	if resp.Content != "Hello" {
-		t.Errorf("content = %q, want %q", resp.Content, "Hello")
+	if !strings.Contains(err.Error(), "undecodable SSE frame") || !strings.Contains(err.Error(), `{"choices":[{"index":0,"delta":{"content":`) {
+		t.Errorf("error %q must name the undecodable frame and carry its payload", err)
+	}
+}
+
+// TestOpenAIStreamedErrorRetryClassification verifies that server errors
+// reported inside the SSE stream retry like their pre-stream HTTP
+// equivalents: 5xx retryable, 4xx not.
+func TestOpenAIStreamedErrorRetryClassification(t *testing.T) {
+	cases := []struct {
+		name         string
+		frame        string
+		wantRequests int32
+	}{
+		{"streamed 400 is not retried",
+			"error: {\"code\":400,\"message\":\"the request exceeds the available context size\",\"type\":\"invalid_request_error\"}\n\n", 1},
+		{"streamed 500 is retried once",
+			"error: {\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}\n\n", 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, tc.frame)
+			}))
+			defer srv.Close()
+
+			prov, err := NewProvider(ProviderInput{
+				Type:          "openai",
+				Model:         "qwen3-1.7b",
+				BaseURL:       srv.URL,
+				RetryMax:      1,
+				RetryBase:     time.Millisecond,
+				RetryMaxDelay: time.Millisecond,
+			})
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+			_, err = prov.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(StreamChunk) {})
+			if err == nil {
+				t.Fatal("Stream must fail")
+			}
+			if got := requests.Load(); got != tc.wantRequests {
+				t.Errorf("upstream requests = %d, want %d", got, tc.wantRequests)
+			}
+		})
 	}
 }
 

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -162,6 +162,8 @@ func TestOpenAIStreamedErrorRetryClassification(t *testing.T) {
 			"error: {\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}\n\n", 2, 0},
 		{"streamed 500 after emitted deltas is not retried",
 			contentChunk + "error: {\"code\":500,\"message\":\"slot unavailable\",\"type\":\"server_error\"}\n\n", 1, 1},
+		{"streamed 500 after deltas with status-like message text is not retried",
+			contentChunk + "error: {\"code\":500,\"message\":\"upstream said 500 Internal Server Error\",\"type\":\"server_error\"}\n\n", 1, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -263,7 +265,12 @@ func TestSSEScannerFrameAssembly(t *testing.T) {
 // TestStreamErrorSnippetRuneBoundary verifies the diagnostic snippet never
 // splits a multibyte rune at the truncation point.
 func TestStreamErrorSnippetRuneBoundary(t *testing.T) {
-	payload := strings.Repeat("я", streamErrorSnippetLimit) // 2 bytes per rune
+	// One ASCII byte shifts the 2-byte runes so the truncation index lands on
+	// a continuation byte and the boundary back-off is actually exercised.
+	payload := "a" + strings.Repeat("я", streamErrorSnippetLimit)
+	if utf8.RuneStart(payload[streamErrorSnippetLimit]) {
+		t.Fatal("test setup: truncation index must fall inside a rune")
+	}
 	got := streamErrorSnippet([]byte(payload))
 	if !strings.HasSuffix(got, "...") {
 		t.Fatalf("snippet must be truncated with ellipsis")

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
-	"github.com/tidwall/gjson"
 )
 
 // openAIProvider implements Provider using the OpenAI API (or compatible).
@@ -50,133 +48,6 @@ func (p *openAIProvider) Complete(ctx context.Context, messages []Message, tools
 		return nil, fmt.Errorf("openai complete: %w", err)
 	}
 	return p.parseCompletion(resp)
-}
-
-func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(StreamChunk)) (*Response, error) {
-	params := p.buildParams(messages, tools)
-	stream := p.client.Chat.Completions.NewStreaming(ctx, params)
-	defer func() { _ = stream.Close() }()
-
-	var fullContent string
-	var toolCalls []ToolCall
-	var stopReason string
-	var inputTokens, outputTokens int
-
-	// Accumulate tool call deltas by index.
-	type tcBuilder struct {
-		id   string
-		name string
-		args string
-	}
-	builders := make(map[int]*tcBuilder)
-
-	finalizeOpenAIToolBuilders := func() []ToolCall {
-		var out []ToolCall
-		for i := 0; i < len(builders); i++ {
-			b, ok := builders[i]
-			if !ok {
-				continue
-			}
-			out = append(out, ToolCall{ID: b.id, Name: b.name, InputJSON: b.args})
-		}
-		return out
-	}
-
-	for stream.Next() {
-		chunk := stream.Current()
-		if len(chunk.Choices) == 0 {
-			continue
-		}
-		choice := chunk.Choices[0]
-
-		if choice.FinishReason != "" {
-			stopReason = mapOpenAIStopReason(string(choice.FinishReason))
-		}
-
-		delta := choice.Delta
-
-		if delta.Content != "" {
-			fullContent += delta.Content
-			onChunk(StreamChunk{TextDelta: delta.Content})
-		}
-
-		raw := delta.RawJSON()
-		if raw != "" {
-			r := gjson.Get(raw, "reasoning_content").String()
-			if r == "" {
-				r = gjson.Get(raw, "thinking").String()
-			}
-			if r != "" {
-				onChunk(StreamChunk{ReasoningDelta: r})
-			}
-		}
-
-		for _, tc := range delta.ToolCalls {
-			idx := int(tc.Index)
-			if _, ok := builders[idx]; !ok {
-				builders[idx] = &tcBuilder{}
-			}
-			b := builders[idx]
-			if tc.ID != "" {
-				b.id = tc.ID
-			}
-			if tc.Function.Name != "" {
-				b.name = tc.Function.Name
-			}
-			b.args += tc.Function.Arguments
-		}
-
-		if chunk.Usage.TotalTokens > 0 {
-			inputTokens = int(chunk.Usage.PromptTokens)
-			outputTokens = int(chunk.Usage.CompletionTokens)
-		}
-	}
-
-	if err := stream.Err(); err != nil {
-		if errors.Is(err, context.Canceled) {
-			toolCalls = finalizeOpenAIToolBuilders()
-			if strings.TrimSpace(fullContent) != "" || len(toolCalls) > 0 {
-				sr := stopReason
-				if sr == "" {
-					if len(toolCalls) > 0 {
-						sr = "tool_use"
-					} else {
-						sr = "end_turn"
-					}
-				}
-				return &Response{
-					Content:      fullContent,
-					ToolCalls:    toolCalls,
-					StopReason:   sr,
-					InputTokens:  inputTokens,
-					OutputTokens: outputTokens,
-				}, fmt.Errorf("openai stream: %w", err)
-			}
-		}
-		return nil, fmt.Errorf("openai stream: %w", err)
-	}
-
-	toolCalls = finalizeOpenAIToolBuilders()
-	for i := range toolCalls {
-		tc := toolCalls[i]
-		onChunk(StreamChunk{ToolCall: &tc})
-	}
-
-	if stopReason == "" {
-		if len(toolCalls) > 0 {
-			stopReason = "tool_use"
-		} else {
-			stopReason = "end_turn"
-		}
-	}
-
-	return &Response{
-		Content:      fullContent,
-		ToolCalls:    toolCalls,
-		StopReason:   stopReason,
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
-	}, nil
 }
 
 func (p *openAIProvider) buildParams(messages []Message, tools []ToolDefinition) openai.ChatCompletionNewParams {

--- a/internal/llm/openai_stream.go
+++ b/internal/llm/openai_stream.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -42,15 +43,16 @@ const sseMaxScanSize = bufio.MaxScanTokenSize << 9
 // "error:" field is preserved, and frames with no payload are skipped instead
 // of being dispatched as empty JSON documents.
 type sseScanner struct {
-	scn *bufio.Scanner
-	cur sseFrame
-	err error
+	scn   *bufio.Scanner
+	cur   sseFrame
+	err   error
+	first bool
 }
 
 func newSSEScanner(r io.Reader) *sseScanner {
 	scn := bufio.NewScanner(r)
 	scn.Buffer(nil, sseMaxScanSize)
-	return &sseScanner{scn: scn}
+	return &sseScanner{scn: scn, first: true}
 }
 
 // Next advances to the next non-empty frame. It returns false at end of
@@ -71,6 +73,11 @@ func (s *sseScanner) Next() bool {
 	}
 	for s.scn.Scan() {
 		line := s.scn.Bytes()
+		if s.first {
+			// The EventSource spec strips one leading U+FEFF BOM.
+			line = bytes.TrimPrefix(line, []byte("\xef\xbb\xbf"))
+			s.first = false
+		}
 		if len(line) == 0 {
 			if flush() {
 				return true
@@ -113,19 +120,26 @@ const streamErrorSnippetLimit = 2048
 
 func streamErrorSnippet(payload []byte) string {
 	s := strings.TrimSpace(string(payload))
-	if len(s) > streamErrorSnippetLimit {
-		return s[:streamErrorSnippetLimit] + "..."
+	if len(s) <= streamErrorSnippetLimit {
+		return s
 	}
-	return s
+	cut := streamErrorSnippetLimit
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
 }
 
 // streamServerError is a failure the server reported inside an SSE stream.
 // It keeps the HTTP-style status code structurally so retry classification
 // (httpStatusFromError) treats streamed errors like their pre-stream
-// equivalents: 5xx retryable, 4xx not.
+// equivalents: 5xx retryable, 4xx not. emitted records whether chunks were
+// already delivered to the caller before the failure: retrying such a call
+// would stream the same deltas twice, so classification refuses the code.
 type streamServerError struct {
-	code int
-	msg  string
+	code    int
+	msg     string
+	emitted bool
 }
 
 func (e *streamServerError) Error() string {
@@ -138,12 +152,12 @@ func (e *streamServerError) Error() string {
 // newStreamServerError parses a server-reported streaming failure. obj is
 // the error object ({"code":400,"message":"...","type":"..."} for llama.cpp)
 // or any other payload the server put in the error frame.
-func newStreamServerError(obj []byte) error {
+func newStreamServerError(obj []byte, emitted bool) error {
 	msg := gjson.GetBytes(obj, "message").String()
 	if msg == "" {
 		msg = streamErrorSnippet(obj)
 	}
-	return &streamServerError{code: int(gjson.GetBytes(obj, "code").Int()), msg: msg}
+	return &streamServerError{code: int(gjson.GetBytes(obj, "code").Int()), msg: msg, emitted: emitted}
 }
 
 // Stream implements Provider.Stream over the lenient SSE path.
@@ -182,6 +196,15 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 		return out
 	}
 
+	// emitted flips once any chunk reached the caller; a retry after that
+	// would deliver the same deltas twice, so streamed server errors carry
+	// it to disable retry classification.
+	var emitted bool
+	emit := func(c StreamChunk) {
+		emitted = true
+		onChunk(c)
+	}
+
 	scanner := newSSEScanner(raw.Body)
 	var streamErr error
 	var done bool
@@ -191,7 +214,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 
 		if payload := bytes.TrimSpace(frame.errData); len(payload) > 0 {
 			// llama.cpp <= 2025 mid-stream error frame ("error: {...}").
-			streamErr = newStreamServerError(payload)
+			streamErr = newStreamServerError(payload, emitted)
 			break
 		}
 
@@ -208,7 +231,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 		}
 		if e := gjson.GetBytes(payload, "error"); e.Exists() && e.Type != gjson.Null {
 			// Standard-shaped in-band error object (llama.cpp b9038+, gateways).
-			streamErr = newStreamServerError([]byte(e.Raw))
+			streamErr = newStreamServerError([]byte(e.Raw), emitted)
 			break
 		}
 
@@ -238,7 +261,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 
 		if delta.Content != "" {
 			fullContent += delta.Content
-			onChunk(StreamChunk{TextDelta: delta.Content})
+			emit(StreamChunk{TextDelta: delta.Content})
 		}
 
 		if raw := delta.RawJSON(); raw != "" {
@@ -247,7 +270,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 				r = gjson.Get(raw, "thinking").String()
 			}
 			if r != "" {
-				onChunk(StreamChunk{ReasoningDelta: r})
+				emit(StreamChunk{ReasoningDelta: r})
 			}
 		}
 
@@ -303,7 +326,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 	toolCalls = finalizeOpenAIToolBuilders()
 	for i := range toolCalls {
 		tc := toolCalls[i]
-		onChunk(StreamChunk{ToolCall: &tc})
+		emit(StreamChunk{ToolCall: &tc})
 	}
 
 	if stopReason == "" {

--- a/internal/llm/openai_stream.go
+++ b/internal/llm/openai_stream.go
@@ -1,0 +1,315 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/tidwall/gjson"
+)
+
+// OpenAI-compatible servers deviate from the OpenAI SSE shape in ways the
+// openai-go decoder does not tolerate: llama.cpp builds through 2025 report
+// mid-stream failures with a non-standard "error:" SSE field, and servers or
+// proxies may interleave keep-alive comments and empty data frames. The SDK
+// decoder turns every such frame into an empty JSON document and aborts the
+// whole stream with "unexpected end of JSON input", hiding the real server
+// message (issue #104). This file owns the lenient SSE path used instead:
+// the request still goes through the SDK client (auth, base URL, params
+// encoding, HTTP error mapping), but frames are decoded here.
+
+// sseFrame is one server-sent event accumulated from the wire.
+type sseFrame struct {
+	// data is the newline-joined payload of "data:" lines.
+	data []byte
+	// errData is the payload of the non-standard "error:" field
+	// (llama.cpp <= 2025 mid-stream errors).
+	errData []byte
+}
+
+// sseMaxScanSize mirrors the openai-go decoder buffer cap (32 MiB).
+const sseMaxScanSize = bufio.MaxScanTokenSize << 9
+
+// sseScanner reads SSE frames leniently: comments are dropped, the llama.cpp
+// "error:" field is preserved, and frames with no payload are skipped instead
+// of being dispatched as empty JSON documents.
+type sseScanner struct {
+	scn *bufio.Scanner
+	cur sseFrame
+	err error
+}
+
+func newSSEScanner(r io.Reader) *sseScanner {
+	scn := bufio.NewScanner(r)
+	scn.Buffer(nil, sseMaxScanSize)
+	return &sseScanner{scn: scn}
+}
+
+// Next advances to the next non-empty frame. It returns false at end of
+// stream or on transport error (see Err).
+func (s *sseScanner) Next() bool {
+	if s.err != nil {
+		return false
+	}
+	var data, errData bytes.Buffer
+	flush := func() bool {
+		if data.Len() == 0 && errData.Len() == 0 {
+			// Nothing accumulated: comment-only frame or a run of blank
+			// lines. Skip instead of dispatching an empty document.
+			return false
+		}
+		s.cur = sseFrame{data: data.Bytes(), errData: errData.Bytes()}
+		return true
+	}
+	for s.scn.Scan() {
+		line := s.scn.Bytes()
+		if len(line) == 0 {
+			if flush() {
+				return true
+			}
+			data.Reset()
+			errData.Reset()
+			continue
+		}
+		name, value, _ := bytes.Cut(line, []byte(":"))
+		if len(value) > 0 && value[0] == ' ' {
+			value = value[1:]
+		}
+		switch string(name) {
+		case "": // comment line (": keep-alive")
+		case "data":
+			data.Write(value)
+			data.WriteByte('\n')
+		case "error":
+			errData.Write(value)
+			errData.WriteByte('\n')
+		}
+	}
+	s.err = s.scn.Err()
+	// A final frame not terminated by a blank line is still dispatched, like
+	// browsers do, so a server that closes right after the last payload is
+	// not silently truncated.
+	if s.err == nil && flush() {
+		return true
+	}
+	return false
+}
+
+func (s *sseScanner) Frame() sseFrame { return s.cur }
+
+func (s *sseScanner) Err() error { return s.err }
+
+// streamErrorSnippetLimit bounds how much of an undecodable frame is carried
+// into the returned error for diagnostics.
+const streamErrorSnippetLimit = 2048
+
+func streamErrorSnippet(payload []byte) string {
+	s := strings.TrimSpace(string(payload))
+	if len(s) > streamErrorSnippetLimit {
+		return s[:streamErrorSnippetLimit] + "..."
+	}
+	return s
+}
+
+// newStreamServerError formats a server-reported streaming failure. obj is
+// the error object ({"code":400,"message":"...","type":"..."} for llama.cpp)
+// or any other payload the server put in the error frame.
+func newStreamServerError(obj []byte) error {
+	msg := gjson.GetBytes(obj, "message").String()
+	if msg == "" {
+		msg = streamErrorSnippet(obj)
+	}
+	if code := gjson.GetBytes(obj, "code").Int(); code > 0 {
+		return fmt.Errorf("server error %d: %s", code, msg)
+	}
+	return fmt.Errorf("server error: %s", msg)
+}
+
+// Stream implements Provider.Stream over the lenient SSE path.
+func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(StreamChunk)) (*Response, error) {
+	params := p.buildParams(messages, tools)
+
+	var raw *http.Response
+	err := p.client.Post(ctx, "chat/completions", params, &raw, option.WithJSONSet("stream", true))
+	if err != nil {
+		return nil, fmt.Errorf("openai stream: %w", err)
+	}
+	defer func() { _ = raw.Body.Close() }()
+
+	var fullContent string
+	var toolCalls []ToolCall
+	var stopReason string
+	var inputTokens, outputTokens int
+
+	// Accumulate tool call deltas by index.
+	type tcBuilder struct {
+		id   string
+		name string
+		args string
+	}
+	builders := make(map[int]*tcBuilder)
+
+	finalizeOpenAIToolBuilders := func() []ToolCall {
+		var out []ToolCall
+		for i := 0; i < len(builders); i++ {
+			b, ok := builders[i]
+			if !ok {
+				continue
+			}
+			out = append(out, ToolCall{ID: b.id, Name: b.name, InputJSON: b.args})
+		}
+		return out
+	}
+
+	scanner := newSSEScanner(raw.Body)
+	var streamErr error
+	var done, decodedAny bool
+	var lastBadFrame string
+
+	for scanner.Next() {
+		frame := scanner.Frame()
+
+		if payload := bytes.TrimSpace(frame.errData); len(payload) > 0 {
+			// llama.cpp <= 2025 mid-stream error frame ("error: {...}").
+			streamErr = newStreamServerError(payload)
+			break
+		}
+
+		payload := bytes.TrimSpace(frame.data)
+		if len(payload) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(payload, []byte("[DONE]")) {
+			done = true
+			continue
+		}
+		if done {
+			continue
+		}
+		if e := gjson.GetBytes(payload, "error"); e.Exists() && e.Type != gjson.Null {
+			// Standard-shaped in-band error object (llama.cpp b9038+, gateways).
+			streamErr = newStreamServerError([]byte(e.Raw))
+			break
+		}
+
+		var chunk openai.ChatCompletionChunk
+		if err := json.Unmarshal(payload, &chunk); err != nil {
+			// Tolerate one broken frame the way JS SSE clients do; keep the
+			// payload so a fully undecodable stream still yields diagnostics.
+			lastBadFrame = streamErrorSnippet(payload)
+			continue
+		}
+		decodedAny = true
+
+		if len(chunk.Choices) == 0 {
+			if chunk.Usage.TotalTokens > 0 {
+				inputTokens = int(chunk.Usage.PromptTokens)
+				outputTokens = int(chunk.Usage.CompletionTokens)
+			}
+			continue
+		}
+		choice := chunk.Choices[0]
+
+		if choice.FinishReason != "" {
+			stopReason = mapOpenAIStopReason(string(choice.FinishReason))
+		}
+
+		delta := choice.Delta
+
+		if delta.Content != "" {
+			fullContent += delta.Content
+			onChunk(StreamChunk{TextDelta: delta.Content})
+		}
+
+		if raw := delta.RawJSON(); raw != "" {
+			r := gjson.Get(raw, "reasoning_content").String()
+			if r == "" {
+				r = gjson.Get(raw, "thinking").String()
+			}
+			if r != "" {
+				onChunk(StreamChunk{ReasoningDelta: r})
+			}
+		}
+
+		for _, tc := range delta.ToolCalls {
+			idx := int(tc.Index)
+			if _, ok := builders[idx]; !ok {
+				builders[idx] = &tcBuilder{}
+			}
+			b := builders[idx]
+			if tc.ID != "" {
+				b.id = tc.ID
+			}
+			if tc.Function.Name != "" {
+				b.name = tc.Function.Name
+			}
+			b.args += tc.Function.Arguments
+		}
+
+		if chunk.Usage.TotalTokens > 0 {
+			inputTokens = int(chunk.Usage.PromptTokens)
+			outputTokens = int(chunk.Usage.CompletionTokens)
+		}
+	}
+
+	if streamErr == nil {
+		streamErr = scanner.Err()
+	}
+	if streamErr == nil && !decodedAny && lastBadFrame != "" {
+		streamErr = fmt.Errorf("undecodable SSE frame: %s", lastBadFrame)
+	}
+
+	if streamErr != nil {
+		if errors.Is(streamErr, context.Canceled) {
+			toolCalls = finalizeOpenAIToolBuilders()
+			if strings.TrimSpace(fullContent) != "" || len(toolCalls) > 0 {
+				sr := stopReason
+				if sr == "" {
+					if len(toolCalls) > 0 {
+						sr = "tool_use"
+					} else {
+						sr = "end_turn"
+					}
+				}
+				return &Response{
+					Content:      fullContent,
+					ToolCalls:    toolCalls,
+					StopReason:   sr,
+					InputTokens:  inputTokens,
+					OutputTokens: outputTokens,
+				}, fmt.Errorf("openai stream: %w", streamErr)
+			}
+		}
+		return nil, fmt.Errorf("openai stream: %w", streamErr)
+	}
+
+	toolCalls = finalizeOpenAIToolBuilders()
+	for i := range toolCalls {
+		tc := toolCalls[i]
+		onChunk(StreamChunk{ToolCall: &tc})
+	}
+
+	if stopReason == "" {
+		if len(toolCalls) > 0 {
+			stopReason = "tool_use"
+		} else {
+			stopReason = "end_turn"
+		}
+	}
+
+	return &Response{
+		Content:      fullContent,
+		ToolCalls:    toolCalls,
+		StopReason:   stopReason,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+	}, nil
+}

--- a/internal/llm/openai_stream.go
+++ b/internal/llm/openai_stream.go
@@ -119,7 +119,23 @@ func streamErrorSnippet(payload []byte) string {
 	return s
 }
 
-// newStreamServerError formats a server-reported streaming failure. obj is
+// streamServerError is a failure the server reported inside an SSE stream.
+// It keeps the HTTP-style status code structurally so retry classification
+// (httpStatusFromError) treats streamed errors like their pre-stream
+// equivalents: 5xx retryable, 4xx not.
+type streamServerError struct {
+	code int
+	msg  string
+}
+
+func (e *streamServerError) Error() string {
+	if e.code > 0 {
+		return fmt.Sprintf("server error %d: %s", e.code, e.msg)
+	}
+	return "server error: " + e.msg
+}
+
+// newStreamServerError parses a server-reported streaming failure. obj is
 // the error object ({"code":400,"message":"...","type":"..."} for llama.cpp)
 // or any other payload the server put in the error frame.
 func newStreamServerError(obj []byte) error {
@@ -127,10 +143,7 @@ func newStreamServerError(obj []byte) error {
 	if msg == "" {
 		msg = streamErrorSnippet(obj)
 	}
-	if code := gjson.GetBytes(obj, "code").Int(); code > 0 {
-		return fmt.Errorf("server error %d: %s", code, msg)
-	}
-	return fmt.Errorf("server error: %s", msg)
+	return &streamServerError{code: int(gjson.GetBytes(obj, "code").Int()), msg: msg}
 }
 
 // Stream implements Provider.Stream over the lenient SSE path.
@@ -171,8 +184,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 
 	scanner := newSSEScanner(raw.Body)
 	var streamErr error
-	var done, decodedAny bool
-	var lastBadFrame string
+	var done bool
 
 	for scanner.Next() {
 		frame := scanner.Frame()
@@ -202,12 +214,12 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 
 		var chunk openai.ChatCompletionChunk
 		if err := json.Unmarshal(payload, &chunk); err != nil {
-			// Tolerate one broken frame the way JS SSE clients do; keep the
-			// payload so a fully undecodable stream still yields diagnostics.
-			lastBadFrame = streamErrorSnippet(payload)
-			continue
+			// A non-empty data frame that is not JSON means the stream is
+			// corrupt; failing silently here would truncate the response.
+			// Carry the payload so the operator sees what the server sent.
+			streamErr = fmt.Errorf("undecodable SSE frame: %s", streamErrorSnippet(payload))
+			break
 		}
-		decodedAny = true
 
 		if len(chunk.Choices) == 0 {
 			if chunk.Usage.TotalTokens > 0 {
@@ -262,9 +274,6 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 
 	if streamErr == nil {
 		streamErr = scanner.Err()
-	}
-	if streamErr == nil && !decodedAny && lastBadFrame != "" {
-		streamErr = fmt.Errorf("undecodable SSE frame: %s", lastBadFrame)
 	}
 
 	if streamErr != nil {

--- a/internal/llm/resilient.go
+++ b/internal/llm/resilient.go
@@ -206,7 +206,10 @@ func httpStatusFromError(err error) int {
 		return oai.StatusCode
 	}
 	var sse *streamServerError
-	if errors.As(err, &sse) && sse.code > 0 {
+	if errors.As(err, &sse) && sse.code > 0 && !sse.emitted {
+		// A streamed error after chunks already reached the caller must not
+		// classify as retryable: replaying the request would emit the same
+		// deltas a second time.
 		return sse.code
 	}
 	var ant *anthropic.Error

--- a/internal/llm/resilient.go
+++ b/internal/llm/resilient.go
@@ -206,10 +206,15 @@ func httpStatusFromError(err error) int {
 		return oai.StatusCode
 	}
 	var sse *streamServerError
-	if errors.As(err, &sse) && sse.code > 0 && !sse.emitted {
-		// A streamed error after chunks already reached the caller must not
-		// classify as retryable: replaying the request would emit the same
-		// deltas a second time.
+	if errors.As(err, &sse) {
+		// The typed streamed error is authoritative: no fallthrough to the
+		// substring matcher below, whose needles could occur inside the
+		// server-provided message text. After chunks already reached the
+		// caller the error must not classify as retryable at all: replaying
+		// the request would emit the same deltas a second time.
+		if sse.emitted {
+			return 0
+		}
 		return sse.code
 	}
 	var ant *anthropic.Error

--- a/internal/llm/resilient.go
+++ b/internal/llm/resilient.go
@@ -205,6 +205,10 @@ func httpStatusFromError(err error) int {
 	if errors.As(err, &oai) && oai.StatusCode > 0 {
 		return oai.StatusCode
 	}
+	var sse *streamServerError
+	if errors.As(err, &sse) && sse.code > 0 {
+		return sse.code
+	}
 	var ant *anthropic.Error
 	if errors.As(err, &ant) && ant.StatusCode > 0 {
 		return ant.StatusCode


### PR DESCRIPTION
Closes #104.

## Root cause

llama.cpp builds through 2025 (verified on b5966; the code survives until the late-2025 server refactor) report mid-stream failures as a **non-standard SSE field** at HTTP 200:

```
error: {"code":400,"message":"the request exceeds the available context size. try increasing the context size or enable context shift","type":"invalid_request_error"}

data: [DONE]
```

The openai-go decoder understands only `event:`/`data:` fields, silently drops the `error:` line, and dispatches an **empty event** at the frame boundary. `json.Unmarshal` of an empty payload then kills the whole stream with `unexpected end of JSON input`, hiding the real server message. Keep-alive comment frames (`: ping`) and empty `data:` frames poison the SDK decoder the same way.

In the reporter's setup every prompt overflowed the server context (agent system prompt > `n_ctx` with context shift off), so every prompt died with the cryptic error. Reproduced end-to-end with the exact log line from the issue:

```
level=ERROR msg="responses prompt" error="LLM error: openai stream: unexpected end of JSON input"
```

Current llama.cpp (b9038) sends mid-stream errors as standard `data: {"error": ...}` frames and rejects oversized prompts pre-stream, so it never hit this path - but the 2025 install base does.

## Fix

`type: openai` streaming now goes through a coddy-owned lenient SSE reader (`internal/llm/openai_stream.go`). The request itself still uses the SDK client (auth, base URL, params encoding with extra fields, proxy, non-2xx → `*openai.Error` mapping are unchanged - the call mirrors `NewStreaming` internals). Decoding changes:

- llama.cpp `error:` frames and standard in-band `{"error": ...}` objects surface as `server error <code>: <message>`;
- comment-only frames, blank-line runs, and empty `data:` frames are skipped instead of failing the stream;
- an unterminated final frame is still dispatched (EventSource parity), a single leading BOM is stripped;
- a malformed non-empty `data:` frame fails the stream **with the payload preserved in the error** (bounded to 2 KB, rune-safe) - this is the issue's "log the raw frame" ask, delivered where the operator actually looks;
- streamed server errors retry like their pre-stream HTTP equivalents (5xx retryable, 4xx not) via a typed `streamServerError`, **except** when deltas already reached the caller - retrying then would duplicate streamed text in the session, so classification refuses it (found by cross-review);
- cancellation still returns partial content with a `context.Canceled`-wrapped error (pinned by test).

`docs/config-reference.md` gains a llama.cpp section: `--jinja` is required for tool calling (without it llama.cpp silently ignores `tools`), plus context sizing guidance.

## Tests

- `features/llamacpp_openai_stream.feature` + godog harness `internal/llm/bdd_llamacpp_stream_test.go`: stub server replays **verbatim SSE captured from real llama-server b5966/b9038** - framing-quirks completion, streaming tool call, mid-stream `error:` frame;
- unit tests in `internal/llm/llm_test.go`: scanner frame assembly (CRLF, multi-line data join, comments, unterminated final frame, `error:` field, BOM), undecodable-frame failure with payload, standard error object, retry classification (streamed 400 → 1 request; streamed 500 → 2; streamed 500 after emitted deltas → 1, no delta replay; status-like text inside the message must not re-enable retry), cancel-keeps-partial, snippet rune boundary.

## Verification

- `make test` full matrix green, `make lint` 0 issues.
- Live on real llama-server (gpu03, Qwen3-1.7B Q8_0):
  - **b5966 poison setup** (`-c 1024 --jinja --no-context-shift`): before → `LLM error: openai stream: unexpected end of JSON input`; after → `LLM error: openai stream: server error 400: the request exceeds the available context size. try increasing the context size or enable context shift`;
  - **b5966 healthy** (`-c 16384 --jinja`): full agent turn with a real tool call (file read verified in the session transcript) and with reasoning enabled (`chat_template_kwargs` accepted; the issue's hypothesis about it did not confirm);
  - **b9038 current**: same agent turn green;
  - **cloud OpenAI-compatible gateway** (litellm → gpt-oss:120b): agent turn with tool call green - no regression on the non-llama.cpp path.

## Cross-review

Reviewed by Codex `gpt-5.6-sol` (2 findings: string-matched retry status never matched the streamed format; unbounded malformed-frame skipping could silently truncate a response) and Cursor `grok-4.6` (MAJOR: retrying a streamed 5xx after emitted deltas replays the same text into the session; plus the substring-matcher fallthrough that message text could re-trigger). All findings fixed in dedicated commits; both reviewers formally APPROVED the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
