### PR TITLE
fix(llm): preserve reasoning on truncated streams

### DIFF
--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -367,6 +367,33 @@ func TestOpenAIStreamTruncatedBeforeFirstDelta(t *testing.T) {
 	}
 }
 
+// TestOpenAIStreamTruncatedKeepsReasoningOnlyPartial ensures a cut stream
+// preserves reasoning that was already sent to the caller, even if no answer
+// text followed it. The ReAct loop needs a non-nil response to persist that
+// visible reasoning next to the truncation error.
+func TestOpenAIStreamTruncatedKeepsReasoningOnlyPartial(t *testing.T) {
+	p, done := streamStubProvider(t,
+		"data: {\"choices\":[{\"finish_reason\":null,\"index\":0,\"delta\":{\"reasoning_content\":\"Thinking through it\"}}],\"id\":\"chatcmpl-tr\",\"model\":\"test-model\",\"object\":\"chat.completion.chunk\"}\n\n")
+	defer done()
+
+	var streamed strings.Builder
+	resp, err := p.Stream(context.Background(), []Message{{Role: RoleUser, Content: "hi"}}, nil, func(c StreamChunk) {
+		streamed.WriteString(c.ReasoningDelta)
+	})
+	if !IsStreamTruncated(err) {
+		t.Fatalf("err = %v, want stream truncation", err)
+	}
+	if isRetryableLLMError(err) {
+		t.Fatal("truncation after emitted reasoning must not be retryable")
+	}
+	if got := streamed.String(); got != "Thinking through it" {
+		t.Fatalf("streamed reasoning = %q, want %q", got, "Thinking through it")
+	}
+	if resp == nil || resp.Content != "" || resp.Reasoning != "Thinking through it" {
+		t.Fatalf("resp = %+v, want reasoning-only partial response", resp)
+	}
+}
+
 // TestOpenAIStreamTruncatedNotRetriedAfterDeltas pins the resilient-wrapper
 // contract for truncations: once deltas reached the caller the request is
 // not replayed (the same text would stream twice) and the partial response

--- a/internal/llm/openai_stream.go
+++ b/internal/llm/openai_stream.go
@@ -211,6 +211,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 	defer func() { _ = raw.Body.Close() }()
 
 	var fullContent string
+	var reasoningBuf strings.Builder
 	var toolCalls []ToolCall
 	var stopReason string
 	var inputTokens, outputTokens int
@@ -309,6 +310,7 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 				r = gjson.Get(raw, "thinking").String()
 			}
 			if r != "" {
+				reasoningBuf.WriteString(r)
 				emit(StreamChunk{ReasoningDelta: r})
 			}
 		}
@@ -355,13 +357,14 @@ func (p *openAIProvider) Stream(ctx context.Context, messages []Message, tools [
 
 	if streamErr != nil {
 		if IsStreamTruncated(streamErr) {
-			// Keep the text the caller already saw, like the cancellation
-			// branch below. Unfinished tool-call builders are dropped
+			// Keep the user-visible output the caller already saw, like the
+			// cancellation branch below. Unfinished tool-call builders are dropped
 			// deliberately: their arguments may be cut mid-JSON, and
 			// replaying an invalid call is worse than losing it.
-			if strings.TrimSpace(fullContent) != "" {
+			if strings.TrimSpace(fullContent) != "" || strings.TrimSpace(reasoningBuf.String()) != "" {
 				return &Response{
 					Content:      fullContent,
+					Reasoning:    reasoningBuf.String(),
 					InputTokens:  inputTokens,
 					OutputTokens: outputTokens,
 				}, fmt.Errorf("openai stream: %w", streamErr)


### PR DESCRIPTION
Preserves reasoning-only output when an OpenAI-compatible stream terminates before a final marker, so ReAct retains user-visible thinking alongside the truncation error. Adds a regression test for the reasoning-only path. Tests: go test ./internal/llm ./internal/agent ./internal/config.