### PR TITLE
Fix Windows self-update with helper

### DIFF
--- a/.github/workflows/tests-on-pr.yaml
+++ b/.github/workflows/tests-on-pr.yaml
@@ -63,9 +63,10 @@ jobs:
   # Cross-building proves the Windows code compiles, not that it works. These
   # packages own the behaviour that differs by platform - the process group
   # probe, the console shell, the background task pool that starts real
-  # processes through it - and their Windows-only tests have no other place to
-  # run. The scope is deliberately narrow; widen it as the rest of the tree is
-  # shown to hold on Windows.
+  # processes through it, the self-update helper that replaces a running
+  # coddy.exe - and their Windows-only tests have no other place to run. The
+  # scope is deliberately narrow; widen it as the rest of the tree is shown to
+  # hold on Windows.
   test-windows:
     name: Test suite (Windows)
     runs-on: windows-latest
@@ -81,7 +82,7 @@ jobs:
           cache: true
 
       - name: Run platform tests
-        run: go test ./internal/platform/... ./internal/bgtask/... ./internal/tools/shell/...
+        run: go test ./internal/platform/... ./internal/bgtask/... ./internal/tools/shell/... ./internal/update/...
 
       - name: Run console TUI tests (fake terminal, no pty)
         run: go test -tags=cli ./external/cli/...

--- a/cmd/coddy/main.go
+++ b/cmd/coddy/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/EvilFreelancer/coddy-agent/internal/rules"
 	"github.com/EvilFreelancer/coddy-agent/internal/session"
 	"github.com/EvilFreelancer/coddy-agent/internal/skills"
+	"github.com/EvilFreelancer/coddy-agent/internal/update"
 	"github.com/EvilFreelancer/coddy-agent/internal/version"
 )
 
@@ -67,6 +68,13 @@ func (r *serverRef) RequestQuestion(ctx context.Context, params acp.QuestionRequ
 }
 
 func main() {
+	if handled, err := update.RunHelper(os.Args[1:], os.Stdout); handled {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
 	if len(os.Args) >= 2 {
 		a := os.Args[1]
 		if a == "-v" || a == "--version" {

--- a/cmd/coddy/update.go
+++ b/cmd/coddy/update.go
@@ -20,6 +20,7 @@ func runUpdate(args []string) error {
 	fs.BoolVar(&yes, "yes", false, "install without confirmation (same as -y)")
 	version := fs.String("version", "", "install a specific release tag (X.Y.Z) instead of latest")
 	repo := fs.String("repo", update.DefaultRepo, "GitHub repository owner/name for releases")
+	noRestart := fs.Bool("no-restart", false, "Windows only: install the update but do not start Coddy again")
 	fs.Usage = func() {
 		_, _ = fmt.Fprintf(fs.Output(), "Usage of update:\n")
 		fs.PrintDefaults()
@@ -36,6 +37,7 @@ func runUpdate(args []string) error {
 		TargetVersion: strings.TrimSpace(*version),
 		CheckOnly:     *check,
 		Yes:           yes,
+		NoRestart:     *noRestart,
 		Stdout:        os.Stdout,
 	})
 	if errors.Is(err, update.ErrUpdateAvailable) {

--- a/docs/update.md
+++ b/docs/update.md
@@ -2,6 +2,8 @@
 
 Use **`coddy update`** to download official release binaries from [GitHub Releases](https://github.com/coddy-project/coddy-agent/releases) and replace the **`coddy`** executable you are running.
 
+On Windows, Coddy starts a short-lived helper from the system temporary directory. The helper waits for `coddy update` to exit, keeps a backup of the installed executable, replaces it, and starts the updated Coddy again. The helper's status lines continue in the same `cmd.exe` or PowerShell console after the `update` command returns.
+
 ## What gets installed
 
 CI publishes one archive per platform on each SemVer tag **`X.Y.Z`**:
@@ -77,6 +79,7 @@ coddy update --help
 ## Limitations
 
 - Only platforms listed in the release table are supported; others get a clear error.
-- On Windows the running process may lock the executable; close other **`coddy`** instances if replace fails.
+- On Windows, Coddy retries a transient executable lock for 30 seconds. If the update cannot be installed, the current executable is left in place. If the updated binary cannot be started, Coddy restores the backup.
+- Asset downloads resume after a temporary connection failure (up to three attempts). GitHub supports the HTTP range requests Coddy uses to resume; a server that does not support ranges is downloaded again from the beginning.
 - **`coddy update`** needs outbound HTTPS to **`api.github.com`** and the asset CDN (GitHub release downloads).
 - Config under **`$CODDY_HOME`** is not modified; only the binary is replaced.

--- a/docs/update.md
+++ b/docs/update.md
@@ -2,7 +2,9 @@
 
 Use **`coddy update`** to download official release binaries from [GitHub Releases](https://github.com/coddy-project/coddy-agent/releases) and replace the **`coddy`** executable you are running.
 
-On Windows, Coddy starts a short-lived helper from the system temporary directory. The helper waits for `coddy update` to exit, keeps a backup of the installed executable, replaces it, and starts the updated Coddy again. The helper's status lines continue in the same `cmd.exe` or PowerShell console after the `update` command returns.
+On Windows, Coddy starts a short-lived helper from the system temporary directory. The helper waits for `coddy update` to exit, keeps a backup of the installed executable, replaces it, and starts the updated Coddy again. The helper's status lines continue in the same `cmd.exe` or PowerShell console after the `update` command returns, so `coddy update` reports success once the download is staged, not once the swap has happened.
+
+Every download is checked against the `SHA256SUMS` asset the release publishes before anything is unpacked or installed. A release without that asset is reported and installed anyway.
 
 ## What gets installed
 
@@ -56,6 +58,12 @@ Override the GitHub repository (default **`coddy-project/coddy-agent`**):
 coddy update --repo coddy-project/coddy-agent
 ```
 
+Install on Windows without starting Coddy again afterwards - useful from a script or a CI step, where the restarted process has no console to run in:
+
+```bash
+coddy update -y --no-restart
+```
+
 All flags:
 
 ```bash
@@ -79,7 +87,8 @@ coddy update --help
 ## Limitations
 
 - Only platforms listed in the release table are supported; others get a clear error.
-- On Windows, Coddy retries a transient executable lock for 30 seconds. If the update cannot be installed, the current executable is left in place. If the updated binary cannot be started, Coddy restores the backup.
-- Asset downloads resume after a temporary connection failure (up to three attempts). GitHub supports the HTTP range requests Coddy uses to resume; a server that does not support ranges is downloaded again from the beginning.
+- On Windows, Coddy waits up to 30 seconds for another process to release the executable. A permission failure reports much sooner and names the directory: installing into `Program Files` needs an elevated console. If the update cannot be installed, the current executable is left in place; if the updated binary cannot be started, Coddy restores the backup.
+- The Windows helper deletes itself through the Coddy it just installed. Installing a release older than that handoff - `coddy update --version` walking backwards - starts the older build directly instead, and its helper stays in `%TEMP%` until the next `coddy update` sweeps it.
+- Asset downloads resume after a temporary connection failure (up to three attempts). GitHub supports the HTTP range requests Coddy uses to resume; a server that does not support ranges is downloaded again from the beginning, and one that resumes at the wrong offset fails the download rather than installing a spliced archive.
 - **`coddy update`** needs outbound HTTPS to **`api.github.com`** and the asset CDN (GitHub release downloads).
 - Config under **`$CODDY_HOME`** is not modified; only the binary is replaced.

--- a/features/update.feature
+++ b/features/update.feature
@@ -1,0 +1,8 @@
+Feature: Windows self-update
+  Coddy must be able to replace its own executable after the current process exits.
+
+  Scenario: Scheduling a downloaded Windows update
+    Given a newer Windows Coddy release is available
+    When Coddy prepares the Windows update
+    Then it reports that the update is ready
+    And it schedules a helper that will restart Coddy

--- a/features/update.feature
+++ b/features/update.feature
@@ -1,8 +1,33 @@
-Feature: Windows self-update
-  Coddy must be able to replace its own executable after the current process exits.
+Feature: Coddy self-update
+  Coddy downloads an official release archive and replaces the executable it is
+  running with the binary inside it.
+
+  Scenario: Installing a newer release
+    Given a newer Coddy release is available
+    When Coddy installs the update
+    Then the installed executable is the one from the release
+    And Coddy reports the release it installed
+
+  Scenario: Verifying the download against the published checksums
+    Given a newer Coddy release is available
+    When Coddy installs the update
+    Then Coddy reports that it verified the archive against the published checksums
+
+  Scenario: Resuming a download the server cut short
+    Given a newer Coddy release is available
+    And the download server drops the first connection halfway
+    When Coddy installs the update
+    Then the installed executable is the one from the release
+    And Coddy reports that it resumed the download
 
   Scenario: Scheduling a downloaded Windows update
     Given a newer Windows Coddy release is available
     When Coddy prepares the Windows update
     Then it reports that the update is ready
     And it schedules a helper that will restart Coddy
+
+  Scenario: Installing a Windows update without starting Coddy again
+    Given a newer Windows Coddy release is available
+    When Coddy prepares the Windows update with --no-restart
+    Then it reports that the update is ready
+    And it schedules a helper that will leave Coddy stopped

--- a/features/update_windows.feature
+++ b/features/update_windows.feature
@@ -1,0 +1,32 @@
+Feature: Windows self-update helper
+  Windows refuses to replace coddy.exe while that executable is running, so
+  `coddy update` stages the new binary and hands the swap to a helper copied
+  into the system temporary directory. The helper waits for the original
+  process to exit, installs the update, and starts Coddy again.
+
+  Scenario: Installing the staged update once the original Coddy has exited
+    Given a staged Coddy update next to the installed executable
+    When the update helper installs it
+    Then the installed executable is the staged one
+    And the helper leaves no staging or backup files behind
+    And the helper hands the restart the path of the helper to delete
+
+  Scenario: Installing without a restart still clears the helper away
+    Given a staged Coddy update next to the installed executable
+    And the update is installed without starting Coddy again
+    When the update helper installs it
+    Then the installed executable is the staged one
+    And the helper hands the cleanup over without starting Coddy
+
+  Scenario: Restarting a release that predates the restart handoff
+    Given a staged Coddy update next to the installed executable
+    And the staged release does not understand the restart handoff
+    When the update helper installs it
+    Then the installed executable is the staged one
+    And the helper starts Coddy without the handoff
+
+  Scenario: Clearing a helper an earlier update left behind
+    Given an update helper left in the system temporary directory
+    When Coddy sweeps helpers from earlier updates
+    Then the helper left by the earlier update is gone
+    And unrelated files in the temporary directory are untouched

--- a/internal/update/archive.go
+++ b/internal/update/archive.go
@@ -13,14 +13,22 @@ import (
 )
 
 func installFromArchive(data []byte, archiveName, destPath string) error {
+	body, err := executableFromArchive(data, archiveName)
+	if err != nil {
+		return err
+	}
+	return writeExecutable(destPath, body)
+}
+
+func executableFromArchive(data []byte, archiveName string) ([]byte, error) {
 	lower := strings.ToLower(archiveName)
 	switch {
 	case strings.HasSuffix(lower, ".tar.gz"):
-		return installFromTarGz(data, BinaryName(runtimeGOOSFromArchive(archiveName)), destPath)
+		return executableFromTarGz(data, BinaryName(runtimeGOOSFromArchive(archiveName)))
 	case strings.HasSuffix(lower, ".zip"):
-		return installFromZip(data, "coddy.exe", destPath)
+		return executableFromZip(data, "coddy.exe")
 	default:
-		return fmt.Errorf("unsupported archive %q", archiveName)
+		return nil, fmt.Errorf("unsupported archive %q", archiveName)
 	}
 }
 
@@ -31,10 +39,10 @@ func runtimeGOOSFromArchive(name string) string {
 	return "linux"
 }
 
-func installFromTarGz(data []byte, binName, destPath string) error {
+func executableFromTarGz(data []byte, binName string) ([]byte, error) {
 	zr, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = zr.Close() }()
 	tr := tar.NewReader(zr)
@@ -44,7 +52,7 @@ func installFromTarGz(data []byte, binName, destPath string) error {
 			break
 		}
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if hdr.Typeflag != tar.TypeReg {
 			continue
@@ -55,17 +63,17 @@ func installFromTarGz(data []byte, binName, destPath string) error {
 		}
 		body, err := io.ReadAll(io.LimitReader(tr, 128<<20))
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return writeExecutable(destPath, body)
+		return body, nil
 	}
-	return fmt.Errorf("archive missing %q", binName)
+	return nil, fmt.Errorf("archive missing %q", binName)
 }
 
-func installFromZip(data []byte, binName, destPath string) error {
+func executableFromZip(data []byte, binName string) ([]byte, error) {
 	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, f := range zr.File {
 		if filepath.Base(f.Name) != binName {
@@ -73,26 +81,38 @@ func installFromZip(data []byte, binName, destPath string) error {
 		}
 		rc, err := f.Open()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		body, err := io.ReadAll(io.LimitReader(rc, 128<<20))
 		_ = rc.Close()
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return writeExecutable(destPath, body)
+		return body, nil
 	}
-	return fmt.Errorf("archive missing %q", binName)
+	return nil, fmt.Errorf("archive missing %q", binName)
 }
 
 func writeExecutable(dest string, body []byte) error {
+	tmpName, err := stageExecutable(dest, body)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+func stageExecutable(dest string, body []byte) (string, error) {
 	dir := filepath.Dir(dest)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
+		return "", err
 	}
 	tmp, err := os.CreateTemp(dir, ".coddy-update-*")
 	if err != nil {
-		return err
+		return "", err
 	}
 	tmpName := tmp.Name()
 	cleanup := true
@@ -103,18 +123,15 @@ func writeExecutable(dest string, body []byte) error {
 	}()
 	if _, err := tmp.Write(body); err != nil {
 		_ = tmp.Close()
-		return err
+		return "", err
 	}
 	if err := tmp.Chmod(0o755); err != nil {
 		_ = tmp.Close()
-		return err
+		return "", err
 	}
 	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpName, dest); err != nil {
-		return err
+		return "", err
 	}
 	cleanup = false
-	return nil
+	return tmpName, nil
 }

--- a/internal/update/bdd_update_test.go
+++ b/internal/update/bdd_update_test.go
@@ -1,0 +1,146 @@
+package update
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+type updateFeatureState struct {
+	archive   []byte
+	server    *httptest.Server
+	dir       string
+	out       bytes.Buffer
+	scheduled *windowsUpdateRequest
+}
+
+func (s *updateFeatureState) reset() {
+	if s.server != nil {
+		s.server.Close()
+	}
+	*s = updateFeatureState{}
+}
+
+func (s *updateFeatureState) newerWindowsReleaseIsAvailable() error {
+	var archive bytes.Buffer
+	zw := zip.NewWriter(&archive)
+	w, err := zw.Create("coddy.exe")
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("new Windows Coddy")); err != nil {
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	s.archive = archive.Bytes()
+	s.dir, err = os.MkdirTemp("", "coddy-update-feature-*")
+	if err != nil {
+		return err
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/coddy-project/coddy-agent/releases/latest":
+			_, _ = fmt.Fprintf(w, `{"tag_name":"0.9.70","assets":[{"name":"coddy_0.9.70_windows_amd64.zip","browser_download_url":"http://%s/asset.zip"}]}`, r.Host)
+		case "/asset.zip":
+			_, _ = w.Write(s.archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return nil
+}
+
+func (s *updateFeatureState) coddyPreparesTheWindowsUpdate() error {
+	dest := filepath.Join(s.dir, "coddy.exe")
+	if err := os.WriteFile(dest, []byte("old Windows Coddy"), 0o755); err != nil {
+		return err
+	}
+	return Run(context.Background(), Options{
+		APIBase:        s.server.URL,
+		Repo:           DefaultRepo,
+		CurrentVersion: "0.9.67",
+		GOOS:           "windows",
+		GOARCH:         "amd64",
+		InstallPath:    dest,
+		Yes:            true,
+		Stdout:         &s.out,
+		windowsInstaller: func(req windowsUpdateRequest) error {
+			s.scheduled = &req
+			return nil
+		},
+	})
+}
+
+func (s *updateFeatureState) updateIsReady() error {
+	if !strings.Contains(s.out.String(), "Update downloaded") {
+		return fmt.Errorf("output does not report a ready update: %q", s.out.String())
+	}
+	return nil
+}
+
+func (s *updateFeatureState) helperWillRestartCoddy() error {
+	if s.scheduled == nil {
+		return fmt.Errorf("no helper was scheduled")
+	}
+	defer func() { _ = os.Remove(s.scheduled.StagedPath) }()
+	if !s.scheduled.Restart {
+		return fmt.Errorf("helper restart = false")
+	}
+	if s.scheduled.TargetPath != filepath.Join(s.dir, "coddy.exe") {
+		return fmt.Errorf("helper target = %q", s.scheduled.TargetPath)
+	}
+	got, err := os.ReadFile(s.scheduled.StagedPath)
+	if err != nil {
+		return err
+	}
+	if string(got) != "new Windows Coddy" {
+		return fmt.Errorf("staged binary = %q", got)
+	}
+	return nil
+}
+
+func TestUpdateFeature(t *testing.T) {
+	s := &updateFeatureState{}
+	t.Cleanup(func() {
+		dir := s.dir
+		s.reset()
+		if dir != "" {
+			_ = os.RemoveAll(dir)
+		}
+	})
+
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(context.Context, *godog.Scenario) (context.Context, error) {
+				dir := s.dir
+				s.reset()
+				if dir != "" {
+					_ = os.RemoveAll(dir)
+				}
+				return context.Background(), nil
+			})
+			sc.Step(`^a newer Windows Coddy release is available$`, s.newerWindowsReleaseIsAvailable)
+			sc.Step(`^Coddy prepares the Windows update$`, s.coddyPreparesTheWindowsUpdate)
+			sc.Step(`^it reports that the update is ready$`, s.updateIsReady)
+			sc.Step(`^it schedules a helper that will restart Coddy$`, s.helperWillRestartCoddy)
+		},
+		Options: &godog.Options{
+			Format: "progress",
+			Paths:  []string{"../../features/update.feature"},
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("update feature failed")
+	}
+}

--- a/internal/update/bdd_update_test.go
+++ b/internal/update/bdd_update_test.go
@@ -1,59 +1,91 @@
 package update
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cucumber/godog"
 )
 
+const (
+	featureReleaseTag = "0.9.70"
+	featurePayload    = "the release build of Coddy"
+)
+
 type updateFeatureState struct {
 	archive   []byte
-	server    *httptest.Server
+	assetName string
+	goarch    string
+	goos      string
+	dest      string
 	dir       string
+	dropFirst bool
+	served    int
 	out       bytes.Buffer
 	scheduled *windowsUpdateRequest
+	server    *httptest.Server
 }
 
 func (s *updateFeatureState) reset() {
 	if s.server != nil {
 		s.server.Close()
 	}
+	if s.dir != "" {
+		_ = os.RemoveAll(s.dir)
+	}
 	*s = updateFeatureState{}
 }
 
-func (s *updateFeatureState) newerWindowsReleaseIsAvailable() error {
-	var archive bytes.Buffer
-	zw := zip.NewWriter(&archive)
-	w, err := zw.Create("coddy.exe")
+// releaseIsAvailable stands up a GitHub-shaped release: the platform archive
+// plus the SHA256SUMS list CI publishes beside it.
+func (s *updateFeatureState) releaseIsAvailable(goos, goarch string) error {
+	assetName, err := AssetFileName(featureReleaseTag, goos, goarch)
 	if err != nil {
 		return err
 	}
-	if _, err := w.Write([]byte("new Windows Coddy")); err != nil {
+	s.goos, s.goarch, s.assetName = goos, goarch, assetName
+	if goos == "windows" {
+		s.archive, err = zipArchive("coddy.exe", []byte(featurePayload))
+	} else {
+		s.archive, err = tarGzArchive(BinaryName(goos), []byte(featurePayload))
+	}
+	if err != nil {
 		return err
 	}
-	if err := zw.Close(); err != nil {
-		return err
-	}
-	s.archive = archive.Bytes()
+
 	s.dir, err = os.MkdirTemp("", "coddy-update-feature-*")
 	if err != nil {
 		return err
 	}
+	s.dest = filepath.Join(s.dir, BinaryName(goos))
+	if err := os.WriteFile(s.dest, []byte("the installed build of Coddy"), 0o755); err != nil {
+		return err
+	}
+
+	sum := sha256.Sum256(s.archive)
+	sums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/repos/coddy-project/coddy-agent/releases/latest":
-			_, _ = fmt.Fprintf(w, `{"tag_name":"0.9.70","assets":[{"name":"coddy_0.9.70_windows_amd64.zip","browser_download_url":"http://%s/asset.zip"}]}`, r.Host)
-		case "/asset.zip":
-			_, _ = w.Write(s.archive)
+		case "/repos/" + DefaultRepo + "/releases/latest":
+			_, _ = fmt.Fprintf(w, `{"tag_name":%q,"assets":[{"name":%q,"browser_download_url":"http://%s/asset"},{"name":%q,"browser_download_url":"http://%s/sums"}]}`,
+				featureReleaseTag, assetName, r.Host, checksumAssetName, r.Host)
+		case "/asset":
+			s.serveAsset(w, r)
+		case "/sums":
+			_, _ = w.Write([]byte(sums))
 		default:
 			http.NotFound(w, r)
 		}
@@ -61,79 +93,179 @@ func (s *updateFeatureState) newerWindowsReleaseIsAvailable() error {
 	return nil
 }
 
-func (s *updateFeatureState) coddyPreparesTheWindowsUpdate() error {
-	dest := filepath.Join(s.dir, "coddy.exe")
-	if err := os.WriteFile(dest, []byte("old Windows Coddy"), 0o755); err != nil {
-		return err
+// serveAsset answers the archive request, honouring a Range header the way the
+// release CDN does, and optionally cutting the first response short so the
+// resume path has something real to recover from.
+func (s *updateFeatureState) serveAsset(w http.ResponseWriter, r *http.Request) {
+	s.served++
+	if s.dropFirst && s.served == 1 {
+		w.Header().Set("Content-Length", strconv.Itoa(len(s.archive)))
+		_, _ = w.Write(s.archive[:len(s.archive)/2])
+		return
 	}
-	return Run(context.Background(), Options{
+	offset := 0
+	if spec := strings.TrimPrefix(r.Header.Get("Range"), "bytes="); spec != r.Header.Get("Range") {
+		start, _, _ := strings.Cut(spec, "-")
+		parsed, err := strconv.Atoi(start)
+		if err != nil || parsed < 0 || parsed > len(s.archive) {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		offset = parsed
+	}
+	if offset > 0 {
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, len(s.archive)-1, len(s.archive)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(s.archive)-offset))
+		w.WriteHeader(http.StatusPartialContent)
+	}
+	_, _ = w.Write(s.archive[offset:])
+}
+
+func (s *updateFeatureState) newerReleaseIsAvailable() error {
+	// Deliberately not the host platform: this scenario is about the ordinary
+	// replace-in-place install, which Windows routes through the helper.
+	return s.releaseIsAvailable("linux", "amd64")
+}
+
+func (s *updateFeatureState) newerWindowsReleaseIsAvailable() error {
+	return s.releaseIsAvailable("windows", "amd64")
+}
+
+func (s *updateFeatureState) serverDropsTheFirstConnection() error {
+	s.dropFirst = true
+	return nil
+}
+
+func (s *updateFeatureState) options() Options {
+	return Options{
 		APIBase:        s.server.URL,
 		Repo:           DefaultRepo,
 		CurrentVersion: "0.9.67",
-		GOOS:           "windows",
-		GOARCH:         "amd64",
-		InstallPath:    dest,
+		GOOS:           s.goos,
+		GOARCH:         s.goarch,
+		InstallPath:    s.dest,
 		Yes:            true,
 		Stdout:         &s.out,
-		windowsInstaller: func(req windowsUpdateRequest) error {
-			s.scheduled = &req
-			return nil
-		},
-	})
+	}
+}
+
+func (s *updateFeatureState) coddyInstallsTheUpdate() error {
+	return Run(context.Background(), s.options())
+}
+
+func (s *updateFeatureState) coddyPreparesTheWindowsUpdate() error {
+	return s.prepareWindowsUpdate(false)
+}
+
+func (s *updateFeatureState) coddyPreparesTheWindowsUpdateWithoutRestart() error {
+	return s.prepareWindowsUpdate(true)
+}
+
+func (s *updateFeatureState) prepareWindowsUpdate(noRestart bool) error {
+	opts := s.options()
+	opts.NoRestart = noRestart
+	opts.windowsInstaller = func(req windowsUpdateRequest) error {
+		s.scheduled = &req
+		return nil
+	}
+	return Run(context.Background(), opts)
+}
+
+func (s *updateFeatureState) installedExecutableIsFromTheRelease() error {
+	got, err := os.ReadFile(s.dest)
+	if err != nil {
+		return err
+	}
+	if string(got) != featurePayload {
+		return fmt.Errorf("installed executable = %q, want %q", got, featurePayload)
+	}
+	return nil
+}
+
+func (s *updateFeatureState) reports(want string) error {
+	if !strings.Contains(s.out.String(), want) {
+		return fmt.Errorf("output does not contain %q: %q", want, s.out.String())
+	}
+	return nil
+}
+
+func (s *updateFeatureState) reportsTheInstalledRelease() error {
+	return s.reports("Installed " + featureReleaseTag)
+}
+
+func (s *updateFeatureState) reportsAVerifiedArchive() error {
+	return s.reports(fmt.Sprintf("Verified %s against %s", s.assetName, checksumAssetName))
+}
+
+func (s *updateFeatureState) reportsAResumedDownload() error {
+	return s.reports("resuming, attempt 2 of 3")
 }
 
 func (s *updateFeatureState) updateIsReady() error {
-	if !strings.Contains(s.out.String(), "Update downloaded") {
-		return fmt.Errorf("output does not report a ready update: %q", s.out.String())
+	return s.reports("Update downloaded")
+}
+
+func (s *updateFeatureState) helperWillLeaveCoddyStopped() error {
+	if err := s.helperWasScheduled(); err != nil {
+		return err
+	}
+	if s.scheduled.Restart {
+		return fmt.Errorf("helper restart = true, want the update installed without one")
 	}
 	return nil
 }
 
 func (s *updateFeatureState) helperWillRestartCoddy() error {
+	if err := s.helperWasScheduled(); err != nil {
+		return err
+	}
+	if !s.scheduled.Restart {
+		return fmt.Errorf("helper restart = false")
+	}
+	return nil
+}
+
+func (s *updateFeatureState) helperWasScheduled() error {
 	if s.scheduled == nil {
 		return fmt.Errorf("no helper was scheduled")
 	}
 	defer func() { _ = os.Remove(s.scheduled.StagedPath) }()
-	if !s.scheduled.Restart {
-		return fmt.Errorf("helper restart = false")
-	}
-	if s.scheduled.TargetPath != filepath.Join(s.dir, "coddy.exe") {
-		return fmt.Errorf("helper target = %q", s.scheduled.TargetPath)
+	if s.scheduled.TargetPath != s.dest {
+		return fmt.Errorf("helper target = %q, want %q", s.scheduled.TargetPath, s.dest)
 	}
 	got, err := os.ReadFile(s.scheduled.StagedPath)
 	if err != nil {
 		return err
 	}
-	if string(got) != "new Windows Coddy" {
-		return fmt.Errorf("staged binary = %q", got)
+	if string(got) != featurePayload {
+		return fmt.Errorf("staged binary = %q, want %q", got, featurePayload)
 	}
 	return nil
 }
 
 func TestUpdateFeature(t *testing.T) {
 	s := &updateFeatureState{}
-	t.Cleanup(func() {
-		dir := s.dir
-		s.reset()
-		if dir != "" {
-			_ = os.RemoveAll(dir)
-		}
-	})
+	t.Cleanup(s.reset)
 
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(sc *godog.ScenarioContext) {
-			sc.Before(func(context.Context, *godog.Scenario) (context.Context, error) {
-				dir := s.dir
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
 				s.reset()
-				if dir != "" {
-					_ = os.RemoveAll(dir)
-				}
-				return context.Background(), nil
+				return ctx, nil
 			})
+			sc.Step(`^a newer Coddy release is available$`, s.newerReleaseIsAvailable)
 			sc.Step(`^a newer Windows Coddy release is available$`, s.newerWindowsReleaseIsAvailable)
+			sc.Step(`^the download server drops the first connection halfway$`, s.serverDropsTheFirstConnection)
+			sc.Step(`^Coddy installs the update$`, s.coddyInstallsTheUpdate)
 			sc.Step(`^Coddy prepares the Windows update$`, s.coddyPreparesTheWindowsUpdate)
+			sc.Step(`^Coddy prepares the Windows update with --no-restart$`, s.coddyPreparesTheWindowsUpdateWithoutRestart)
+			sc.Step(`^the installed executable is the one from the release$`, s.installedExecutableIsFromTheRelease)
+			sc.Step(`^Coddy reports the release it installed$`, s.reportsTheInstalledRelease)
+			sc.Step(`^Coddy reports that it verified the archive against the published checksums$`, s.reportsAVerifiedArchive)
+			sc.Step(`^Coddy reports that it resumed the download$`, s.reportsAResumedDownload)
 			sc.Step(`^it reports that the update is ready$`, s.updateIsReady)
 			sc.Step(`^it schedules a helper that will restart Coddy$`, s.helperWillRestartCoddy)
+			sc.Step(`^it schedules a helper that will leave Coddy stopped$`, s.helperWillLeaveCoddyStopped)
 		},
 		Options: &godog.Options{
 			Format: "progress",
@@ -143,4 +275,39 @@ func TestUpdateFeature(t *testing.T) {
 	if suite.Run() != 0 {
 		t.Fatal("update feature failed")
 	}
+}
+
+func zipArchive(name string, body []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := w.Write(body); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func tarGzArchive(name string, body []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(body); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/update/bdd_update_windows_test.go
+++ b/internal/update/bdd_update_windows_test.go
@@ -1,0 +1,229 @@
+//go:build windows
+
+package update
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+const (
+	helperFeatureStaged    = "the staged build of Coddy"
+	helperFeatureInstalled = "the installed build of Coddy"
+)
+
+type helperFeatureState struct {
+	dir       string
+	staged    string
+	target    string
+	orphan    string
+	bystander string
+	handoff   bool
+	restart   bool
+	started   []string
+	out       bytes.Buffer
+
+	restoreProbe func(string) bool
+	restoreStart func(string, ...string) error
+}
+
+func (s *helperFeatureState) reset() {
+	if s.restoreProbe != nil {
+		restartProbe = s.restoreProbe
+	}
+	if s.restoreStart != nil {
+		startProcess = s.restoreStart
+	}
+	if s.dir != "" {
+		_ = os.RemoveAll(s.dir)
+	}
+	for _, path := range []string{s.orphan, s.bystander} {
+		if path != "" {
+			_ = os.Remove(path)
+		}
+	}
+	*s = helperFeatureState{}
+}
+
+// stubRestart replaces the two calls that reach outside the process, so the
+// scenarios can watch how the helper hands the restart over without starting a
+// real executable.
+func (s *helperFeatureState) stubRestart() {
+	s.restoreProbe, s.restoreStart = restartProbe, startProcess
+	s.handoff = true
+	s.restart = true
+	restartProbe = func(string) bool { return s.handoff }
+	startProcess = func(target string, args ...string) error {
+		s.started = append(s.started, strings.Join(append([]string{target}, args...), " "))
+		return nil
+	}
+}
+
+func (s *helperFeatureState) stagedUpdateNextToTheExecutable() error {
+	dir, err := os.MkdirTemp("", "coddy-helper-feature-*")
+	if err != nil {
+		return err
+	}
+	s.dir = dir
+	s.target = filepath.Join(dir, "coddy.exe")
+	s.staged = filepath.Join(dir, ".coddy-update-staged")
+	if err := os.WriteFile(s.target, []byte(helperFeatureInstalled), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(s.staged, []byte(helperFeatureStaged), 0o755); err != nil {
+		return err
+	}
+	s.stubRestart()
+	return nil
+}
+
+func (s *helperFeatureState) stagedReleasePredatesTheHandoff() error {
+	s.handoff = false
+	return nil
+}
+
+func (s *helperFeatureState) updateSkipsTheRestart() error {
+	s.restart = false
+	return nil
+}
+
+func (s *helperFeatureState) helperInstallsTheUpdate() error {
+	req := windowsUpdateRequest{
+		ParentPID:  os.Getpid(),
+		Restart:    s.restart,
+		StagedPath: s.staged,
+		TargetPath: s.target,
+	}
+	return installWindowsUpdate(req, filepath.Join(os.TempDir(), helperPrefix+"feature.exe"), &s.out)
+}
+
+func (s *helperFeatureState) installedExecutableIsTheStagedOne() error {
+	got, err := os.ReadFile(s.target)
+	if err != nil {
+		return err
+	}
+	if string(got) != helperFeatureStaged {
+		return fmt.Errorf("installed executable = %q, want %q", got, helperFeatureStaged)
+	}
+	return nil
+}
+
+func (s *helperFeatureState) noLeftoversRemain() error {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Name() != "coddy.exe" {
+			return fmt.Errorf("install directory still holds %q", entry.Name())
+		}
+	}
+	return nil
+}
+
+func (s *helperFeatureState) restartCarriesTheHelperPath() error {
+	if len(s.started) != 1 {
+		return fmt.Errorf("started %d processes, want 1: %v", len(s.started), s.started)
+	}
+	if !strings.Contains(s.started[0], restartAfterUpdateCommand) || !strings.Contains(s.started[0], helperPrefix) {
+		return fmt.Errorf("restart command = %q", s.started[0])
+	}
+	return nil
+}
+
+func (s *helperFeatureState) cleanupHappensWithoutARestart() error {
+	if len(s.started) != 1 {
+		return fmt.Errorf("started %d processes, want 1: %v", len(s.started), s.started)
+	}
+	if !strings.Contains(s.started[0], helperPrefix) || !strings.Contains(s.started[0], "--no-restart") {
+		return fmt.Errorf("cleanup command = %q, want a helper deletion that does not start Coddy", s.started[0])
+	}
+	return nil
+}
+
+func (s *helperFeatureState) restartOmitsTheHandoff() error {
+	if len(s.started) != 1 {
+		return fmt.Errorf("started %d processes, want 1: %v", len(s.started), s.started)
+	}
+	if s.started[0] != s.target {
+		return fmt.Errorf("restart command = %q, want a plain %q", s.started[0], s.target)
+	}
+	return nil
+}
+
+func (s *helperFeatureState) orphanedHelperInTemp() error {
+	helper, err := os.CreateTemp("", helperPrefix+"*.exe")
+	if err != nil {
+		return err
+	}
+	s.orphan = helper.Name()
+	if err := helper.Close(); err != nil {
+		return err
+	}
+	bystander, err := os.CreateTemp("", "coddy-not-a-helper-*.exe")
+	if err != nil {
+		return err
+	}
+	s.bystander = bystander.Name()
+	return bystander.Close()
+}
+
+func (s *helperFeatureState) coddySweepsOldHelpers() error {
+	sweepOrphanedHelpers()
+	return nil
+}
+
+func (s *helperFeatureState) orphanedHelperIsGone() error {
+	if _, err := os.Stat(s.orphan); !os.IsNotExist(err) {
+		return fmt.Errorf("helper %s survived the sweep (stat err %v)", s.orphan, err)
+	}
+	return nil
+}
+
+func (s *helperFeatureState) bystanderSurvives() error {
+	if _, err := os.Stat(s.bystander); err != nil {
+		return fmt.Errorf("the sweep removed an unrelated file: %w", err)
+	}
+	return nil
+}
+
+func TestWindowsUpdateHelperFeature(t *testing.T) {
+	s := &helperFeatureState{}
+	t.Cleanup(s.reset)
+
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				s.reset()
+				return ctx, nil
+			})
+			sc.Step(`^a staged Coddy update next to the installed executable$`, s.stagedUpdateNextToTheExecutable)
+			sc.Step(`^the staged release does not understand the restart handoff$`, s.stagedReleasePredatesTheHandoff)
+			sc.Step(`^the update is installed without starting Coddy again$`, s.updateSkipsTheRestart)
+			sc.Step(`^the update helper installs it$`, s.helperInstallsTheUpdate)
+			sc.Step(`^the installed executable is the staged one$`, s.installedExecutableIsTheStagedOne)
+			sc.Step(`^the helper leaves no staging or backup files behind$`, s.noLeftoversRemain)
+			sc.Step(`^the helper hands the restart the path of the helper to delete$`, s.restartCarriesTheHelperPath)
+			sc.Step(`^the helper starts Coddy without the handoff$`, s.restartOmitsTheHandoff)
+			sc.Step(`^the helper hands the cleanup over without starting Coddy$`, s.cleanupHappensWithoutARestart)
+			sc.Step(`^an update helper left in the system temporary directory$`, s.orphanedHelperInTemp)
+			sc.Step(`^Coddy sweeps helpers from earlier updates$`, s.coddySweepsOldHelpers)
+			sc.Step(`^the helper left by the earlier update is gone$`, s.orphanedHelperIsGone)
+			sc.Step(`^unrelated files in the temporary directory are untouched$`, s.bystanderSurvives)
+		},
+		Options: &godog.Options{
+			Format: "progress",
+			Paths:  []string{"../../features/update_windows.feature"},
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("windows update helper feature failed")
+	}
+}

--- a/internal/update/checksum.go
+++ b/internal/update/checksum.go
@@ -1,0 +1,69 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// checksumAssetName is the digest list CI publishes next to the archives.
+const checksumAssetName = "SHA256SUMS"
+
+// verifyAssetChecksum compares a downloaded archive against the digest the
+// release publishes for it. The bytes are about to be unpacked and executed as
+// the user's Coddy, and a resumed download stitches its body together from
+// several responses, so this is the only thing standing between a truncated or
+// substituted transfer and an installed binary.
+//
+// A release without a digest list - a fork built by hand, an older tag - is
+// reported and installed anyway; the check tightens what is published, it does
+// not add a new requirement to publishing.
+func verifyAssetChecksum(ctx context.Context, client *http.Client, rel *ghRelease, assetName string, data []byte, out io.Writer) error {
+	sums, err := pickAsset(rel, checksumAssetName)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "Release %s publishes no %s; skipping checksum verification.\n", rel.TagName, checksumAssetName)
+		return nil
+	}
+	body, err := downloadURL(ctx, client, sums.BrowserDownloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", checksumAssetName, err)
+	}
+	want, err := findChecksum(string(body), assetName)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if got != want {
+		return fmt.Errorf("checksum mismatch for %s: got %s, %s lists %s", assetName, got, checksumAssetName, want)
+	}
+	_, _ = fmt.Fprintf(out, "Verified %s against %s.\n", assetName, checksumAssetName)
+	return nil
+}
+
+// findChecksum reads the sha256sum output format: a hex digest, whitespace, and
+// a file name that binary mode prefixes with an asterisk.
+func findChecksum(list, assetName string) (string, error) {
+	for _, line := range strings.Split(list, "\n") {
+		digest, name, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		if strings.TrimPrefix(strings.TrimSpace(name), "*") != assetName {
+			continue
+		}
+		digest = strings.ToLower(digest)
+		if len(digest) != sha256.Size*2 {
+			return "", fmt.Errorf("%s lists a malformed digest for %s", checksumAssetName, assetName)
+		}
+		if _, err := hex.DecodeString(digest); err != nil {
+			return "", fmt.Errorf("%s lists a malformed digest for %s", checksumAssetName, assetName)
+		}
+		return digest, nil
+	}
+	return "", fmt.Errorf("%s does not list %s", checksumAssetName, assetName)
+}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -112,6 +113,24 @@ func downloadURL(ctx context.Context, client *http.Client, url string, reporter 
 			// response instead of appending a duplicate prefix.
 			data = nil
 		}
+		if resp.StatusCode == http.StatusPartialContent {
+			// A 206 that starts somewhere other than where we stopped would
+			// splice a gap or a duplicate into the archive, and nothing later
+			// in this function would notice.
+			offset, err := partialContentOffset(resp)
+			if err != nil {
+				_ = resp.Body.Close()
+				return nil, err
+			}
+			switch {
+			case offset == int64(len(data)):
+			case offset == 0:
+				data = nil
+			default:
+				_ = resp.Body.Close()
+				return nil, fmt.Errorf("download resumed at byte %d, expected %d", offset, len(data))
+			}
+		}
 		if resp.ContentLength >= 0 && int64(len(data))+resp.ContentLength > maxBytes {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf("download exceeds %d MiB limit", maxBytes>>20)
@@ -135,7 +154,29 @@ func downloadURL(ctx context.Context, client *http.Client, url string, reporter 
 			lastErr = closeErr
 		}
 	}
-	return nil, fmt.Errorf("download failed after %d attempts: %w", 3, lastErr)
+	return nil, fmt.Errorf("download failed after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// partialContentOffset reports the first byte a 206 response carries, so the
+// caller can check it against what it already holds.
+func partialContentOffset(resp *http.Response) (int64, error) {
+	raw := strings.TrimSpace(resp.Header.Get("Content-Range"))
+	if raw == "" {
+		return 0, fmt.Errorf("resumed download has no Content-Range header")
+	}
+	spec, ok := strings.CutPrefix(raw, "bytes ")
+	if !ok {
+		return 0, fmt.Errorf("resumed download has unsupported Content-Range %q", raw)
+	}
+	start, _, ok := strings.Cut(strings.TrimSpace(spec), "-")
+	if !ok {
+		return 0, fmt.Errorf("resumed download has malformed Content-Range %q", raw)
+	}
+	offset, err := strconv.ParseInt(strings.TrimSpace(start), 10, 64)
+	if err != nil || offset < 0 {
+		return 0, fmt.Errorf("resumed download has malformed Content-Range %q", raw)
+	}
+	return offset, nil
 }
 
 func appendResponse(data *[]byte, body io.Reader, maxBytes, total int64, reporter downloadReporter) error {

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 const (
@@ -68,20 +69,104 @@ func pickAsset(rel *ghRelease, assetName string) (*releaseAsset, error) {
 	return nil, fmt.Errorf("release %s has no asset %q", rel.TagName, assetName)
 }
 
-func downloadURL(ctx context.Context, client *http.Client, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
+func downloadURL(ctx context.Context, client *http.Client, url string, reporter downloadReporter) ([]byte, error) {
+	const (
+		maxAttempts = 3
+		maxBytes    = 256 << 20
+	)
+
+	var (
+		data    []byte
+		lastErr error
+	)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			if reporter != nil {
+				reporter.Retry(attempt, maxAttempts, lastErr)
+			}
+			if err := waitForDownloadRetry(ctx, time.Duration(attempt-1)*200*time.Millisecond); err != nil {
+				return nil, err
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", "coddy-agent-update")
+		if len(data) > 0 {
+			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", len(data)))
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("download %s", resp.Status)
+		}
+		if len(data) > 0 && resp.StatusCode == http.StatusOK {
+			// The server ignored our Range request. Restart from the complete
+			// response instead of appending a duplicate prefix.
+			data = nil
+		}
+		if resp.ContentLength >= 0 && int64(len(data))+resp.ContentLength > maxBytes {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("download exceeds %d MiB limit", maxBytes>>20)
+		}
+
+		total := int64(-1)
+		if resp.ContentLength >= 0 {
+			total = int64(len(data)) + resp.ContentLength
+		}
+		readErr := appendResponse(&data, resp.Body, maxBytes, total, reporter)
+		closeErr := resp.Body.Close()
+		if readErr == nil && closeErr == nil {
+			if reporter != nil {
+				reporter.Complete(int64(len(data)))
+			}
+			return data, nil
+		}
+		if readErr != nil {
+			lastErr = readErr
+		} else {
+			lastErr = closeErr
+		}
 	}
-	req.Header.Set("User-Agent", "coddy-agent-update")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
+	return nil, fmt.Errorf("download failed after %d attempts: %w", 3, lastErr)
+}
+
+func appendResponse(data *[]byte, body io.Reader, maxBytes, total int64, reporter downloadReporter) error {
+	buf := make([]byte, 64<<10)
+	for {
+		n, err := body.Read(buf)
+		if n > 0 {
+			if int64(len(*data)+n) > maxBytes {
+				return fmt.Errorf("download exceeds %d MiB limit", maxBytes>>20)
+			}
+			*data = append(*data, buf[:n]...)
+			if reporter != nil {
+				reporter.Progress(int64(len(*data)), total)
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
 	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("download %s", resp.Status)
+}
+
+func waitForDownloadRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
-	const maxBytes = 256 << 20
-	return io.ReadAll(io.LimitReader(resp.Body, maxBytes))
 }

--- a/internal/update/progress.go
+++ b/internal/update/progress.go
@@ -3,6 +3,10 @@ package update
 import (
 	"fmt"
 	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
 )
 
 type downloadReporter interface {
@@ -16,14 +20,23 @@ type consoleDownloadProgress struct {
 	last int
 	name string
 	out  io.Writer
+	// bar is false when the writer is a file or a pipe. Redrawing a bar with
+	// carriage returns there produces one line per percent in the log instead
+	// of one line that moves.
+	bar bool
 }
 
 func newDownloadProgress(out io.Writer, name string) *consoleDownloadProgress {
-	return &consoleDownloadProgress{last: -1, name: name, out: out}
+	return &consoleDownloadProgress{last: -1, name: name, out: out, bar: isTerminalWriter(out)}
+}
+
+func isTerminalWriter(out io.Writer) bool {
+	f, ok := out.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
 }
 
 func (p *consoleDownloadProgress) Progress(downloaded, total int64) {
-	if total <= 0 {
+	if !p.bar || total <= 0 {
 		return
 	}
 	percent := int(downloaded * 100 / total)
@@ -33,9 +46,16 @@ func (p *consoleDownloadProgress) Progress(downloaded, total int64) {
 	if percent == p.last {
 		return
 	}
+	// A server that ignored the Range header restarts the transfer, and the bar
+	// with it. Break the line so the shrinking bar does not overwrite what the
+	// previous attempt already reported.
+	if percent < p.last && p.drew {
+		_, _ = fmt.Fprintln(p.out)
+		p.drew = false
+	}
 	p.last = percent
 	filled := percent / 5
-	_, _ = fmt.Fprintf(p.out, "\rDownloading %s [%s%s] %3d%% (%s/%s)", p.name, repeat("#", filled), repeat("-", 20-filled), percent, formatBytes(downloaded), formatBytes(total))
+	_, _ = fmt.Fprintf(p.out, "\rDownloading %s [%s%s] %3d%% (%s/%s)", p.name, strings.Repeat("#", filled), strings.Repeat("-", 20-filled), percent, formatBytes(downloaded), formatBytes(total))
 	p.drew = true
 }
 
@@ -62,15 +82,4 @@ func formatBytes(n int64) string {
 		return fmt.Sprintf("%.1f MiB", float64(n)/mib)
 	}
 	return fmt.Sprintf("%d KiB", n/1024)
-}
-
-func repeat(s string, n int) string {
-	if n <= 0 {
-		return ""
-	}
-	result := make([]byte, len(s)*n)
-	for i := 0; i < n; i++ {
-		copy(result[i*len(s):], s)
-	}
-	return string(result)
 }

--- a/internal/update/progress.go
+++ b/internal/update/progress.go
@@ -1,0 +1,76 @@
+package update
+
+import (
+	"fmt"
+	"io"
+)
+
+type downloadReporter interface {
+	Complete(downloaded int64)
+	Progress(downloaded, total int64)
+	Retry(attempt, maxAttempts int, err error)
+}
+
+type consoleDownloadProgress struct {
+	drew bool
+	last int
+	name string
+	out  io.Writer
+}
+
+func newDownloadProgress(out io.Writer, name string) *consoleDownloadProgress {
+	return &consoleDownloadProgress{last: -1, name: name, out: out}
+}
+
+func (p *consoleDownloadProgress) Progress(downloaded, total int64) {
+	if total <= 0 {
+		return
+	}
+	percent := int(downloaded * 100 / total)
+	if percent > 100 {
+		percent = 100
+	}
+	if percent == p.last {
+		return
+	}
+	p.last = percent
+	filled := percent / 5
+	_, _ = fmt.Fprintf(p.out, "\rDownloading %s [%s%s] %3d%% (%s/%s)", p.name, repeat("#", filled), repeat("-", 20-filled), percent, formatBytes(downloaded), formatBytes(total))
+	p.drew = true
+}
+
+func (p *consoleDownloadProgress) Retry(attempt, maxAttempts int, err error) {
+	if p.drew {
+		_, _ = fmt.Fprintln(p.out)
+	}
+	_, _ = fmt.Fprintf(p.out, "Download interrupted (%v); resuming, attempt %d of %d.\n", err, attempt, maxAttempts)
+	p.last = -1
+	p.drew = false
+}
+
+func (p *consoleDownloadProgress) Complete(downloaded int64) {
+	if p.drew {
+		_, _ = fmt.Fprintln(p.out)
+		return
+	}
+	_, _ = fmt.Fprintf(p.out, "Downloaded %s.\n", formatBytes(downloaded))
+}
+
+func formatBytes(n int64) string {
+	const mib = 1024 * 1024
+	if n >= mib {
+		return fmt.Sprintf("%.1f MiB", float64(n)/mib)
+	}
+	return fmt.Sprintf("%d KiB", n/1024)
+}
+
+func repeat(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	result := make([]byte, len(s)*n)
+	for i := 0; i < n; i++ {
+		copy(result[i*len(s):], s)
+	}
+	return string(result)
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -31,6 +31,9 @@ type Options struct {
 	Yes            bool
 	Stdout         io.Writer
 	HTTPClient     *http.Client
+
+	// windowsInstaller replaces the Windows helper launcher in deterministic tests.
+	windowsInstaller windowsUpdateInstaller
 }
 
 // Run checks GitHub releases and optionally installs a newer binary.
@@ -102,9 +105,35 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	_, _ = fmt.Fprintf(out, "Downloading %s ...\n", asset.Name)
-	data, err := downloadURL(ctx, client, asset.BrowserDownloadURL)
+	data, err := downloadURL(ctx, client, asset.BrowserDownloadURL, newDownloadProgress(out, asset.Name))
 	if err != nil {
 		return err
+	}
+	if opts.GOOS == "windows" {
+		body, err := executableFromArchive(data, asset.Name)
+		if err != nil {
+			return err
+		}
+		staged, err := stageExecutable(dest, body)
+		if err != nil {
+			return err
+		}
+		req := windowsUpdateRequest{
+			ParentPID:  os.Getpid(),
+			Restart:    true,
+			StagedPath: staged,
+			TargetPath: dest,
+		}
+		installer := opts.windowsInstaller
+		if installer == nil {
+			installer = scheduleWindowsUpdate
+		}
+		if err := installer(req); err != nil {
+			_ = os.Remove(staged)
+			return err
+		}
+		_, _ = fmt.Fprintf(out, "Update downloaded. A helper will install %s after Coddy exits and restart it.\n", latest)
+		return nil
 	}
 	if err := installFromArchive(data, asset.Name, dest); err != nil {
 		return err

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -29,6 +29,7 @@ type Options struct {
 	InstallPath    string // empty = replace os.Executable()
 	CheckOnly      bool
 	Yes            bool
+	NoRestart      bool // Windows only: install the update but do not start Coddy again
 	Stdout         io.Writer
 	HTTPClient     *http.Client
 
@@ -109,6 +110,9 @@ func Run(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
+	if err := verifyAssetChecksum(ctx, client, rel, asset.Name, data, out); err != nil {
+		return err
+	}
 	if opts.GOOS == "windows" {
 		body, err := executableFromArchive(data, asset.Name)
 		if err != nil {
@@ -120,7 +124,7 @@ func Run(ctx context.Context, opts Options) error {
 		}
 		req := windowsUpdateRequest{
 			ParentPID:  os.Getpid(),
-			Restart:    true,
+			Restart:    !opts.NoRestart,
 			StagedPath: staged,
 			TargetPath: dest,
 		}
@@ -132,7 +136,11 @@ func Run(ctx context.Context, opts Options) error {
 			_ = os.Remove(staged)
 			return err
 		}
-		_, _ = fmt.Fprintf(out, "Update downloaded. A helper will install %s after Coddy exits and restart it.\n", latest)
+		if req.Restart {
+			_, _ = fmt.Fprintf(out, "Update downloaded. A helper will install %s after Coddy exits and restart it.\n", latest)
+		} else {
+			_, _ = fmt.Fprintf(out, "Update downloaded. A helper will install %s after Coddy exits.\n", latest)
+		}
 		return nil
 	}
 	if err := installFromArchive(data, asset.Name, dest); err != nil {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -10,9 +11,77 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
+
+func TestInstallFromArchive_zip(t *testing.T) {
+	t.Parallel()
+	payload := mustZip(t, "nested/coddy.exe", []byte("Windows Coddy"))
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "coddy.exe")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := installFromArchive(payload, "coddy_0.9.3_windows_amd64.zip", dest); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "Windows Coddy" {
+		t.Fatalf("unexpected content: %q", b)
+	}
+}
+
+func TestDownloadURL_resumesAfterInterruptedResponse(t *testing.T) {
+	t.Parallel()
+	payload := []byte(strings.Repeat("Coddy", 32<<10))
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:len(payload)/2])
+			return
+		}
+		wantRange := "bytes=" + strconv.Itoa(len(payload)/2) + "-"
+		if got := r.Header.Get("Range"); got != wantRange {
+			t.Errorf("Range = %q, want %q", got, wantRange)
+			http.Error(w, "bad range", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)-len(payload)/2))
+		w.Header().Set("Content-Range", "bytes "+strconv.Itoa(len(payload)/2)+"-"+strconv.Itoa(len(payload)-1)+"/"+strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(payload[len(payload)/2:])
+	}))
+	defer srv.Close()
+
+	reporter := &recordingDownloadReporter{}
+	got, err := downloadURL(context.Background(), srv.Client(), srv.URL, reporter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded bytes differ: got %d, want %d", len(got), len(payload))
+	}
+	if reporter.retries != 1 {
+		t.Fatalf("retries = %d, want 1", reporter.retries)
+	}
+}
+
+type recordingDownloadReporter struct {
+	retries int
+}
+
+func (*recordingDownloadReporter) Complete(int64)        {}
+func (*recordingDownloadReporter) Progress(int64, int64) {}
+func (r *recordingDownloadReporter) Retry(int, int, error) {
+	r.retries++
+}
 
 func TestInstallFromArchive_tarGz(t *testing.T) {
 	t.Parallel()
@@ -148,6 +217,23 @@ func mustTarGz(t *testing.T, name string, body []byte) []byte {
 		t.Fatal(err)
 	}
 	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func mustZip(t *testing.T, name string, body []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(body); err != nil {
 		t.Fatal(err)
 	}
 	if err := zw.Close(); err != nil {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,12 +1,11 @@
 package update
 
 import (
-	"archive/tar"
-	"archive/zip"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -203,41 +202,129 @@ func TestRun_downloadAndInstall(t *testing.T) {
 
 func mustTarGz(t *testing.T, name string, body []byte) []byte {
 	t.Helper()
-	var buf bytes.Buffer
-	zw := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(zw)
-	if err := tw.WriteHeader(&tar.Header{
-		Name: name,
-		Mode: 0o755,
-		Size: int64(len(body)),
-	}); err != nil {
+	data, err := tarGzArchive(name, body)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := tw.Write(body); err != nil {
-		t.Fatal(err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := zw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return buf.Bytes()
+	return data
 }
 
 func mustZip(t *testing.T, name string, body []byte) []byte {
 	t.Helper()
-	var buf bytes.Buffer
-	zw := zip.NewWriter(&buf)
-	w, err := zw.Create(name)
+	data, err := zipArchive(name, body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := w.Write(body); err != nil {
+	return data
+}
+
+func TestDownloadURL_rejectsAMisalignedResume(t *testing.T) {
+	t.Parallel()
+	payload := []byte(strings.Repeat("Coddy", 32<<10))
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:len(payload)/2])
+			return
+		}
+		// A byte off is enough to splice a gap into the archive, and nothing
+		// downstream would notice it.
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes 1-%d/%d", len(payload)-1, len(payload)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(payload[1:])
+	}))
+	defer srv.Close()
+
+	_, err := downloadURL(context.Background(), srv.Client(), srv.URL, nil)
+	if err == nil || !strings.Contains(err.Error(), "resumed at byte 1") {
+		t.Fatalf("error = %v, want a misaligned resume", err)
+	}
+}
+
+func TestDownloadURL_restartsWhenTheServerIgnoresRange(t *testing.T) {
+	t.Parallel()
+	payload := []byte(strings.Repeat("Coddy", 32<<10))
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			_, _ = w.Write(payload[:len(payload)/2])
+			return
+		}
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	got, err := downloadURL(context.Background(), srv.Client(), srv.URL, nil)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := zw.Close(); err != nil {
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestFindChecksum(t *testing.T) {
+	t.Parallel()
+	digest := strings.Repeat("ab", 32)
+	list := "0000  coddy_1.0.0_linux_amd64.tar.gz\n" + digest + " *coddy_1.0.0_windows_amd64.zip\n"
+
+	got, err := findChecksum(list, "coddy_1.0.0_windows_amd64.zip")
+	if err != nil {
 		t.Fatal(err)
 	}
-	return buf.Bytes()
+	if got != digest {
+		t.Fatalf("digest = %q, want %q", got, digest)
+	}
+	if _, err := findChecksum(list, "coddy_1.0.0_darwin_arm64.tar.gz"); err == nil {
+		t.Fatal("expected an error for an asset the list does not cover")
+	}
+	if _, err := findChecksum(list, "coddy_1.0.0_linux_amd64.tar.gz"); err == nil {
+		t.Fatal("expected an error for a malformed digest")
+	}
+}
+
+func TestVerifyAssetChecksum_rejectsAMismatch(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, "%s  coddy_1.0.0_linux_amd64.tar.gz\n", strings.Repeat("ab", 32))
+	}))
+	defer srv.Close()
+
+	rel := &ghRelease{TagName: "1.0.0", Assets: []releaseAsset{{Name: checksumAssetName, BrowserDownloadURL: srv.URL}}}
+	err := verifyAssetChecksum(context.Background(), srv.Client(), rel, "coddy_1.0.0_linux_amd64.tar.gz", []byte("tampered"), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v, want a checksum mismatch", err)
+	}
+}
+
+func TestVerifyAssetChecksum_skipsAReleaseWithoutAList(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	rel := &ghRelease{TagName: "1.0.0"}
+	if err := verifyAssetChecksum(context.Background(), nil, rel, "coddy_1.0.0_linux_amd64.tar.gz", []byte("anything"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "skipping checksum verification") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestDownloadProgress_drawsNoBarOutsideATerminal(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	p := newDownloadProgress(&out, "coddy_1.0.0_linux_amd64.tar.gz")
+	for i := int64(1); i <= 100; i++ {
+		p.Progress(i, 100)
+	}
+	if strings.Contains(out.String(), "\r") {
+		t.Fatalf("redrew a progress bar into a plain writer: %q", out.String())
+	}
+	p.Complete(100)
+	if !strings.Contains(out.String(), "Downloaded") {
+		t.Fatalf("output = %q", out.String())
+	}
 }

--- a/internal/update/windows.go
+++ b/internal/update/windows.go
@@ -1,0 +1,33 @@
+package update
+
+import "io"
+
+const (
+	applyUpdateCommand        = "__apply-update"
+	restartAfterUpdateCommand = "__restart-after-update"
+)
+
+type windowsUpdateRequest struct {
+	ParentPID  int
+	Restart    bool
+	StagedPath string
+	TargetPath string
+}
+
+type windowsUpdateInstaller func(windowsUpdateRequest) error
+
+// RunHelper handles the private command used by a copied Windows executable to
+// install a staged self-update after its parent has exited.
+func RunHelper(args []string, out io.Writer) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+	switch args[0] {
+	case applyUpdateCommand:
+		return true, runWindowsUpdateHelper(args[1:], out)
+	case restartAfterUpdateCommand:
+		return true, runWindowsRestartAfterUpdate(args[1:], out)
+	default:
+		return false, nil
+	}
+}

--- a/internal/update/windows.go
+++ b/internal/update/windows.go
@@ -16,10 +16,12 @@ type windowsUpdateRequest struct {
 
 type windowsUpdateInstaller func(windowsUpdateRequest) error
 
-// RunHelper handles the private command used by a copied Windows executable to
-// install a staged self-update after its parent has exited.
+// RunHelper handles the private commands used by a copied Windows executable to
+// install a staged self-update after its parent has exited. On every other
+// platform they are not commands at all, so the caller reports them the same
+// way it reports any other unknown argument.
 func RunHelper(args []string, out io.Writer) (bool, error) {
-	if len(args) == 0 {
+	if len(args) == 0 || !helperCommandsAvailable {
 		return false, nil
 	}
 	switch args[0] {

--- a/internal/update/windows_other.go
+++ b/internal/update/windows_other.go
@@ -3,18 +3,27 @@
 package update
 
 import (
-	"fmt"
+	"errors"
 	"io"
 )
 
+// helperCommandsAvailable keeps the private update commands off platforms that
+// have no use for them; there `coddy __apply-update` is just an unknown
+// argument.
+var helperCommandsAvailable = false
+
+// errNotWindows is returned by the Windows-only halves of the self-update flow
+// when they are linked into a build for another platform.
+var errNotWindows = errors.New("windows self-update can only run on windows")
+
 func scheduleWindowsUpdate(windowsUpdateRequest) error {
-	return fmt.Errorf("Windows self-update can only run on Windows")
+	return errNotWindows
 }
 
 func runWindowsUpdateHelper(_ []string, _ io.Writer) error {
-	return fmt.Errorf("Windows update helper can only run on Windows")
+	return errNotWindows
 }
 
 func runWindowsRestartAfterUpdate(_ []string, _ io.Writer) error {
-	return fmt.Errorf("Windows update helper can only run on Windows")
+	return errNotWindows
 }

--- a/internal/update/windows_other.go
+++ b/internal/update/windows_other.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package update
+
+import (
+	"fmt"
+	"io"
+)
+
+func scheduleWindowsUpdate(windowsUpdateRequest) error {
+	return fmt.Errorf("Windows self-update can only run on Windows")
+}
+
+func runWindowsUpdateHelper(_ []string, _ io.Writer) error {
+	return fmt.Errorf("Windows update helper can only run on Windows")
+}
+
+func runWindowsRestartAfterUpdate(_ []string, _ io.Writer) error {
+	return fmt.Errorf("Windows update helper can only run on Windows")
+}

--- a/internal/update/windows_other_test.go
+++ b/internal/update/windows_other_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package update
+
+import (
+	"io"
+	"testing"
+)
+
+func TestRunHelperLeavesPrivateCommandsToTheCallerOffWindows(t *testing.T) {
+	t.Parallel()
+	for _, command := range []string{applyUpdateCommand, restartAfterUpdateCommand} {
+		handled, err := RunHelper([]string{command}, io.Discard)
+		if handled || err != nil {
+			t.Fatalf("RunHelper(%q) = (%v, %v), want the caller to report an unknown command", command, handled, err)
+		}
+	}
+}

--- a/internal/update/windows_windows.go
+++ b/internal/update/windows_windows.go
@@ -3,6 +3,7 @@
 package update
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -18,26 +19,57 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// helperCommandsAvailable enables the private update commands; only a Windows
+// build has a helper that speaks them.
+var helperCommandsAvailable = true
+
+// renameFile, restartProbe, and startProcess are the seams the update tests
+// replace. Production always renames through the operating system and starts
+// the real executable.
+var (
+	renameFile   = os.Rename
+	restartProbe = targetUnderstandsRestartHandoff
+	startProcess = restartCoddy
+)
+
+// helperPrefix names the copies of Coddy that install an update from the system
+// temporary directory. Both creating and recognising a helper go through it, so
+// a stale one is always identifiable as ours.
+const helperPrefix = "coddy-update-helper-"
+
+var (
+	// sharingViolationDeadline covers another process holding the executable
+	// open - an antivirus scanner, an indexer, a shell preview handler. Those
+	// let go on their own, so waiting is worth it.
+	sharingViolationDeadline = 30 * time.Second
+	// accessDeniedDeadline is deliberately short. Windows reports a still
+	// mapped image and a plain permission failure with the same code, and the
+	// second one never resolves by waiting.
+	accessDeniedDeadline = 5 * time.Second
+)
+
 func scheduleWindowsUpdate(req windowsUpdateRequest) error {
 	if err := validateWindowsUpdateRequest(req); err != nil {
 		return err
 	}
+	// A helper whose restart step could not delete it outlives its update.
+	// Sweeping here bounds the leak to one file instead of one per run.
+	sweepOrphanedHelpers()
+
 	source, err := resolveExecutablePath()
 	if err != nil {
 		return err
+	}
+	started, err := processCreationTime(windows.CurrentProcess())
+	if err != nil {
+		return fmt.Errorf("read current Coddy start time: %w", err)
 	}
 	helper, err := copyUpdateHelper(source)
 	if err != nil {
 		return fmt.Errorf("copy update helper: %w", err)
 	}
 
-	cmd := exec.Command(helper,
-		applyUpdateCommand,
-		"--parent-pid", strconv.Itoa(req.ParentPID),
-		"--source", req.StagedPath,
-		"--target", req.TargetPath,
-		"--restart",
-	)
+	cmd := exec.Command(helper, helperArgs(req, started)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -49,10 +81,28 @@ func scheduleWindowsUpdate(req windowsUpdateRequest) error {
 	return nil
 }
 
+// helperArgs is the command line the helper parses back into the request. The
+// request is the only thing that decides whether Coddy starts again, so the
+// restart flag has to be conditional here rather than always present.
+func helperArgs(req windowsUpdateRequest, parentStarted int64) []string {
+	args := []string{
+		applyUpdateCommand,
+		"--parent-pid", strconv.Itoa(req.ParentPID),
+		"--parent-started", strconv.FormatInt(parentStarted, 10),
+		"--source", req.StagedPath,
+		"--target", req.TargetPath,
+	}
+	if req.Restart {
+		args = append(args, "--restart")
+	}
+	return args
+}
+
 func runWindowsUpdateHelper(args []string, out io.Writer) error {
 	fs := flag.NewFlagSet(applyUpdateCommand, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	parentPID := fs.Int("parent-pid", 0, "parent process ID")
+	parentStarted := fs.Int64("parent-started", 0, "parent process creation time in nanoseconds")
 	source := fs.String("source", "", "staged executable")
 	target := fs.String("target", "", "installed executable")
 	restart := fs.Bool("restart", false, "restart Coddy after installing")
@@ -70,7 +120,7 @@ func runWindowsUpdateHelper(args []string, out io.Writer) error {
 	}
 
 	_, _ = fmt.Fprintln(out, "Windows update helper started.")
-	if err := waitForParentExit(req.ParentPID, out); err != nil {
+	if err := waitForParentExit(req.ParentPID, *parentStarted, out); err != nil {
 		return err
 	}
 	helperPath, err := os.Executable()
@@ -84,11 +134,21 @@ func runWindowsRestartAfterUpdate(args []string, out io.Writer) error {
 	fs := flag.NewFlagSet(restartAfterUpdateCommand, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	helper := fs.String("helper", "", "temporary update helper")
+	probe := fs.Bool("probe", false, "exit successfully to report that this build understands the handoff")
+	noRestart := fs.Bool("no-restart", false, "delete the temporary helper without starting Coddy")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	// The helper asks before it hands over, so the probe must stay side effect
+	// free: an older build answers the same question by failing to parse it.
+	if *probe {
+		return nil
+	}
 	if err := removeTemporaryHelper(strings.TrimSpace(*helper)); err != nil {
 		_, _ = fmt.Fprintf(out, "Could not remove temporary update helper: %v\n", err)
+	}
+	if *noRestart {
+		return nil
 	}
 	target, err := resolveExecutablePath()
 	if err != nil {
@@ -121,7 +181,7 @@ func copyUpdateHelper(source string) (string, error) {
 	}
 	defer func() { _ = input.Close() }()
 
-	helper, err := os.CreateTemp("", "coddy-update-helper-*.exe")
+	helper, err := os.CreateTemp("", helperPrefix+"*.exe")
 	if err != nil {
 		return "", err
 	}
@@ -143,8 +203,37 @@ func copyUpdateHelper(source string) (string, error) {
 	return helperPath, nil
 }
 
-func waitForParentExit(parentPID int, out io.Writer) error {
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(parentPID))
+// sweepOrphanedHelpers deletes update helpers a previous run left in the system
+// temporary directory. A helper that is still executing keeps its own file
+// locked and is skipped, so this never disturbs a concurrent update.
+func sweepOrphanedHelpers() {
+	dir := os.TempDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if !isTemporaryHelper(path) {
+			continue
+		}
+		_ = os.Remove(path)
+	}
+}
+
+func processCreationTime(handle windows.Handle) (int64, error) {
+	var creation, exit, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(handle, &creation, &exit, &kernel, &user); err != nil {
+		return 0, err
+	}
+	return creation.Nanoseconds(), nil
+}
+
+func waitForParentExit(parentPID int, parentStarted int64, out io.Writer) error {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(parentPID))
 	if err != nil {
 		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
 			return nil
@@ -152,6 +241,20 @@ func waitForParentExit(parentPID int, out io.Writer) error {
 		return fmt.Errorf("open current Coddy process: %w", err)
 	}
 	defer func() { _ = windows.CloseHandle(handle) }()
+
+	// Windows hands a freed PID to whichever process asks for one next. Without
+	// this check the helper could sit waiting on an unrelated program that
+	// inherited the number, and install the update far too late, or never.
+	if parentStarted != 0 {
+		started, err := processCreationTime(handle)
+		if err != nil {
+			return fmt.Errorf("read current Coddy start time: %w", err)
+		}
+		if started != parentStarted {
+			_, _ = fmt.Fprintln(out, "Current Coddy process already exited.")
+			return nil
+		}
+	}
 
 	_, _ = fmt.Fprintln(out, "Waiting for the current Coddy process to exit...")
 	state, err := windows.WaitForSingleObject(handle, windows.INFINITE)
@@ -170,30 +273,65 @@ func installWindowsUpdate(req windowsUpdateRequest, helperPath string, out io.Wr
 	if err != nil {
 		return fmt.Errorf("back up current Coddy before update: %w", err)
 	}
-	keepBackup := true
-	defer func() {
-		if !keepBackup {
-			_ = os.Remove(backup)
-		}
-	}()
+	// The backup only has a job while the target is half replaced. Every exit
+	// below either restores it or leaves the target whole, so none of them has
+	// a reason to keep a second copy of the executable on disk.
+	defer func() { _ = os.Remove(backup) }()
 
 	_, _ = fmt.Fprintln(out, "Installing downloaded update...")
 	if err := renameWithRetry(req.StagedPath, req.TargetPath, out); err != nil {
+		_ = os.Remove(req.StagedPath)
 		return fmt.Errorf("install update: %w; current Coddy was preserved at %s", err, req.TargetPath)
 	}
 
 	if req.Restart {
 		_, _ = fmt.Fprintln(out, "Restarting Coddy...")
-		if err := restartCoddy(req.TargetPath, restartAfterUpdateCommand, "--helper", helperPath); err != nil {
-			if restoreErr := restoreWindowsBackup(req.TargetPath, backup); restoreErr != nil {
+		if err := restartUpdatedCoddy(req.TargetPath, helperPath); err != nil {
+			if restoreErr := restoreWindowsBackup(req.TargetPath, backup, out); restoreErr != nil {
 				return fmt.Errorf("restart updated Coddy: %w; restore previous Coddy: %v", err, restoreErr)
 			}
 			return fmt.Errorf("restart updated Coddy: %w; restored the previous version", err)
 		}
+	} else {
+		// Nobody is going to start Coddy again, but deleting this helper still
+		// takes a process that is not this one. The install already succeeded,
+		// so a helper that survives is litter, not a failure.
+		cleanUpAfterInstall(req.TargetPath, helperPath)
 	}
-	keepBackup = false
 	_, _ = fmt.Fprintln(out, "Coddy update installed successfully.")
 	return nil
+}
+
+// restartUpdatedCoddy starts the freshly installed executable. The preferred
+// route hands it the helper path so it can delete the helper this process still
+// runs from, which only builds carrying that handoff understand. Installing an
+// older release - `coddy update --version` walking backwards - is a normal
+// thing to do, so fall back to a plain restart and leave the helper for the
+// next update to sweep.
+func restartUpdatedCoddy(target, helperPath string) error {
+	if helperPath != "" && restartProbe(target) {
+		return startProcess(target, restartAfterUpdateCommand, "--helper", helperPath)
+	}
+	return startProcess(target)
+}
+
+// cleanUpAfterInstall asks the installed build to delete the helper without
+// starting Coddy, for the `--no-restart` install that has nothing else to hand
+// the job to. A release that predates the handoff leaves the helper for the
+// next update to sweep.
+func cleanUpAfterInstall(target, helperPath string) {
+	if helperPath == "" || !restartProbe(target) {
+		return
+	}
+	_ = startProcess(target, restartAfterUpdateCommand, "--helper", helperPath, "--no-restart")
+}
+
+func targetUnderstandsRestartHandoff(target string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, target, restartAfterUpdateCommand, "--probe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd.Run() == nil
 }
 
 func copyWindowsBackup(target string) (string, error) {
@@ -226,24 +364,44 @@ func copyWindowsBackup(target string) (string, error) {
 }
 
 func renameWithRetry(source, target string, out io.Writer) error {
-	deadline := time.Now().Add(30 * time.Second)
-	for attempt := 1; ; attempt++ {
-		err := os.Rename(source, target)
+	start := time.Now()
+	announced := false
+	for {
+		err := renameFile(source, target)
 		if err == nil {
 			return nil
 		}
-		if !isRetryableWindowsLock(err) || time.Now().After(deadline) {
-			return err
+		deadline, retryable := retryDeadlineFor(err)
+		if !retryable || time.Since(start) > deadline {
+			return describeRenameFailure(err, target)
 		}
-		if attempt == 1 {
+		if !announced {
 			_, _ = fmt.Fprintln(out, "Waiting for Windows to release the executable lock...")
+			announced = true
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
 }
 
-func isRetryableWindowsLock(err error) bool {
-	return errors.Is(err, windows.ERROR_ACCESS_DENIED) || errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+// retryDeadlineFor reports how long a failed rename is worth retrying. Waiting
+// out a sharing violation usually works; waiting out a permission failure only
+// delays the report, so that one gets a much shorter budget.
+func retryDeadlineFor(err error) (time.Duration, bool) {
+	switch {
+	case errors.Is(err, windows.ERROR_SHARING_VIOLATION):
+		return sharingViolationDeadline, true
+	case errors.Is(err, windows.ERROR_ACCESS_DENIED):
+		return accessDeniedDeadline, true
+	default:
+		return 0, false
+	}
+}
+
+func describeRenameFailure(err error, target string) error {
+	if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		return fmt.Errorf("%w (Windows denied access to %s; installing there may need an elevated console)", err, filepath.Dir(target))
+	}
+	return err
 }
 
 func restartCoddy(target string, args ...string) error {
@@ -264,7 +422,7 @@ func removeTemporaryHelper(helper string) error {
 		if err == nil || errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
-		if !isRetryableWindowsLock(err) || time.Now().After(deadline) {
+		if _, retryable := retryDeadlineFor(err); !retryable || time.Now().After(deadline) {
 			return err
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -272,20 +430,25 @@ func removeTemporaryHelper(helper string) error {
 }
 
 func isTemporaryHelper(path string) bool {
-	if filepath.Base(path) == "." || !strings.HasPrefix(strings.ToLower(filepath.Base(path)), "coddy-update-helper-") || !strings.HasSuffix(strings.ToLower(path), ".exe") {
+	if filepath.Base(path) == "." || !strings.HasPrefix(strings.ToLower(filepath.Base(path)), helperPrefix) || !strings.HasSuffix(strings.ToLower(path), ".exe") {
 		return false
 	}
 	rel, err := filepath.Rel(os.TempDir(), path)
 	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }
 
-func restoreWindowsBackup(target, backup string) error {
+func restoreWindowsBackup(target, backup string, out io.Writer) error {
 	failed := target + ".failed"
-	if err := os.Rename(target, failed); err != nil {
+	if err := renameFile(target, failed); err != nil {
 		return fmt.Errorf("move failed update aside: %w", err)
 	}
 	if err := renameWithRetry(backup, target, io.Discard); err != nil {
 		return err
+	}
+	// The rejected build has no use once the working one is back. Failing to
+	// delete it is not worth turning a successful rollback into an error.
+	if err := os.Remove(failed); err != nil && !errors.Is(err, os.ErrNotExist) {
+		_, _ = fmt.Fprintf(out, "Could not remove the rejected update at %s: %v\n", failed, err)
 	}
 	return nil
 }

--- a/internal/update/windows_windows.go
+++ b/internal/update/windows_windows.go
@@ -1,0 +1,291 @@
+//go:build windows
+
+package update
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func scheduleWindowsUpdate(req windowsUpdateRequest) error {
+	if err := validateWindowsUpdateRequest(req); err != nil {
+		return err
+	}
+	source, err := resolveExecutablePath()
+	if err != nil {
+		return err
+	}
+	helper, err := copyUpdateHelper(source)
+	if err != nil {
+		return fmt.Errorf("copy update helper: %w", err)
+	}
+
+	cmd := exec.Command(helper,
+		applyUpdateCommand,
+		"--parent-pid", strconv.Itoa(req.ParentPID),
+		"--source", req.StagedPath,
+		"--target", req.TargetPath,
+		"--restart",
+	)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(helper)
+		return fmt.Errorf("start update helper: %w", err)
+	}
+	return nil
+}
+
+func runWindowsUpdateHelper(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet(applyUpdateCommand, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	parentPID := fs.Int("parent-pid", 0, "parent process ID")
+	source := fs.String("source", "", "staged executable")
+	target := fs.String("target", "", "installed executable")
+	restart := fs.Bool("restart", false, "restart Coddy after installing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	req := windowsUpdateRequest{
+		ParentPID:  *parentPID,
+		Restart:    *restart,
+		StagedPath: strings.TrimSpace(*source),
+		TargetPath: strings.TrimSpace(*target),
+	}
+	if err := validateWindowsUpdateRequest(req); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out, "Windows update helper started.")
+	if err := waitForParentExit(req.ParentPID, out); err != nil {
+		return err
+	}
+	helperPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve update helper path: %w", err)
+	}
+	return installWindowsUpdate(req, helperPath, out)
+}
+
+func runWindowsRestartAfterUpdate(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet(restartAfterUpdateCommand, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	helper := fs.String("helper", "", "temporary update helper")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := removeTemporaryHelper(strings.TrimSpace(*helper)); err != nil {
+		_, _ = fmt.Fprintf(out, "Could not remove temporary update helper: %v\n", err)
+	}
+	target, err := resolveExecutablePath()
+	if err != nil {
+		return err
+	}
+	if err := restartCoddy(target); err != nil {
+		return fmt.Errorf("restart Coddy after update: %w", err)
+	}
+	_, _ = fmt.Fprintln(out, "Coddy restarted.")
+	return nil
+}
+
+func validateWindowsUpdateRequest(req windowsUpdateRequest) error {
+	if req.ParentPID <= 0 {
+		return fmt.Errorf("invalid update parent PID")
+	}
+	if req.StagedPath == "" || req.TargetPath == "" {
+		return fmt.Errorf("update source and target are required")
+	}
+	if filepath.Clean(req.StagedPath) == filepath.Clean(req.TargetPath) {
+		return fmt.Errorf("update source and target must differ")
+	}
+	return nil
+}
+
+func copyUpdateHelper(source string) (string, error) {
+	input, err := os.Open(source)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = input.Close() }()
+
+	helper, err := os.CreateTemp("", "coddy-update-helper-*.exe")
+	if err != nil {
+		return "", err
+	}
+	helperPath := helper.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(helperPath)
+		}
+	}()
+	if _, err := io.Copy(helper, input); err != nil {
+		_ = helper.Close()
+		return "", err
+	}
+	if err := helper.Close(); err != nil {
+		return "", err
+	}
+	cleanup = false
+	return helperPath, nil
+}
+
+func waitForParentExit(parentPID int, out io.Writer) error {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(parentPID))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return nil
+		}
+		return fmt.Errorf("open current Coddy process: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	_, _ = fmt.Fprintln(out, "Waiting for the current Coddy process to exit...")
+	state, err := windows.WaitForSingleObject(handle, windows.INFINITE)
+	if err != nil {
+		return fmt.Errorf("wait for current Coddy process: %w", err)
+	}
+	if state != uint32(windows.WAIT_OBJECT_0) {
+		return fmt.Errorf("wait for current Coddy process returned %d", state)
+	}
+	_, _ = fmt.Fprintln(out, "Current Coddy process exited.")
+	return nil
+}
+
+func installWindowsUpdate(req windowsUpdateRequest, helperPath string, out io.Writer) error {
+	backup, err := copyWindowsBackup(req.TargetPath)
+	if err != nil {
+		return fmt.Errorf("back up current Coddy before update: %w", err)
+	}
+	keepBackup := true
+	defer func() {
+		if !keepBackup {
+			_ = os.Remove(backup)
+		}
+	}()
+
+	_, _ = fmt.Fprintln(out, "Installing downloaded update...")
+	if err := renameWithRetry(req.StagedPath, req.TargetPath, out); err != nil {
+		return fmt.Errorf("install update: %w; current Coddy was preserved at %s", err, req.TargetPath)
+	}
+
+	if req.Restart {
+		_, _ = fmt.Fprintln(out, "Restarting Coddy...")
+		if err := restartCoddy(req.TargetPath, restartAfterUpdateCommand, "--helper", helperPath); err != nil {
+			if restoreErr := restoreWindowsBackup(req.TargetPath, backup); restoreErr != nil {
+				return fmt.Errorf("restart updated Coddy: %w; restore previous Coddy: %v", err, restoreErr)
+			}
+			return fmt.Errorf("restart updated Coddy: %w; restored the previous version", err)
+		}
+	}
+	keepBackup = false
+	_, _ = fmt.Fprintln(out, "Coddy update installed successfully.")
+	return nil
+}
+
+func copyWindowsBackup(target string) (string, error) {
+	input, err := os.Open(target)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = input.Close() }()
+
+	backup, err := os.CreateTemp(filepath.Dir(target), ".coddy-update-backup-*")
+	if err != nil {
+		return "", err
+	}
+	backupPath := backup.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(backupPath)
+		}
+	}()
+	if _, err := io.Copy(backup, input); err != nil {
+		_ = backup.Close()
+		return "", err
+	}
+	if err := backup.Close(); err != nil {
+		return "", err
+	}
+	cleanup = false
+	return backupPath, nil
+}
+
+func renameWithRetry(source, target string, out io.Writer) error {
+	deadline := time.Now().Add(30 * time.Second)
+	for attempt := 1; ; attempt++ {
+		err := os.Rename(source, target)
+		if err == nil {
+			return nil
+		}
+		if !isRetryableWindowsLock(err) || time.Now().After(deadline) {
+			return err
+		}
+		if attempt == 1 {
+			_, _ = fmt.Fprintln(out, "Waiting for Windows to release the executable lock...")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func isRetryableWindowsLock(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) || errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}
+
+func restartCoddy(target string, args ...string) error {
+	cmd := exec.Command(target, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Start()
+}
+
+func removeTemporaryHelper(helper string) error {
+	if !isTemporaryHelper(helper) {
+		return fmt.Errorf("invalid temporary helper path %q", helper)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		err := os.Remove(helper)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if !isRetryableWindowsLock(err) || time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func isTemporaryHelper(path string) bool {
+	if filepath.Base(path) == "." || !strings.HasPrefix(strings.ToLower(filepath.Base(path)), "coddy-update-helper-") || !strings.HasSuffix(strings.ToLower(path), ".exe") {
+		return false
+	}
+	rel, err := filepath.Rel(os.TempDir(), path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func restoreWindowsBackup(target, backup string) error {
+	failed := target + ".failed"
+	if err := os.Rename(target, failed); err != nil {
+		return fmt.Errorf("move failed update aside: %w", err)
+	}
+	if err := renameWithRetry(backup, target, io.Discard); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/update/windows_windows_test.go
+++ b/internal/update/windows_windows_test.go
@@ -1,0 +1,88 @@
+//go:build windows
+
+package update
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyUpdateHelperUsesSystemTemp(t *testing.T) {
+	t.Parallel()
+	source := filepath.Join(t.TempDir(), "coddy.exe")
+	if err := os.WriteFile(source, []byte("current Coddy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	helper, err := copyUpdateHelper(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(helper) })
+
+	rel, err := filepath.Rel(os.TempDir(), helper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+		t.Fatalf("helper %q is outside system temp %q", helper, os.TempDir())
+	}
+	got, err := os.ReadFile(helper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "current Coddy" {
+		t.Fatalf("helper contents = %q", got)
+	}
+}
+
+func TestIsTemporaryHelper(t *testing.T) {
+	t.Parallel()
+	valid := filepath.Join(os.TempDir(), "coddy-update-helper-123.exe")
+	if !isTemporaryHelper(valid) {
+		t.Fatalf("isTemporaryHelper(%q) = false", valid)
+	}
+	for _, path := range []string{
+		filepath.Join(os.TempDir(), "other.exe"),
+		filepath.Join(filepath.Dir(os.TempDir()), "not-temp", "coddy-update-helper-123.exe"),
+	} {
+		if isTemporaryHelper(path) {
+			t.Fatalf("isTemporaryHelper(%q) = true", path)
+		}
+	}
+}
+
+func TestInstallWindowsUpdateRestoresPreviousBinaryWhenRestartFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "coddy.exe")
+	staged := filepath.Join(dir, "coddy.new.exe")
+	if err := os.WriteFile(target, []byte("previous Coddy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staged, []byte("not an executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := installWindowsUpdate(windowsUpdateRequest{
+		Restart:    true,
+		StagedPath: staged,
+		TargetPath: target,
+	}, "", &out)
+	if err == nil {
+		t.Fatal("expected restart failure")
+	}
+	if !strings.Contains(err.Error(), "restored the previous version") {
+		t.Fatalf("error = %v", err)
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "previous Coddy" {
+		t.Fatalf("target after rollback = %q", got)
+	}
+}

--- a/internal/update/windows_windows_test.go
+++ b/internal/update/windows_windows_test.go
@@ -4,10 +4,16 @@ package update
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
+	"slices"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestCopyUpdateHelperUsesSystemTemp(t *testing.T) {
@@ -84,5 +90,172 @@ func TestInstallWindowsUpdateRestoresPreviousBinaryWhenRestartFails(t *testing.T
 	}
 	if string(got) != "previous Coddy" {
 		t.Fatalf("target after rollback = %q", got)
+	}
+	if entries, readErr := os.ReadDir(dir); readErr != nil {
+		t.Fatal(readErr)
+	} else if len(entries) != 1 || entries[0].Name() != "coddy.exe" {
+		t.Fatalf("rollback left files behind: %v", names(entries))
+	}
+}
+
+func names(entries []os.DirEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.Name())
+	}
+	return out
+}
+
+func TestRetryDeadlineFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		err       error
+		want      time.Duration
+		retryable bool
+	}{
+		{"sharing violation waits out the other process", windows.ERROR_SHARING_VIOLATION, sharingViolationDeadline, true},
+		{"access denied is mostly a permission problem", windows.ERROR_ACCESS_DENIED, accessDeniedDeadline, true},
+		{"a missing source never appears", os.ErrNotExist, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, retryable := retryDeadlineFor(&os.LinkError{Op: "rename", Err: tc.err})
+			if retryable != tc.retryable || got != tc.want {
+				t.Fatalf("retryDeadlineFor = (%v, %v), want (%v, %v)", got, retryable, tc.want, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestRenameWithRetryWaitsOutASharingViolation(t *testing.T) {
+	restore := renameFile
+	t.Cleanup(func() { renameFile = restore })
+
+	calls := 0
+	renameFile = func(string, string) error {
+		calls++
+		if calls < 3 {
+			return &os.LinkError{Op: "rename", Err: windows.ERROR_SHARING_VIOLATION}
+		}
+		return nil
+	}
+
+	var out bytes.Buffer
+	if err := renameWithRetry("staged", "target", &out); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Fatalf("renamed %d times, want 3", calls)
+	}
+	if got := strings.Count(out.String(), "Waiting for Windows"); got != 1 {
+		t.Fatalf("announced the wait %d times, want 1", got)
+	}
+}
+
+func TestRenameWithRetryReportsAnElevationHintOnAccessDenied(t *testing.T) {
+	restoreRename, restoreDeadline := renameFile, accessDeniedDeadline
+	t.Cleanup(func() {
+		renameFile = restoreRename
+		accessDeniedDeadline = restoreDeadline
+	})
+	accessDeniedDeadline = 10 * time.Millisecond
+
+	denied := &os.LinkError{Op: "rename", Err: windows.ERROR_ACCESS_DENIED}
+	renameFile = func(string, string) error { return denied }
+
+	target := filepath.Join(t.TempDir(), "coddy.exe")
+	err := renameWithRetry("staged", target, &bytes.Buffer{})
+	if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		t.Fatalf("error = %v, want an access denied", err)
+	}
+	if !strings.Contains(err.Error(), "elevated console") {
+		t.Fatalf("error does not explain the likely cause: %v", err)
+	}
+}
+
+func TestInstallWindowsUpdateCleansUpWhenTheSwapFails(t *testing.T) {
+	restore := renameFile
+	t.Cleanup(func() { renameFile = restore })
+	renameFile = func(string, string) error { return errors.New("the volume went away") }
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "coddy.exe")
+	staged := filepath.Join(dir, ".coddy-update-staged")
+	if err := os.WriteFile(target, []byte("previous Coddy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staged, []byte("next Coddy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := installWindowsUpdate(windowsUpdateRequest{
+		Restart:    true,
+		StagedPath: staged,
+		TargetPath: target,
+	}, "", &out)
+	if err == nil {
+		t.Fatal("expected the install to fail")
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "previous Coddy" {
+		t.Fatalf("target = %q, want the untouched previous build", got)
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 1 || entries[0].Name() != "coddy.exe" {
+		t.Fatalf("failed install left files behind: %v", names(entries))
+	}
+}
+
+func TestWaitForParentExitIgnoresARecycledPID(t *testing.T) {
+	t.Parallel()
+	// A live PID whose creation time does not match belongs to somebody else,
+	// so the helper must not block on it. Waiting on this process really would
+	// deadlock, which is exactly what the check has to prevent.
+	var out bytes.Buffer
+	if err := waitForParentExit(os.Getpid(), 1, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "already exited") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestRunHelperAnswersTheRestartProbe(t *testing.T) {
+	t.Parallel()
+	// The probe is how a helper asks whether the build it just installed
+	// understands the handoff, so it has to succeed and do nothing else.
+	handled, err := RunHelper([]string{restartAfterUpdateCommand, "--probe"}, io.Discard)
+	if !handled || err != nil {
+		t.Fatalf("RunHelper(probe) = (%v, %v), want (true, nil)", handled, err)
+	}
+}
+
+func TestHelperArgsCarryTheRestartDecision(t *testing.T) {
+	t.Parallel()
+	req := windowsUpdateRequest{ParentPID: 42, StagedPath: "staged", TargetPath: "target"}
+
+	if got := helperArgs(req, 7); slices.Contains(got, "--restart") {
+		t.Fatalf("args = %v, want no restart flag", got)
+	}
+	req.Restart = true
+	got := helperArgs(req, 7)
+	if !slices.Contains(got, "--restart") {
+		t.Fatalf("args = %v, want a restart flag", got)
+	}
+	// The helper parses these back into the request it acts on, so a rename
+	// here has to travel with the flag names above.
+	for _, want := range []string{applyUpdateCommand, "--parent-pid", "42", "--parent-started", "7", "--source", "staged", "--target", "target"} {
+		if !slices.Contains(got, want) {
+			t.Fatalf("args = %v, missing %q", got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Run Windows self-updates through a helper copied to `%TEMP%`.
- Wait for the original process, preserve a backup, retry transient file locks, and restart the updated binary.
- Render console download progress and resume interrupted downloads with HTTP Range requests.
- Add Windows recovery, helper-location, download-resume, and BDD coverage.

## Root cause

Windows cannot replace `coddy.exe` while that executable is running. The previous updater attempted the rename from the process being replaced, which fails with `Access is denied`.

## Validation

- `go test ./internal/update`
- `go test ./cmd/coddy`
- `make check-windows`
- `make lint`
- `make lint-windows`

`make test` could not finish in this environment because the bundled runtime has no `npm` for the unchanged UI build step.
