### PR TITLE
Fix provider name HTML pattern validation

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -21,7 +21,7 @@
           "name": {
             "type": "string",
             "description": "Logical id used as the first segment of models[].model. ASCII letters, digits, hyphen, underscore; must start with a letter.",
-            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_\\-]*$"
           },
           "type": {
             "type": "string",

--- a/external/httpserver/server_test.go
+++ b/external/httpserver/server_test.go
@@ -1813,6 +1813,13 @@ agent:
 	if sch["type"] != "object" {
 		t.Fatalf("schema root type %v", sch["type"])
 	}
+	providers := sch["properties"].(map[string]interface{})["providers"].(map[string]interface{})
+	items := providers["items"].(map[string]interface{})
+	properties := items["properties"].(map[string]interface{})
+	providerName := properties["name"].(map[string]interface{})
+	if got, want := providerName["pattern"], `^[a-zA-Z][a-zA-Z0-9_\-]*$`; got != want {
+		t.Fatalf("provider name pattern: got %v want %v", got, want)
+	}
 
 	jbody := `{"providers":[{"name":"openai","type":"openai","api_key":"k"}],"models":[{"model":"openai/gpt-4o","max_tokens":4096,"temperature":0.1}],"agent":{"model":"openai/gpt-4o","max_turns":12}}`
 	vreq, _ := http.NewRequest(http.MethodPost, ts.URL+"/coddy/config/validate", strings.NewReader(jbody))

--- a/internal/config/docs_schema_test.go
+++ b/internal/config/docs_schema_test.go
@@ -127,6 +127,21 @@ func TestDocsConfigSchemaMatchesStructs(t *testing.T) {
 	checkSchemaNodeMatchesType(t, "$", reflect.TypeOf(Config{}), doc)
 }
 
+// TestDocsConfigSchemaProviderNamePatternUsesHTMLVCompatibleHyphen ensures the
+// published schema can be used directly as an HTML pattern attribute. Modern
+// browsers compile such patterns with the RegExp v flag, which requires a
+// literal hyphen in a character class to be escaped.
+func TestDocsConfigSchemaProviderNamePatternUsesHTMLVCompatibleHyphen(t *testing.T) {
+	doc := loadDocsSchema(t)
+	providers := doc["properties"].(map[string]interface{})["providers"].(map[string]interface{})
+	items := providers["items"].(map[string]interface{})
+	properties := items["properties"].(map[string]interface{})
+	name := properties["name"].(map[string]interface{})
+	if got, want := name["pattern"], `^[a-zA-Z][a-zA-Z0-9_\-]*$`; got != want {
+		t.Fatalf("provider name pattern: got %v want %v", got, want)
+	}
+}
+
 // TestDocsConfigSchemaEnums pins schema enums to the constants the loader validates against.
 func TestDocsConfigSchemaEnums(t *testing.T) {
 	doc := loadDocsSchema(t)

--- a/internal/config/jsondto_schema_test.go
+++ b/internal/config/jsondto_schema_test.go
@@ -37,7 +37,7 @@ func TestUISchemaProviderNamePatternAndAPIKeyPlaceholderHint(t *testing.T) {
 	items := providers["items"].(map[string]interface{})
 	pprops := items["properties"].(map[string]interface{})
 	name := pprops["name"].(map[string]interface{})
-	if got, want := name["pattern"], `^[a-zA-Z][a-zA-Z0-9_-]*$`; got != want {
+	if got, want := name["pattern"], `^[a-zA-Z][a-zA-Z0-9_\-]*$`; got != want {
 		t.Fatalf("provider name pattern: got %v want %v", got, want)
 	}
 	apiKey := pprops["api_key"].(map[string]interface{})

--- a/internal/config/ui_schema.go
+++ b/internal/config/ui_schema.go
@@ -180,7 +180,9 @@ func ensureObjectMatchesSchema(obj map[string]interface{}, schemaProps map[strin
 func UISchemaMap() map[string]interface{} {
 	providerName := strProp("Provider name",
 		"Logical id used in model ids (provider/model-id). ASCII letters, digits, hyphen, and underscore only; must start with a letter. When api_key is empty, the runtime reads the key from the environment variable NAME_API_KEY (NAME is this field in uppercase with hyphens mapped to underscores).")
-	providerName["pattern"] = `^[a-zA-Z][a-zA-Z0-9_-]*$`
+	// HTML pattern attributes are compiled with the JavaScript RegExp v flag.
+	// Escape the hyphen so the schema can be rendered by modern browsers.
+	providerName["pattern"] = `^[a-zA-Z][a-zA-Z0-9_\-]*$`
 	providerAPIKey := strProp("API key",
 		"You may set a literal key, reference ${ENV} in YAML (expanded when the file is loaded), or leave empty so the process reads the conventional NAME_API_KEY variable derived from the provider name (see provider name description).")
 	providerAPIKey["x-coddy-provider-api-key-env-placeholder"] = true


### PR DESCRIPTION
## Summary

- Escape the provider-name hyphen in the runtime UI schema and published configuration schema.
- Cover the served schema and static schema with regression tests.

## Root cause

Modern browsers compile HTML `pattern` values with the JavaScript `v` flag. An unescaped hyphen in the character class therefore made the provider-name input pattern invalid.

## Validation

- `go test ./internal/config -run 'Test(UISchemaProviderNamePatternAndAPIKeyPlaceholderHint|TestDocsConfigSchemaProviderNamePatternUsesHTMLVCompatibleHyphen|TestDocsConfigSchemaMatchesStructs)' -count=1`
- `go test -tags='http,ui' ./external/httpserver -run TestCoddyConfigSchemaValidateAndPut -count=1`
- `go build -tags='http ui' -o build/coddy.exe ./cmd/coddy`
- Browser check: the new pattern compiles with `v`, accepts `provider-name`, and rejects a leading digit.
- `golangci-lint run ./...` (0 issues)

The complete Go suite is currently blocked by the unrelated Windows failure in `internal/skills.TestSkillReadonly`.
