### PR TITLE
fix(examples): point the demo config's second model at a model rpa still serves

### DIFF
--- a/examples/cli/cli_e2e_models.py
+++ b/examples/cli/cli_e2e_models.py
@@ -15,13 +15,13 @@ def main() -> int:
         tui.wait_for("coddy v", timeout=30)
         tui.wait_for("qwen3.8-27b", timeout=10)  # footer shows the default
         # Switch by explicit id (validated by the manager against YAML models).
-        tui.type_text("/model rpa/gpt-oss:20b")
+        tui.type_text("/model rpa/qwen3.6-35b-a3b")
         tui.send(CR)
-        tui.wait_for("(rpa) gpt-oss:20b", timeout=20)
+        tui.wait_for("(rpa) qwen3.6-35b-a3b", timeout=20)
         session = tui.single_session_dir() / "session.json"
         data = json.loads(session.read_text())
         blob = json.dumps(data)
-        if "gpt-oss:20b" not in blob:
+        if "qwen3.6-35b-a3b" not in blob:
             raise AssertionError("session.json does not record the switched model")
         return ok("cli_e2e_models")
     finally:

--- a/examples/config.demo.yaml
+++ b/examples/config.demo.yaml
@@ -14,10 +14,10 @@ models:
     max_tokens: 131072
     temperature: 0.2
     max_context_tokens: 131072
-  - model: "rpa/gpt-oss:20b"
-    max_tokens: 8192
-    temperature: 0.2
-    max_context_tokens: 8192
+  - model: "rpa/qwen3.6-35b-a3b"
+    max_tokens: 32000
+    temperature: 0.6
+    max_context_tokens: 262144
   - model: "neuraldeep/qwen3.8-27b"
     max_tokens: 32000
     temperature: 0.6

--- a/examples/httpserver/http_e2e_models.py
+++ b/examples/httpserver/http_e2e_models.py
@@ -158,7 +158,7 @@ def main() -> int:
         print("metadata.model mismatch", md, "want", alt, file=sys.stderr)
         return 1
 
-    # Switch metadata.model back to agent default (e.g. 120b after testing 20b).
+    # Switch metadata.model back to agent default (e.g. gpt-oss:120b after testing qwen3.6-35b-a3b).
     if alt != agent_default:
         extra: dict[str, str] = {}
         if sid:


### PR DESCRIPTION
## Summary

`examples/test_httpserver.sh` failed on main at step 3, `http_e2e_models.py`, with `bad profile completion 500 ...`, so none of the later harnesses ran.

**Cause.** As of 2026-09-03 `GET https://api.rpa.icu/models` with the demo key returns only `GigaChat-2`, `gpt-oss:120b`, `large-v2`, and `qwen3.6-35b-a3b`. `examples/config.demo.yaml` still listed `rpa/gpt-oss:20b` as its second `models[]` row. `http_e2e_models.py` steers a completion to that row via `metadata.model`, the provider answers `400 Invalid model name passed in model=gpt-oss:20b`, the gateway wraps it in a 500, and the wrapper stops under `set -e`. The binary and the harness are fine; the demo catalog was stale.

## Change

- `examples/config.demo.yaml`: the second row is now `rpa/qwen3.6-35b-a3b` with `max_tokens: 32000`, `temperature: 0.6`, `max_context_tokens: 262144`. The provider runs it on vLLM, accepts a 140k-token prompt and rejects 400k, so the native 262144 window is the working figure.
- `examples/cli/cli_e2e_models.py`: switches to the same id and expects the footer label `(rpa) qwen3.6-35b-a3b`.
- `examples/httpserver/http_e2e_models.py`: stale comment naming 20b refreshed.

`acp_e2e_models.py`, `examples/README.md`, and `docs/` do not mention `gpt-oss:20b`; the only other occurrence in the repo is a synthetic id in a reasoning unit test.

## Verification

Fresh build via `./examples/build_coddy.sh` (0.9.89).

- `http_e2e_models` passes. The session transcript shows the "OK." reply carried `model: rpa/qwen3.6-35b-a3b` and the restore turn returned to `gpt-oss:120b`, so the provider really served the new row.
- `cli_e2e_models` passes live (pexpect + pyte).
- `./examples/test_httpserver.sh` ran twice: steps 1-10 green. One run saw a reasoning-only reply from `gpt-oss:120b` in the todo harness, which passed on the rerun (model-side flake on the unchanged default row).
- Steps 12-17 (`scheduler_agent`, `plan_files`, `config`, `remote`, `background_reap`) all pass when run with the wrapper's exact setup minus the compact step.

## Out of scope

`http_e2e_compact.py` (step 11) now exits 14 with two assertions that contradict deliberate server behavior: it expects the `/compact` user row to be hidden, but `runCompactCommand` in `internal/agent/compact.go` persists it on purpose; and it expects a short session to answer `nothing_to_compact`, but both compact surfaces call `CompactSession` with force set. This drift was masked while the wrapper died at step 3. The fix belongs in the harness expectations (the ACP twin likely shares them) and is left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
