### PR TITLE
fix(examples): read the ACP slash catalog after the session/new response

### DIFF
--- a/examples/acp/acp_e2e_rules.py
+++ b/examples/acp/acp_e2e_rules.py
@@ -3,7 +3,7 @@
 
 Copies ``examples/rules_fixture/.coddy/rules`` into the session work dir, then:
 
-1. ``available_commands_update`` includes ``generate-rules``.
+1. ``available_commands_update`` (written after the ``session/new`` response) includes ``generate-rules``.
 2. Glob rule activates with a Go file resource block; assistant includes ``RULE_GLOB_TOKEN:e2e-glob``.
 3. Mention-only rule via ``@mention_demo`` includes ``RULE_MENTION_TOKEN:e2e-mention``.
 """
@@ -123,6 +123,37 @@ def collect_assistant_text(backlog: list[dict[str, Any]]) -> str:
     return "".join(parts)
 
 
+def wait_for_session_update(
+    proc: subprocess.Popen[str],
+    session_update: str,
+    max_lines: int = 64,
+) -> list[dict[str, Any]]:
+    """Read notifications until a ``session/update`` of the given kind arrives.
+
+    Coddy writes ``available_commands_update`` only after the ``session/new`` (or
+    ``session/load``) response is on the wire, so the catalog is never part of that
+    call's backlog (see ``docs/acp-protocol.md``). Returns every line read, the
+    matching notification last, so callers can fold it into the earlier backlog.
+    """
+    assert proc.stdout is not None
+    seen: list[dict[str, Any]] = []
+    for _ in range(max_lines):
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("unexpected EOF from coddy stdout")
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        seen.append(msg)
+        if msg.get("method") != "session/update":
+            continue
+        u = msg.get("params", {}).get("update") or {}
+        if u.get("sessionUpdate") == session_update:
+            return seen
+    raise RuntimeError(f"no {session_update} notification within {max_lines} lines after the response")
+
+
 def slash_command_names(backlog: list[dict[str, Any]]) -> set[str]:
     out: set[str] = set()
     for m in backlog:
@@ -230,6 +261,7 @@ def main() -> int:
             print("missing sessionId", jd(r1), file=sys.stderr)
             return 1
 
+        bl1 += wait_for_session_update(proc, "available_commands_update")
         names = slash_command_names(bl1)
         if BUNDLED_SLASH not in names:
             print("slash catalog missing", BUNDLED_SLASH, "got", sorted(names), file=sys.stderr)

--- a/examples/acp/acp_e2e_skills_slash.py
+++ b/examples/acp/acp_e2e_skills_slash.py
@@ -3,7 +3,8 @@
 
 Mirrors ``examples/httpserver/http_e2e_skills_slash.py`` over stdio JSON-RPC:
 
-1. After ``session/new``, an ``available_commands_update`` lists the fixture command ``coddy_slash_demo``.
+1. After ``session/new``, an ``available_commands_update`` lists the fixture command ``coddy_slash_demo``
+   (the notification follows the ``session/new`` response, so the script reads past it).
 2. A ``session/prompt`` starting with ``/coddy_slash_demo`` yields assistant text containing ``DEMO_SKILL_TOKEN:z7k9-demo-slash``.
 3. A control turn must not repeat that token.
 
@@ -126,6 +127,37 @@ def collect_assistant_text(backlog: list[dict[str, Any]]) -> str:
     return "".join(parts)
 
 
+def wait_for_session_update(
+    proc: subprocess.Popen[str],
+    session_update: str,
+    max_lines: int = 64,
+) -> list[dict[str, Any]]:
+    """Read notifications until a ``session/update`` of the given kind arrives.
+
+    Coddy writes ``available_commands_update`` only after the ``session/new`` (or
+    ``session/load``) response is on the wire, so the catalog is never part of that
+    call's backlog (see ``docs/acp-protocol.md``). Returns every line read, the
+    matching notification last, so callers can fold it into the earlier backlog.
+    """
+    assert proc.stdout is not None
+    seen: list[dict[str, Any]] = []
+    for _ in range(max_lines):
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("unexpected EOF from coddy stdout")
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        seen.append(msg)
+        if msg.get("method") != "session/update":
+            continue
+        u = msg.get("params", {}).get("update") or {}
+        if u.get("sessionUpdate") == session_update:
+            return seen
+    raise RuntimeError(f"no {session_update} notification within {max_lines} lines after the response")
+
+
 def slash_command_names(backlog: list[dict[str, Any]]) -> set[str]:
     out: set[str] = set()
     for m in backlog:
@@ -230,6 +262,7 @@ def main() -> int:
             print("missing sessionId", jd(r1), file=sys.stderr)
             return 1
 
+        bl1 += wait_for_session_update(proc, "available_commands_update")
         names = slash_command_names(bl1)
         if FIXTURE_SLASH_NAME not in names:
             print(


### PR DESCRIPTION
## Summary

`examples/acp/acp_e2e_skills_slash.py` failed on main with `slash catalog missing coddy_slash_demo got []` (and `acp_e2e_rules.py`, the next step of `examples/acp/test_acp.sh`, fails the same way).

**Cause.** Both scripts collected `available_commands_update` from the backlog of the `session/new` call. Since the replay hold (22a983b, PR #79) that notification is written from `HandleSessionReady`, strictly after the `session/new` result is on the wire (see `docs/acp-protocol.md`, "available_commands_update"). The script's `rpc_call` returned on the response, so the catalog landed in the backlog of the following call and the name set was empty. A raw stdout probe with the same `--home`, `CODDY_HOME` and `config.demo.yaml` shows the response on one line and the catalog with `coddy_slash_demo` on the next, so `${CODDY_HOME}` expansion in `skills.dirs` was never the problem.

**Change.** A small `wait_for_session_update` helper in both scripts reads notifications past the `session/new` response until the catalog arrives and folds them into the backlog. No Go change, so no Go regression test.

## Verification

Binary built with `make build TAGS="http scheduler memory cli"` from this branch, `CODDY_CONFIG=examples/config.demo.yaml`:

- `python3 examples/acp/acp_e2e_skills_slash.py` passes;
- `python3 examples/acp/acp_e2e_rules.py` passes;
- `examples/acp/test_acp.sh` passes smoke, models, web, todo, skills slash, rules and config, then stops in `acp_e2e_memory.py`.

The memory failure is unrelated and reproducible on main: the memory copilot persists a note that does not contain the `MEMFRUIT_...` codeword the script scans for. Left out of this PR on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
