### PR TITLE
feat(prompts): name Coddy at the start of every system prompt

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -124,6 +124,9 @@ prompts:
   # Leave empty to use built-in templates. Paths support ~ and ${CWD} (session cwd at render time).
   # Template fields: {{.CWD}}, {{.Tools}}, {{.Skills}}, {{.TodoList}}, {{.Memory}}, {{.UTCNow}}
   # (use {{if .TodoList}} ... {{end}} for optional checklist injection; see docs/config.md)
+  # Coddy prepends its identity line ("You are Coddy, ...") to any template that does not
+  # already open with it, so gateways can attribute the traffic. See internal/prompts/identity.go
+  # and docs/react-agent.md (Agent identity).
   dir: ""
   # File names inside prompts.dir (defaults: agent.md, plan.md)
   # agent_prompt: "agent.md"

--- a/docs/config.md
+++ b/docs/config.md
@@ -122,6 +122,10 @@ agent:
 prompts:
   # Empty dir = use embedded defaults. Otherwise a directory containing the files named below.
   #
+  # Whatever you put here, Coddy prepends its identity line ("You are Coddy, ...") unless the
+  # template already opens with it — gateways attribute traffic by the start of the system
+  # prompt. Source: internal/prompts/identity.go, rationale: docs/react-agent.md (Agent identity).
+  #
   # Go text/template data. Fields in internal/prompts/loader.go. YAML shape is config.Prompts in internal/config/prompts.go.
   #   {{.CWD}}      - session working directory
   #   {{.Tools}}    - markdown list of tool names and short descriptions for the current mode

--- a/docs/react-agent.md
+++ b/docs/react-agent.md
@@ -29,6 +29,7 @@ Templates are **`internal/prompts/agent.md`** and **`plan.md`** (embedded by def
 Rendered order matches the markdown files roughly as follows:
 
 ```
+[Identity line — see "Agent identity" below; absent when the template opens with it]
 [Intro + Mode + How to work / How to plan]
 Working directory: {{.CWD}}
 
@@ -63,6 +64,25 @@ Working directory: {{.CWD}}
 The **`TodoList`** body is markdown from **`internal/tools/todo.FormatPlanMarkdown`** applied to **`session.Plan`**. It is injected **only when** at least one entry exists. Embedded templates treat an empty **`TodoList`** as false for **`{{if .TodoList}}`**. The environment block is appended outside the configurable template so OS and shell facts cannot be accidentally omitted by a custom prompt.
 
 Immediately before **each** provider **`Stream`** call within a single **`session/prompt`**, Coddy reapplies **`Render`** so the **`system`** message reflects todo changes from tools executed earlier in that same episode. **`UTCNow`** is set to **`time.Now().UTC()`** formatted as RFC3339 on each render so the footer clock advances across ReAct iterations.
+
+### Agent identity
+
+**Every system prompt Coddy sends opens by naming the product.** The sentence lives in **`internal/prompts/identity.go`** as **`prompts.Identity`** (**`"You are Coddy, an AI coding agent."`**), and **`prompts.WithIdentity`** is what puts it there.
+
+Why it exists: an LLM gateway cannot tell one OpenAI-compatible client from another by the wire protocol, so gateways attribute traffic by matching the **opening of the system prompt** against a table of known products (**`"You are Claude Code…"`**, **`"You are Cline…"`**). Coddy used to open with a generic sentence and was therefore invisible in that kind of analytics. Treat **`prompts.Identity`** as a published contract: gateways key on the **`you are coddy`** substring, and rewording it silently drops Coddy out of their reports until they catch up.
+
+Where it is applied:
+
+- **`buildSystemPrompt`** (`internal/agent/system_prompt.go`), last step before the context breakdown — covers agent and plan modes, a user's own **`prompts.dir`** template, and the render fallback;
+- **`buildCompactionRequest`** (`internal/agent/compact.go`) — the summarizer is its own request with its own system prompt;
+- the auxiliary HTTP prompts: chat-title generation (`external/httpserver/coddy_coddy.go`), prompt enhancement (`external/httpserver/enhance_prompt.go`) and the memory copilot (`external/memory/copilot.go`).
+
+Two properties the tests lock (`internal/prompts/identity_test.go`, `internal/agent/identity_prompt_test.go`):
+
+1. the marker lands within the **first 220 characters**, because that is the prefix a gateway inspects — a long **`{{.CWD}}`** must not push it out;
+2. the line appears **exactly once**. The built-in templates already open with **`You are Coddy, …`**, so **`WithIdentity`** detects the marker and returns them untouched instead of stacking a second identity line on top.
+
+A custom **`prompts.dir`** template does **not** need to name Coddy: the line is prepended for it automatically.
 
 ### Tool Calling via Function Calling API
 

--- a/external/httpserver/bdd_remote_test.go
+++ b/external/httpserver/bdd_remote_test.go
@@ -234,7 +234,10 @@ type remoteStubProvider struct{}
 
 func (remoteStubProvider) Complete(_ context.Context, messages []llm.Message, _ []llm.ToolDefinition) (*llm.Response, error) {
 	for _, message := range messages {
-		if message.Role == llm.RoleSystem && message.Content == enhancePromptInstruction {
+		// Contains, not equality: every system prompt Coddy sends is prefixed
+		// with its identity line (internal/prompts/identity.go). The instruction
+		// itself must still travel verbatim, which is what this asserts.
+		if message.Role == llm.RoleSystem && strings.Contains(message.Content, enhancePromptInstruction) {
 			return &llm.Response{Content: "Refactor the memory endpoint and add tests.", StopReason: "end_turn"}, nil
 		}
 	}

--- a/external/httpserver/coddy_coddy.go
+++ b/external/httpserver/coddy_coddy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/EvilFreelancer/coddy-agent/internal/acp"
 	"github.com/EvilFreelancer/coddy-agent/internal/bgtask"
 	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/prompts"
 	"github.com/EvilFreelancer/coddy-agent/internal/session"
 	"github.com/EvilFreelancer/coddy-agent/internal/tools/todo"
 )
@@ -339,10 +340,11 @@ func (s *Server) coddyDescribePost(w http.ResponseWriter, r *http.Request) {
 	resp, err := provider.Complete(ctx, []llm.Message{
 		{
 			Role: llm.RoleSystem,
-			Content: "You generate short descriptions for chat titles and command labels. " +
-				"Return exactly one short phrase (3 to 8 words) describing what the user's text is about. " +
-				"Match the user's language when possible. " +
-				"No quotes, no preamble, no headings, no line breaks, no numbering. Output only the phrase.",
+			Content: prompts.WithIdentity(
+				"You generate short descriptions for chat titles and command labels. " +
+					"Return exactly one short phrase (3 to 8 words) describing what the user's text is about. " +
+					"Match the user's language when possible. " +
+					"No quotes, no preamble, no headings, no line breaks, no numbering. Output only the phrase."),
 		},
 		{Role: llm.RoleUser, Content: raw},
 	}, nil)

--- a/external/httpserver/enhance_prompt.go
+++ b/external/httpserver/enhance_prompt.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/prompts"
 	"github.com/EvilFreelancer/coddy-agent/internal/session"
 )
 
@@ -93,7 +94,7 @@ func (s *Server) coddyEnhancePromptPost(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	response, err := provider.Complete(r.Context(), []llm.Message{
-		{Role: llm.RoleSystem, Content: enhancePromptInstruction},
+		{Role: llm.RoleSystem, Content: prompts.WithIdentity(enhancePromptInstruction)},
 		{Role: llm.RoleUser, Content: "Draft prompt to enhance, not answer:\n\n" + draft},
 	}, nil)
 	if err != nil {

--- a/external/memory/copilot.go
+++ b/external/memory/copilot.go
@@ -14,6 +14,7 @@ import (
 	memtools "github.com/EvilFreelancer/coddy-agent/external/memory/tools"
 	"github.com/EvilFreelancer/coddy-agent/internal/config"
 	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/prompts"
 	"github.com/EvilFreelancer/coddy-agent/internal/tooling"
 )
 
@@ -143,7 +144,7 @@ func RunBeforeTurn(ctx context.Context, log *slog.Logger, cfg *config.Config, cw
 	toolDefs := memtools.ToolDefinitions(memTools)
 	toolEnv := &tooling.Env{CWD: cwd}
 	msgs := []llm.Message{
-		{Role: llm.RoleSystem, Content: strings.TrimSpace(beforeTurnSystemPrompt)},
+		{Role: llm.RoleSystem, Content: prompts.WithIdentity(beforeTurnSystemPrompt)},
 		{Role: llm.RoleUser, Content: "User message for this turn:\n" + userQuery},
 	}
 	maxTurns := cfg.Memory.PersistMaxTurns

--- a/features/agent_identity.feature
+++ b/features/agent_identity.feature
@@ -1,0 +1,19 @@
+Feature: Coddy identifies itself to the gateway
+  A gateway in front of the model cannot tell one OpenAI-compatible client from
+  another by the wire protocol, so it attributes traffic by matching the opening
+  of the system prompt against a table of known products. Every request Coddy
+  sends therefore names the product at the start of its system prompt, whichever
+  template the session runs on, and names it exactly once.
+
+  Scenario Outline: The request Coddy sends opens by naming the product
+    Given a session in "<mode>" mode using "<templates>" prompt templates
+    When the agent sends a turn to the model
+    Then the system prompt of that request names Coddy in its opening
+    And the system prompt names Coddy exactly once
+
+    Examples:
+      | mode  | templates |
+      | agent | built-in  |
+      | plan  | built-in  |
+      | agent | custom    |
+      | plan  | custom    |

--- a/internal/agent/bdd_identity_test.go
+++ b/internal/agent/bdd_identity_test.go
@@ -1,0 +1,207 @@
+package agent
+
+// Godog harness for features/agent_identity.feature: drives a real Agent turn
+// with a fake provider and asserts what the system prompt on the wire looks
+// like, so the identity line is checked where a gateway would read it rather
+// than at the function that builds it.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/acp"
+	"github.com/EvilFreelancer/coddy-agent/internal/config"
+	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
+)
+
+// The prefix a gateway inspects before giving up on identifying the client.
+const bddIdentityWindow = 220
+
+// bddIdentityProvider answers every turn with a canned reply and records the
+// message slice it was handed.
+type bddIdentityProvider struct {
+	seen [][]llm.Message
+}
+
+func (p *bddIdentityProvider) Complete(_ context.Context, messages []llm.Message, _ []llm.ToolDefinition) (*llm.Response, error) {
+	p.seen = append(p.seen, messages)
+	return &llm.Response{Content: "done", StopReason: "end_turn"}, nil
+}
+
+func (p *bddIdentityProvider) Stream(_ context.Context, messages []llm.Message, _ []llm.ToolDefinition, onChunk func(llm.StreamChunk)) (*llm.Response, error) {
+	p.seen = append(p.seen, messages)
+	onChunk(llm.StreamChunk{TextDelta: "done"})
+	return &llm.Response{Content: "done", StopReason: "end_turn"}, nil
+}
+
+type identityFeatureState struct {
+	provider *bddIdentityProvider
+	state    *session.State
+	ag       *Agent
+	tmp      []string
+}
+
+func (s *identityFeatureState) reset() error {
+	s.provider = &bddIdentityProvider{}
+	s.state = nil
+	s.ag = nil
+	return nil
+}
+
+func (s *identityFeatureState) close() {
+	for _, d := range s.tmp {
+		_ = os.RemoveAll(d)
+	}
+	s.tmp = nil
+}
+
+func (s *identityFeatureState) tempDir() (string, error) {
+	d, err := os.MkdirTemp("", "coddy-bdd-identity-")
+	if err != nil {
+		return "", err
+	}
+	s.tmp = append(s.tmp, d)
+	return d, nil
+}
+
+// customPromptsDir writes templates that deliberately never mention Coddy, so
+// the scenario proves the line is added rather than inherited from the file.
+func (s *identityFeatureState) customPromptsDir() (string, error) {
+	dir, err := s.tempDir()
+	if err != nil {
+		return "", err
+	}
+	for _, name := range []string{"agent.md", "plan.md"} {
+		body := "You are a terse assistant. Working directory: {{.CWD}}\n"
+		if err := os.WriteFile(dir+"/"+name, []byte(body), 0o644); err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+func (s *identityFeatureState) sessionInMode(mode, templates string) error {
+	cwd, err := s.tempDir()
+	if err != nil {
+		return err
+	}
+	sessionDir, err := s.tempDir()
+	if err != nil {
+		return err
+	}
+
+	sessionMode := session.ModeAgent
+	if mode == "plan" {
+		sessionMode = session.ModePlan
+	}
+	s.state = &session.State{
+		ID:         "sess_bdd_identity",
+		CWD:        cwd,
+		Mode:       sessionMode,
+		SessionDir: sessionDir,
+	}
+
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{{Name: "fake", Type: "openai", APIKey: "test"}},
+		Models:    []config.ModelEntry{{Model: "fake/model", MaxTokens: 100, MaxContextTokens: 128000}},
+		Agent:     config.Agent{Model: "fake/model"},
+	}
+	cfg.Agent.ApplyDefaults()
+	cfg.Prompts.ApplyDefaults()
+
+	switch templates {
+	case "built-in":
+		// Embedded templates; nothing to configure.
+	case "custom":
+		dir, err := s.customPromptsDir()
+		if err != nil {
+			return err
+		}
+		cfg.Prompts.Dir = dir
+	default:
+		return fmt.Errorf("unknown template source %q", templates)
+	}
+
+	s.ag = NewAgent(cfg, s.state, resumePermissionSender{}, nil)
+	s.ag.providerFactory = func(llm.ProviderInput) (llm.Provider, error) { return s.provider, nil }
+	return nil
+}
+
+func (s *identityFeatureState) sendsTurn() error {
+	_, err := s.ag.Run(context.Background(), []acp.ContentBlock{{Type: "text", Text: "probe prompt"}})
+	return err
+}
+
+func (s *identityFeatureState) systemPrompt() (string, error) {
+	if len(s.provider.seen) == 0 {
+		return "", fmt.Errorf("provider received no request")
+	}
+	msgs := s.provider.seen[len(s.provider.seen)-1]
+	if len(msgs) == 0 || msgs[0].Role != llm.RoleSystem {
+		return "", fmt.Errorf("first message is not a system prompt: %+v", msgs)
+	}
+	return msgs[0].Content, nil
+}
+
+func (s *identityFeatureState) namesCoddyInOpening() error {
+	prompt, err := s.systemPrompt()
+	if err != nil {
+		return err
+	}
+	head := prompt
+	if len(head) > bddIdentityWindow {
+		head = head[:bddIdentityWindow]
+	}
+	if !strings.Contains(strings.ToLower(head), "you are coddy") {
+		return fmt.Errorf("opening does not name Coddy:\n%s", head)
+	}
+	return nil
+}
+
+func (s *identityFeatureState) namesCoddyOnce() error {
+	prompt, err := s.systemPrompt()
+	if err != nil {
+		return err
+	}
+	if n := strings.Count(strings.ToLower(prompt), "you are coddy"); n != 1 {
+		return fmt.Errorf("system prompt names Coddy %d times, want 1", n)
+	}
+	return nil
+}
+
+func initializeIdentityScenario(sc *godog.ScenarioContext) {
+	s := &identityFeatureState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		return ctx, s.reset()
+	})
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		s.close()
+		return ctx, nil
+	})
+	sc.Step(`^a session in "([^"]+)" mode using "([^"]+)" prompt templates$`, s.sessionInMode)
+	sc.Step(`^the agent sends a turn to the model$`, s.sendsTurn)
+	sc.Step(`^the system prompt of that request names Coddy in its opening$`, s.namesCoddyInOpening)
+	sc.Step(`^the system prompt names Coddy exactly once$`, s.namesCoddyOnce)
+}
+
+func TestAgentIdentityFeature(t *testing.T) {
+	suite := godog.TestSuite{
+		Name:                "agent-identity",
+		ScenarioInitializer: initializeIdentityScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/agent_identity.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("agent identity feature suite failed")
+	}
+}

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/EvilFreelancer/coddy-agent/internal/acp"
 	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/prompts"
 	"github.com/EvilFreelancer/coddy-agent/internal/session"
 )
 
@@ -273,7 +274,7 @@ func buildCompactionRequest(head []llm.Message, instructions string) []llm.Messa
 		b.WriteString(s)
 	}
 	return []llm.Message{
-		{Role: llm.RoleSystem, Content: compactionSystemPrompt},
+		{Role: llm.RoleSystem, Content: prompts.WithIdentity(compactionSystemPrompt)},
 		{Role: llm.RoleUser, Content: b.String()},
 	}
 }

--- a/internal/agent/identity_prompt_test.go
+++ b/internal/agent/identity_prompt_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/config"
+	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
+)
+
+// Every system prompt Coddy sends has to name the product near its start:
+// a gateway in front of the model reads only the opening of the prompt to
+// tell one client from another. See internal/prompts/identity.go.
+const identityWindowChars = 220
+
+func assertPromptIdentifiesCoddy(t *testing.T, prompt, what string) {
+	t.Helper()
+	head := prompt
+	if len(head) > identityWindowChars {
+		head = head[:identityWindowChars]
+	}
+	if !strings.Contains(strings.ToLower(head), "you are coddy") {
+		t.Errorf("%s does not identify Coddy within the first %d characters:\n%s",
+			what, identityWindowChars, head)
+	}
+}
+
+func identityAgent(t *testing.T, cwd string) *Agent {
+	t.Helper()
+	st := &session.State{ID: "identity", CWD: cwd, Mode: session.ModeAgent}
+	cfg := &config.Config{}
+	cfg.Agent.ApplyDefaults()
+	cfg.Prompts.ApplyDefaults()
+	return NewAgent(cfg, st, nil, nil)
+}
+
+func TestBuildSystemPromptIdentifiesCoddyInEveryMode(t *testing.T) {
+	a := identityAgent(t, t.TempDir())
+	for _, mode := range []string{"agent", "plan"} {
+		assertPromptIdentifiesCoddy(t, a.buildSystemPrompt(mode, nil, nil, "", nil), mode+" mode prompt")
+	}
+}
+
+// prompts.dir replaces the built-in template wholesale. Users who bring their
+// own persona must still be attributable, so the identity line is prepended.
+func TestBuildSystemPromptIdentifiesCoddyWithCustomPromptsDir(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"agent.md", "plan.md"} {
+		body := "You are a terse assistant. Working directory: {{.CWD}}\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := identityAgent(t, t.TempDir())
+	a.cfg.Prompts.Dir = dir
+
+	for _, mode := range []string{"agent", "plan"} {
+		prompt := a.buildSystemPrompt(mode, nil, nil, "", nil)
+		assertPromptIdentifiesCoddy(t, prompt, "custom "+mode+" prompt")
+		if !strings.Contains(prompt, "You are a terse assistant.") {
+			t.Errorf("custom %s template body was dropped:\n%s", mode, prompt)
+		}
+	}
+}
+
+// A broken prompts.dir falls back to a generic stub with no product name.
+func TestBuildSystemPromptIdentifiesCoddyOnRenderFallback(t *testing.T) {
+	a := identityAgent(t, t.TempDir())
+	a.cfg.Prompts.Dir = filepath.Join(t.TempDir(), "missing")
+
+	assertPromptIdentifiesCoddy(t, a.buildSystemPrompt("agent", nil, nil, "", nil), "fallback prompt")
+}
+
+// The summarizer runs as its own request with its own system prompt, so it is
+// a separate client from the gateway's point of view.
+func TestCompactionRequestIdentifiesCoddy(t *testing.T) {
+	msgs := buildCompactionRequest([]llm.Message{{Role: llm.RoleUser, Content: "hi"}}, "")
+	if len(msgs) == 0 || msgs[0].Role != llm.RoleSystem {
+		t.Fatalf("expected a leading system message, got %+v", msgs)
+	}
+	assertPromptIdentifiesCoddy(t, msgs[0].Content, "compaction prompt")
+	if !strings.Contains(msgs[0].Content, "You are compacting the conversation history") {
+		t.Errorf("compaction instructions were lost:\n%s", msgs[0].Content)
+	}
+}
+
+// No prompt may carry the line twice — that is pure token waste on every turn.
+func TestIdentityLineAppearsOnce(t *testing.T) {
+	a := identityAgent(t, t.TempDir())
+	for _, mode := range []string{"agent", "plan"} {
+		prompt := strings.ToLower(a.buildSystemPrompt(mode, nil, nil, "", nil))
+		if n := strings.Count(prompt, "you are coddy"); n != 1 {
+			t.Errorf("%s mode prompt names Coddy %d times, want 1", mode, n)
+		}
+	}
+}

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -111,6 +111,10 @@ func (a *Agent) buildSystemPrompt(mode string, activeSkills []*skills.Skill, too
 		UTCNow:         time.Now().UTC().Format(time.RFC3339),
 	})
 	full = joinNonEmptyPromptBlocks(full, a.environment.PromptContext())
+	// Applied last so it also covers a user's own prompts.dir template and the
+	// render fallback, and before the context breakdown so the estimate counts
+	// what is actually sent. See internal/prompts/identity.go.
+	full = prompts.WithIdentity(full)
 	if _, ok := a.state.(rulesState); ok {
 		// The Conversation estimate mirrors what buildMessages sends: only the
 		// LLM-visible window after the last compaction summary.

--- a/internal/prompts/agent.md
+++ b/internal/prompts/agent.md
@@ -1,4 +1,4 @@
-You are an AI coding agent with full access to the user's codebase.
+You are Coddy, an AI coding agent with full access to the user's codebase.
 Working directory: {{.CWD}}
 
 ## Mode: Agent

--- a/internal/prompts/identity.go
+++ b/internal/prompts/identity.go
@@ -1,0 +1,59 @@
+package prompts
+
+import "strings"
+
+// Identity is the self-identification sentence every Coddy-authored system
+// prompt opens with.
+//
+// Why it exists: an LLM gateway cannot tell one OpenAI-compatible client from
+// another by the wire protocol, so gateways classify traffic by matching the
+// opening of the system prompt against a table of known products
+// ("You are Claude Code…", "You are Cline…"). Coddy used to open with a
+// generic sentence and was therefore invisible in that kind of analytics.
+//
+// Treat this string as a published contract: gateways key on it, and changing
+// the wording silently drops Coddy out of their reports until they catch up.
+const Identity = "You are Coddy, an AI coding agent."
+
+// IdentityMarker is the lowercase substring a gateway keys on. It is kept
+// separate from Identity so the surrounding sentence can be reworded without
+// breaking attribution.
+const IdentityMarker = "you are coddy"
+
+// identityWindow mirrors how much of a system prompt a gateway inspects
+// (NeuralDeep reads the first 220 characters, lowercases them, then matches
+// substrings). A marker outside that prefix is as good as absent, so the
+// dedup check below uses the same window rather than scanning the whole text.
+const identityWindow = 220
+
+// WithIdentity guarantees a system prompt names Coddy inside the window a
+// gateway looks at.
+//
+// A prompt that already identifies itself there — the built-in templates do —
+// is returned untouched, so the common path reads as one natural sentence
+// instead of a stacked identity line plus a generic opener. Everything else
+// (a user's own prompts.dir template, the render fallback, the auxiliary
+// summarizer/title/memory prompts) gets the line prepended.
+func WithIdentity(prompt string) string {
+	trimmed := strings.TrimSpace(prompt)
+	if trimmed == "" {
+		return Identity
+	}
+	if strings.Contains(strings.ToLower(headOf(trimmed, identityWindow)), IdentityMarker) {
+		return trimmed
+	}
+	return Identity + "\n" + trimmed
+}
+
+// headOf returns at most n runes from the start of s. Runes rather than bytes
+// so a multi-byte prompt is not cut mid-character.
+func headOf(s string, n int) string {
+	if len(s) <= n { // fast path: byte length bounds rune count
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}

--- a/internal/prompts/identity_test.go
+++ b/internal/prompts/identity_test.go
@@ -1,0 +1,124 @@
+package prompts_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/prompts"
+)
+
+// Gateways that sit in front of the model attribute a request to a client by
+// matching the opening of its system prompt, so these tests pin two things:
+// the marker exists, and it stays close enough to the start to be seen.
+const gatewayWindow = 220
+
+func headWindow(s string) string {
+	if len(s) > gatewayWindow {
+		return s[:gatewayWindow]
+	}
+	return s
+}
+
+func assertIdentified(t *testing.T, prompt, what string) {
+	t.Helper()
+	head := strings.ToLower(headWindow(prompt))
+	if !strings.Contains(head, "you are coddy") {
+		t.Errorf("%s does not identify Coddy within the first %d characters:\n%s",
+			what, gatewayWindow, headWindow(prompt))
+	}
+}
+
+func TestWithIdentityPrependsMarkerToForeignPrompt(t *testing.T) {
+	custom := "You are a helpful assistant. Follow the house style."
+	got := prompts.WithIdentity(custom)
+
+	assertIdentified(t, got, "custom prompt")
+	if !strings.HasSuffix(got, custom) {
+		t.Errorf("original prompt must be preserved verbatim after the identity line, got:\n%s", got)
+	}
+}
+
+func TestWithIdentityDoesNotDuplicateExistingMarker(t *testing.T) {
+	already := prompts.Identity + "\nWorking directory: /tmp"
+	got := prompts.WithIdentity(already)
+
+	if got != already {
+		t.Errorf("a prompt that already identifies Coddy must be returned untouched, got:\n%s", got)
+	}
+	if strings.Count(strings.ToLower(got), "you are coddy") != 1 {
+		t.Errorf("identity line was duplicated:\n%s", got)
+	}
+}
+
+func TestWithIdentityDedupIsCaseInsensitive(t *testing.T) {
+	already := "YOU ARE CODDY, an AI coding agent.\nRest of the prompt."
+	if got := prompts.WithIdentity(already); got != already {
+		t.Errorf("dedup must ignore case, got:\n%s", got)
+	}
+}
+
+// A marker buried past the window is invisible to a gateway, so a prompt that
+// only names Coddy deep inside still has to get the line prepended.
+func TestWithIdentityPrependsWhenMarkerIsPastTheWindow(t *testing.T) {
+	buried := strings.Repeat("x", gatewayWindow+50) + " you are coddy"
+	got := prompts.WithIdentity(buried)
+
+	assertIdentified(t, got, "prompt naming Coddy past the window")
+}
+
+func TestWithIdentityHandlesEmptyPrompt(t *testing.T) {
+	if got := strings.TrimSpace(prompts.WithIdentity("")); got != prompts.Identity {
+		t.Errorf("empty prompt should collapse to the identity line, got %q", got)
+	}
+	if got := strings.TrimSpace(prompts.WithIdentity("   \n\t ")); got != prompts.Identity {
+		t.Errorf("blank prompt should collapse to the identity line, got %q", got)
+	}
+}
+
+func TestIdentityConstantCarriesTheMarker(t *testing.T) {
+	assertIdentified(t, prompts.Identity, "Identity constant")
+}
+
+// The built-in templates carry the name themselves so the common path reads as
+// one sentence instead of a stacked identity line plus a generic opener.
+func TestBuiltInTemplatesIdentifyCoddy(t *testing.T) {
+	for _, mode := range []string{"agent", "plan"} {
+		rendered, err := prompts.Render(mode, "", defaultAgentTplFile, defaultPlanTplFile, prompts.TemplateData{
+			CWD:    "/home/user/project",
+			UTCNow: fixtureUTC,
+		})
+		if err != nil {
+			t.Fatalf("Render %s: %v", mode, err)
+		}
+		assertIdentified(t, rendered, "built-in "+mode+" template")
+
+		// Built-in templates must not gain a second identity line on the way out.
+		if got := prompts.WithIdentity(rendered); got != rendered {
+			t.Errorf("built-in %s template should already satisfy WithIdentity", mode)
+		}
+	}
+}
+
+// A long working directory eats into the window; the marker must survive it.
+func TestBuiltInTemplatesIdentifyCoddyWithLongCWD(t *testing.T) {
+	long := "/home/user/" + strings.Repeat("nested-directory/", 12) + "project"
+	for _, mode := range []string{"agent", "plan"} {
+		rendered, err := prompts.Render(mode, "", defaultAgentTplFile, defaultPlanTplFile, prompts.TemplateData{
+			CWD:    long,
+			UTCNow: fixtureUTC,
+		})
+		if err != nil {
+			t.Fatalf("Render %s: %v", mode, err)
+		}
+		assertIdentified(t, rendered, "built-in "+mode+" template with a long CWD")
+	}
+}
+
+// RenderWithFallback returns a generic stub when a custom template is broken;
+// that stub has no name of its own and depends on WithIdentity.
+func TestFallbackPromptIsIdentifiedByWithIdentity(t *testing.T) {
+	fallback := prompts.RenderWithFallback("agent", "/nonexistent-prompts-dir",
+		defaultAgentTplFile, defaultPlanTplFile, prompts.TemplateData{CWD: "/tmp", UTCNow: fixtureUTC})
+
+	assertIdentified(t, prompts.WithIdentity(fallback), "render fallback")
+}

--- a/internal/prompts/plan.md
+++ b/internal/prompts/plan.md
@@ -1,4 +1,4 @@
-You are an AI planning assistant. Your job is to analyze, plan, and document.
+You are Coddy, an AI planning assistant. Your job is to analyze, plan, and document.
 Working directory: {{.CWD}}
 
 ## Mode: Plan


### PR DESCRIPTION
## Why

An LLM gateway cannot tell one OpenAI-compatible client from another by the wire protocol, so gateways attribute traffic by matching the **opening of the system prompt** against a table of known products (`"You are Claude Code…"`, `"You are Cline…"`). Coddy opened with a generic sentence and was therefore invisible in that kind of analytics.

Measured on a live NeuralDeep hub over a 6 hour window: 1670 requests and 31M tokens came from Coddy, and every one of them landed in the "unrecognised" bucket. The word `coddy` first appears at offset 609 in `agent.md` and 2604 in `plan.md`, well past the ~220 character prefix a gateway inspects.

## What changed

New `prompts.Identity` (`"You are Coddy, an AI coding agent."`) plus `prompts.WithIdentity`, applied at every site that sends a system message:

- `buildSystemPrompt`, last step before the context breakdown, so it also covers a user's own `prompts.dir` template and the render fallback;
- `buildCompactionRequest`, since the summarizer is its own request with its own prompt;
- the auxiliary HTTP prompts (chat-title generation, prompt enhancement) and the memory copilot.

The built-in `agent.md` and `plan.md` now open with the product name themselves, so `WithIdentity` detects it and returns them untouched rather than stacking a second identity line. A custom `prompts.dir` template does not need to name Coddy; the line is prepended for it automatically.

`prompts.Identity` is documented as a published contract: gateways key on the `you are coddy` substring, so rewording it drops Coddy out of their reports until they catch up.

## Tests

`features/agent_identity.feature` drives a **real turn through a fake provider** and asserts the system prompt as it goes on the wire, over four scenarios (agent/plan mode × built-in/custom templates). Verified red before the change (4 scenarios failed) and green after.

Unit tests cover the edges the spec deliberately leaves out: dedup when a template already names Coddy, a marker buried past the gateway window, an empty prompt, a long `{{.CWD}}` eating into the window, the render fallback, and the compaction summarizer. Two properties are locked everywhere — the marker lands within the first 220 characters, and it appears exactly once.

One existing test needed loosening: `bdd_remote_test.go` matched the enhance-prompt system message on exact equality. It now uses `Contains`, so the instruction is still asserted verbatim while tolerating the prefix.

`make test` (full matrix) and `make lint` both pass.

No UI surfaces were touched, so there are no screenshots to attach. The HTTP API surface and `internal/config` yaml structs are unchanged, so `openapi.go` and `docs/config.schema.json` need no sync; `config.example.yaml` gained a comment only.

## Docs

New "Agent identity" section in `docs/react-agent.md` with the rationale, the full list of call sites and the two locked properties, plus pointers from `docs/config.md` and `config.example.yaml` next to `prompts.dir`.

## Counterpart

The gateway side is a separate PR on the NeuralDeep hub, which adds `you are coddy` to its classifier together with two needles for the historical wording, so builds released before this change stay attributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)