### PR TITLE
fix(examples): align compaction e2e harnesses with the forced /compact contract

### DIFF
--- a/examples/acp/acp_e2e_compact.py
+++ b/examples/acp/acp_e2e_compact.py
@@ -8,7 +8,7 @@ Phase 1 (manual): seeds three short real-LLM exchanges, sends the built-in
 
 - ``messages.json`` gains a row with ``compaction_summary: true``;
 - every seeded exchange stays in the transcript (nothing is deleted);
-- the ``/compact`` command text itself is not persisted;
+- the ``/compact`` command text itself is persisted as a ``user`` row;
 - an assistant confirmation row mentions the compaction;
 - a follow-up prompt still works (the session continues from the summary).
 
@@ -209,8 +209,11 @@ def run_manual_phase(binary: str, cfg: str, session_root: str, session_id: str) 
             if p not in joined:
                 print(f"FAIL: seeded prompt lost from transcript: {p!r}", file=sys.stderr)
                 rc = rc or 13
-        if "/compact" in joined:
-            print("FAIL: /compact command leaked into transcript", file=sys.stderr)
+        if not any(
+            m.get("role") == "user" and str(m.get("content", "")).strip() == "/compact"
+            for m in msgs
+        ):
+            print("FAIL: /compact command missing from transcript", file=sys.stderr)
             rc = rc or 14
         if not any(
             m.get("role") == "assistant" and "compact" in str(m.get("content", "")).lower()

--- a/examples/httpserver/http_e2e_compact.py
+++ b/examples/httpserver/http_e2e_compact.py
@@ -12,12 +12,14 @@ Checks:
 
 1. Three short exchanges seed a session; ``/compact`` sent as a normal prompt
    returns a confirmation text and inserts a ``compaction_summary`` row into
-   ``GET /coddy/sessions/{id}/messages`` while keeping every original row and
-   not persisting the command text.
+   ``GET /coddy/sessions/{id}/messages`` while keeping every original row; the
+   command text itself is persisted as a ``user`` row like any other input.
 2. A second session compacts via ``POST /coddy/sessions/{id}/compact``: 200
    with ``compacted: true``, non-empty ``summary``, positive counts.
-3. ``POST .../compact`` on a too-short session answers 200 with
-   ``compacted: false`` and reason ``nothing_to_compact``.
+3. ``POST .../compact`` on a one-turn session is forced like any manual
+   trigger: 200 with ``compacted: true`` and ``kept_messages: 0`` (the kept
+   tail shrinks until something folds; ``nothing_to_compact`` is reserved for
+   a session with no prior conversation at all).
 4. A follow-up prompt after compaction still produces an assistant reply.
 
 Environment:
@@ -128,8 +130,11 @@ def main() -> int:
         if p not in joined:
             print(f"FAIL: seeded prompt lost: {p!r}", file=sys.stderr)
             rc = rc or 13
-    if any(str(m.get("content", "")).strip() == "/compact" for m in msgs):
-        print("FAIL: /compact command persisted in transcript", file=sys.stderr)
+    if not any(
+        m.get("role") == "user" and str(m.get("content", "")).strip() == "/compact"
+        for m in msgs
+    ):
+        print("FAIL: /compact command missing from transcript", file=sys.stderr)
         rc = rc or 14
 
     _, follow = agent_turn(v1, sid, "Reply with exactly: STILL-ALIVE")
@@ -164,11 +169,16 @@ def main() -> int:
         print("FAIL: endpoint compaction left no summary row", file=sys.stderr)
         rc = rc or 24
 
-    # --- 3. nothing_to_compact on a short session ----------------------------
+    # --- 3. manual trigger forces compaction on a short session ---------------
     sid3, _ = agent_turn(v1, None, "Reply with exactly: OK")
     code, body, _ = http_json("POST", f"{origin}/coddy/sessions/{sid3}/compact", {}, {})
-    if code != 200 or body.get("compacted") is not False or body.get("reason") != "nothing_to_compact":
-        print(f"FAIL: short session compact {code}: {body}", file=sys.stderr)
+    if (
+        code != 200
+        or body.get("compacted") is not True
+        or int(body.get("compacted_messages", 0)) <= 0
+        or int(body.get("kept_messages", -1)) != 0
+    ):
+        print(f"FAIL: short session forced compact {code}: {body}", file=sys.stderr)
         rc = rc or 31
 
     if rc == 0:


### PR DESCRIPTION
## Summary

`examples/httpserver/http_e2e_compact.py` and `examples/acp/acp_e2e_compact.py` fail on a binary built from main (`make build TAGS="http scheduler memory cli"`, `CODDY_CONFIG=examples/config.demo.yaml`, model `rpa/gpt-oss:120b`), so no open PR causes it:

- `FAIL: /compact command persisted in transcript` (HTTP, rc 14) and `FAIL: /compact command leaked into transcript` (ACP, rc 14);
- `FAIL: short session compact 200: {'compacted': True, ...}` (HTTP, rc 31).

**Cause.** Both harnesses date from eeb271d and were never updated after 38627e8, which changed the manual compaction contract on purpose: the built-in `/compact` command persists its own text as a `user` row (`runCompactCommand` in `internal/agent/compact.go`), and the manual trigger, both the command and `POST /coddy/sessions/{id}/compact`, **forces** compaction by shrinking the kept tail down to zero turns, so a one-turn session compacts instead of answering `nothing_to_compact`. Code, `docs/http-api.md`, the served OpenAPI, `features/context_compaction_command.feature` ("the /compact command is part of the transcript") and `TestRunCompactCommandForcesShortChat` all agree, so the harnesses are the stale side.

**Change.** Scripts only, no Go change:

- both scripts now require a `user` row whose content is exactly `/compact` instead of asserting its absence (exit code 14 unchanged);
- the HTTP one-turn check now expects the forced result: 200 with `compacted: true`, positive `compacted_messages`, and `kept_messages == 0` (exit code 31 unchanged);
- docstrings describe the new expectations. `examples/README.md` still describes both harnesses accurately and is untouched.

## Verification

Binary built with `./examples/build_coddy.sh` from this branch, demo config:

- `http_e2e_compact.py` and `acp_e2e_compact.py` pass against a scratch `coddy http`;
- both pass again through exact copies of `examples/httpserver/test_httpserver.sh` and `examples/acp/test_acp.sh` with the full wrapper setup (temp home, resolved config, fixtures, `--scheduler-enabled`) and only the compact step kept.

The unmodified wrappers cannot reach the compact step on main today for reasons unrelated to this PR: `test_httpserver.sh` stops at `http_e2e_models.py` because api.rpa.icu no longer serves `gpt-oss:20b` (demo config swap handled separately), and `test_acp.sh` stops at `acp_e2e_skills_slash.py`, the catalog race fixed in #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
