### PR TITLE
fix(cli): wire the config reloader into the console and fix e2e idle detection

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,15 @@ Slash commands: client-side `/model`, `/mode`, `/resume`, `/new`, `/theme`,
 skill (from the ACP available-commands catalog). Enter on a slash suggestion
 applies and submits in one stroke.
 
+Agent self-configuration works as it does over ACP and HTTP: every turn
+offers the staged config tools (`config_get`, `config_set`,
+`config_changes`, `config_commit`, `config_revert`, `config_rollback`; see
+**Agent self-configuration** in `docs/config-reference.md`), and a commit or
+rollback hot-reloads the running console, so the model catalog (`ctrl+l`,
+`ctrl+p`), the footer, and the header's `[Context]`, `[Skills]`, `[Rules]`,
+and `[MCP]` sections follow the new file without a restart. `-p/--prompt`
+offers the same tools; under `--remote` the server owns the reload.
+
 | Key | Action |
 |-----|--------|
 | enter | send |

--- a/examples/cli/capture.py
+++ b/examples/cli/capture.py
@@ -148,7 +148,7 @@ def main() -> int:
         tui.pump(0.3)
 
         tui.prompt("What is 17*23? Explain briefly, then answer.")
-        tui.wait_for("Working...", timeout=30)
+        tui.wait_turn_started(timeout=30)
         tui.pump(1.0)
         snapshot(tui, outdir, "04-working")
         tui.wait_idle(timeout=240)

--- a/examples/cli/cli_e2e_compact.py
+++ b/examples/cli/cli_e2e_compact.py
@@ -18,7 +18,7 @@ def main() -> int:
         tui.wait_idle(timeout=240)
         tui.type_text("/compact")
         tui.send(CR)
-        tui.wait_for("Working...", timeout=60)
+        tui.wait_turn_started(timeout=60)
         tui.wait_idle(timeout=300)
         msgs = tui.messages()
         if not any(m.get("compaction_summary") for m in msgs):

--- a/examples/cli/cli_e2e_skills_slash.py
+++ b/examples/cli/cli_e2e_skills_slash.py
@@ -21,7 +21,7 @@ def main() -> int:
         tui.wait_for("coddy_slash_demo", timeout=20)  # header [Skills] section
         tui.type_text("/coddy_slash_demo run the demo")
         tui.send(CR)
-        tui.wait_for("Working...", timeout=30)
+        tui.wait_turn_started(timeout=30)
         tui.wait_idle(timeout=240)
         if DEMO_TOKEN not in tui.assistant_text():
             raise AssertionError("demo skill token missing from the assistant reply")

--- a/examples/cli/cli_smoke.py
+++ b/examples/cli/cli_smoke.py
@@ -14,7 +14,7 @@ def main() -> int:
         tui.wait_for("coddy v", timeout=30)
         tui.wait_for("escape interrupt", timeout=10)
         tui.prompt("Reply with exactly: CLI_SMOKE_OK")
-        tui.wait_for("Working...", timeout=30)
+        tui.wait_turn_started(timeout=30)
         tui.wait_idle(timeout=240)
         tui.wait_session_file("messages.json", timeout=30)
         msgs = tui.messages()

--- a/examples/cli/cli_tui_driver.py
+++ b/examples/cli/cli_tui_driver.py
@@ -4,13 +4,14 @@
 Spawns `coddy cli --plain --theme dark` in a pty (pexpect), feeds the output
 through a pyte terminal emulator, and exposes wait/send/assert helpers.
 Assertions favor on-disk session artifacts; screen greps are limited to
-deterministic chrome (headers, spinner label, fixture tokens).
+deterministic chrome (headers, the spinner glyph, fixture tokens).
 
 Linux-only (pty). Requires: pexpect, pyte (examples/cli/requirements.txt).
 """
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import shutil
@@ -50,6 +51,36 @@ CTRL_D = "\x04"
 CTRL_L = "\x0c"
 CTRL_O = "\x0f"
 CTRL_T = "\x14"
+
+# Braille frames of the console spinner (external/cli/tui/loader.go). The
+# status phrase next to it changes with the step ("Waiting for the model",
+# "Reading README.md · 3s"), so the glyph is the only stable "turn running"
+# chrome on screen.
+SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+TURN_LOCK_NAME = ".coddy-turn.lock"
+
+
+def turn_lock_held(session_dir: Path) -> bool:
+    """True while the console holds the exclusive flock on the session's turn lock.
+
+    The file stays on disk after the turn; only the flock says whether a
+    turn is running (internal/session/manager_turn_lock_unix.go).
+    """
+    try:
+        fd = os.open(session_dir / TURN_LOCK_NAME, os.O_RDONLY)
+    except OSError:
+        return False
+    try:
+        fcntl.flock(fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return True
+    except OSError:
+        return False
+    else:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(fd)
 
 
 def coddy_bin() -> str:
@@ -208,13 +239,45 @@ class CoddyTUI:
         self.dump(f"wait_gone({needle!r}) timed out")
         raise AssertionError(f"screen still shows {needle!r}")
 
+    def turn_running(self) -> bool:
+        """A turn is running while the spinner is on screen or the turn lock is held."""
+        text = self.text()
+        if any(frame in text for frame in SPINNER_FRAMES):
+            return True
+        return any(turn_lock_held(d) for d in self.session_dirs())
+
+    def wait_turn_started(self, timeout: float = 30.0) -> None:
+        """Wait until a submitted prompt (or slash command) is visibly running."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            self.pump(0.3)
+            if self.turn_running():
+                return
+        self.dump("wait_turn_started timed out")
+        raise AssertionError("the turn never started")
+
     def wait_idle(self, timeout: float = 240.0) -> None:
-        """Wait until the working spinner label disappears."""
+        """Wait until the running turn ends: no spinner on screen and the turn lock released.
+
+        A turn that has not started yet within the grace period counts as
+        finished (a fast failure can end before the first poll).
+        """
         self.pump(1.0)
-        self.wait_gone("Working...", timeout=timeout)
-        if not self.child.isalive():
-            self.dump("child exited while waiting for idle")
-            raise AssertionError("coddy exited during the turn")
+        deadline = time.time() + timeout
+        grace = time.time() + 5.0
+        seen = False
+        while time.time() < deadline:
+            self.pump(0.3)
+            if not self.child.isalive():
+                self.dump("child exited while waiting for idle")
+                raise AssertionError("coddy exited during the turn")
+            if self.turn_running():
+                seen = True
+                continue
+            if seen or time.time() >= grace:
+                return
+        self.dump("wait_idle timed out")
+        raise AssertionError("the turn is still running")
 
     def send(self, data: str) -> None:
         self.child.send(data.encode())

--- a/external/cli/app.go
+++ b/external/cli/app.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/EvilFreelancer/coddy-agent/external/cli/tui"
@@ -35,9 +36,12 @@ type turnDone struct {
 // App is the interactive console application: one UI goroutine over a
 // session manager, rendering ACP updates into a component tree.
 type App struct {
-	cfg *config.Config
-	mgr backend
-	log *slog.Logger
+	// cfgAt is the live process configuration. config_commit and
+	// config_rollback swap it from a turn worker (see replaceConfig) while
+	// the UI goroutine and other workers keep reading it, hence the atomic.
+	cfgAt atomic.Pointer[config.Config]
+	mgr   backend
+	log   *slog.Logger
 
 	// remoteURL is set when mgr talks to a remote coddy http server.
 	remoteURL string
@@ -118,7 +122,6 @@ type App struct {
 // newApp assembles the application over an existing manager and terminal.
 func newApp(cfg *config.Config, mgr backend, log *slog.Logger, term appTerminal, themeName string, plain bool) *App {
 	a := &App{
-		cfg:             cfg,
 		mgr:             mgr,
 		log:             log,
 		term:            term,
@@ -136,6 +139,7 @@ func newApp(cfg *config.Config, mgr backend, log *slog.Logger, term appTerminal,
 		closed:          make(chan struct{}),
 		doneCh:          make(chan struct{}),
 	}
+	a.cfgAt.Store(cfg)
 	a.workCtx, a.workStop = context.WithCancel(context.Background())
 	a.applyTheme(themeName)
 	a.buildTree()
@@ -144,6 +148,33 @@ func newApp(cfg *config.Config, mgr backend, log *slog.Logger, term appTerminal,
 
 // Sender returns the acp.UpdateSender facade for the manager and turns.
 func (a *App) Sender() acp.UpdateSender { return &sender{app: a} }
+
+// config returns the live process configuration (never nil after newApp).
+func (a *App) config() *config.Config { return a.cfgAt.Load() }
+
+// replaceConfig adopts a reloaded process configuration. config_commit and
+// config_rollback call it from the turn worker once the manager reloaded,
+// so the pointer swap happens here and the visible refresh (model catalog,
+// footer, header sections) is queued for the UI goroutine. st is the
+// session whose turn committed; its option set carries the new model
+// catalog.
+func (a *App) replaceConfig(next *config.Config, st *session.State) {
+	if a == nil || next == nil {
+		return
+	}
+	a.cfgAt.Store(next)
+	msg := configReloaded{}
+	sessionID := ""
+	if st != nil {
+		sessionID = st.GetID()
+		msg.opts = session.BuildACPConfigOptions(next, st)
+	}
+	_ = a.Sender().SendSessionUpdate(sessionID, msg)
+}
+
+// configReloaded is the internal update completing replaceConfig on the UI
+// goroutine.
+type configReloaded struct{ opts []acp.ConfigOption }
 
 func (a *App) applyTheme(name string) {
 	a.themeName = name
@@ -164,7 +195,7 @@ func (a *App) buildTree() {
 	a.editor.OnChange = a.onEditorChange
 	a.editorWrap = &tui.Container{}
 	a.editorWrap.AddChild(a.editor)
-	a.foot = newFooter(a.theme, a.cfg.Paths.CWD)
+	a.foot = newFooter(a.theme, a.config().Paths.CWD)
 
 	root := a.screen.Root
 	root.AddChild(a.header)
@@ -175,7 +206,7 @@ func (a *App) buildTree() {
 	root.AddChild(a.foot)
 	a.screen.SetFocus(a.editor)
 
-	provider := newCompletionProvider(a.cfg.Paths.CWD, a.slashCatalog)
+	provider := newCompletionProvider(a.config().Paths.CWD, a.slashCatalog)
 	a.editor.SetAutocomplete(provider, selectListTheme(a.theme), tui.SelectListLayout{MinPrimaryColumnWidth: 12, MaxPrimaryColumnWidth: 32}, a.screen.RequestRender)
 }
 
@@ -192,7 +223,7 @@ func (a *App) Start(ctx context.Context, sessionID string, resume bool) error {
 			}
 			a.mgr.SetPreferredSessionID(sessionID)
 		}
-		res, err := a.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: a.cfg.Paths.CWD})
+		res, err := a.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: a.config().Paths.CWD})
 		if err != nil {
 			return fmt.Errorf("session/new: %w", err)
 		}
@@ -249,7 +280,7 @@ func (a *App) adoptSession(id string, modes *acp.ModeState, opts []acp.ConfigOpt
 		}
 	}
 	if a.modelID == "" {
-		a.modelID = a.cfg.Agent.Model
+		a.modelID = a.config().Agent.Model
 	}
 	a.refreshFooterModel()
 	a.foot.SetSession("", a.modeID)
@@ -259,11 +290,11 @@ func (a *App) refreshFooterModel() {
 	reasoning := a.reasoning
 	if reasoning == "" {
 		if st := a.mgr.SessionByID(a.sessionID); st != nil {
-			reasoning = st.EffectiveReasoning(a.cfg)
+			reasoning = st.EffectiveReasoning(a.config())
 		}
 	}
 	if reasoning == "" {
-		if entry := a.cfg.FindModelEntry(a.modelID); entry != nil {
+		if entry := a.config().FindModelEntry(a.modelID); entry != nil {
 			reasoning = entry.ReasoningDefault
 		}
 	}
@@ -272,7 +303,7 @@ func (a *App) refreshFooterModel() {
 
 func (a *App) populateHeader() {
 	var contextFiles []string
-	contextFiles = append(contextFiles, a.cfg.Instructions.Files...)
+	contextFiles = append(contextFiles, a.config().Instructions.Files...)
 	var skillNames []string
 	rulesCount := 0
 	if st := a.mgr.SessionByID(a.sessionID); st != nil {
@@ -282,7 +313,7 @@ func (a *App) populateHeader() {
 		rulesCount = len(st.GetRulesCatalog())
 	}
 	var mcpNames []string
-	for _, srv := range a.cfg.MCPServers {
+	for _, srv := range a.config().MCPServers {
 		mcpNames = append(mcpNames, srv.Name)
 	}
 	a.header.SetSections(contextFiles, skillNames, rulesCount, mcpNames)
@@ -667,7 +698,7 @@ func (a *App) modelIDs() []string {
 		return values
 	}
 	var ids []string
-	for _, m := range a.cfg.Models {
+	for _, m := range a.config().Models {
 		ids = append(ids, m.Model)
 	}
 	return ids
@@ -752,11 +783,11 @@ func (a *App) cycleModel(dir int) {
 }
 
 func (a *App) cycleReasoning() {
-	entry := a.cfg.FindModelEntry(a.modelID)
+	entry := a.config().FindModelEntry(a.modelID)
 	// Cycle the levels the model actually offers, not just a configured override:
 	// ReasoningLevelsFor is the same resolved, provider-aware list the composer and
 	// GET /v1/models expose, so shift+tab works for auto-detected reasoning models too.
-	levels := a.cfg.ReasoningLevelsFor(entry)
+	levels := a.config().ReasoningLevelsFor(entry)
 	if entry == nil || len(levels) == 0 {
 		return
 	}
@@ -832,13 +863,13 @@ type toolFullLoaded struct {
 
 // pickSessionBlocking shows the resume picker before the UI loop starts.
 func (a *App) pickSessionBlocking(ctx context.Context) error {
-	cwd := a.cfg.Paths.CWD
+	cwd := a.config().Paths.CWD
 	res, err := a.mgr.HandleSessionList(ctx, acp.SessionListParams{CWD: &cwd})
 	if err != nil {
 		return fmt.Errorf("session list: %w", err)
 	}
 	if len(res.Sessions) == 0 {
-		newRes, err := a.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: a.cfg.Paths.CWD})
+		newRes, err := a.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: a.config().Paths.CWD})
 		if err != nil {
 			return fmt.Errorf("session/new: %w", err)
 		}
@@ -875,7 +906,7 @@ func (a *App) pickSessionBlocking(ctx context.Context) error {
 		case item := <-choice:
 			a.closeModal()
 			if item == nil {
-				newRes, err := a.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: a.cfg.Paths.CWD})
+				newRes, err := a.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: a.config().Paths.CWD})
 				if err != nil {
 					return fmt.Errorf("session/new: %w", err)
 				}
@@ -900,7 +931,7 @@ func (a *App) loadSession(ctx context.Context, id string) error {
 	}
 	resCh := make(chan loadResult, 1)
 	go func() {
-		res, err := a.mgr.HandleSessionLoad(ctx, acp.SessionLoadParams{SessionID: id, CWD: a.cfg.Paths.CWD})
+		res, err := a.mgr.HandleSessionLoad(ctx, acp.SessionLoadParams{SessionID: id, CWD: a.config().Paths.CWD})
 		mode := ""
 		var opts []acp.ConfigOption
 		if err == nil && res != nil {
@@ -1009,7 +1040,7 @@ func (a *App) startNewSessionWorker(old string) {
 	a.workers.Add(1)
 	go func() {
 		defer a.workers.Done()
-		res, err := a.mgr.HandleSessionNew(a.workCtx, acp.SessionNewParams{CWD: a.cfg.Paths.CWD})
+		res, err := a.mgr.HandleSessionNew(a.workCtx, acp.SessionNewParams{CWD: a.config().Paths.CWD})
 		if err != nil {
 			_ = a.Sender().SendSessionUpdate(old, statusErr{msg: "new session: " + err.Error(), always: true})
 			return
@@ -1083,7 +1114,7 @@ func (a *App) ExitHint() string {
 // StartContinue reopens the most recent session recorded for this folder
 // (the -c/--continue flag).
 func (a *App) StartContinue(ctx context.Context) error {
-	id, err := latestBackendSessionID(ctx, a.mgr, a.cfg.Paths.CWD)
+	id, err := latestBackendSessionID(ctx, a.mgr, a.config().Paths.CWD)
 	if err != nil {
 		return err
 	}

--- a/external/cli/chat_test.go
+++ b/external/cli/chat_test.go
@@ -3,14 +3,26 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/EvilFreelancer/coddy-agent/external/cli/tui"
+	"github.com/EvilFreelancer/coddy-agent/internal/acp"
 	"github.com/EvilFreelancer/coddy-agent/internal/config"
 	"github.com/EvilFreelancer/coddy-agent/internal/platform"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
 	"github.com/EvilFreelancer/coddy-agent/internal/tools/shell"
 )
 
@@ -204,7 +216,7 @@ func TestEscapeKillsTheRunningCommand(t *testing.T) {
 		t.Skipf("no portable long-running command for shell %q", commandShell.Kind)
 	}
 	a := newTestApp(t)
-	cmd, err := shell.StartOperatorCommand("sleep 60", a.cfg.Paths.CWD)
+	cmd, err := shell.StartOperatorCommand("sleep 60", a.config().Paths.CWD)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,5 +320,157 @@ func TestAssistantMessageStartsWithASeparatorRow(t *testing.T) {
 	}
 	if visible := tui.StripTerminalSequences(lines[0]); strings.TrimSpace(visible) != "" {
 		t.Fatalf("first row must be a blank separator, got %q", lines[0])
+	}
+}
+
+// --- run.go: the console turn agent and the staged config flow ---
+
+// stagedConfigBackend stands in for an OpenAI-compatible server answering
+// blocking (stream: false) requests. It records the tool names every request
+// offered and, when scripted, drives one self-configuration turn: config_set,
+// then config_commit, then a plain answer. Unscripted it answers at once.
+type stagedConfigBackend struct {
+	script bool
+
+	mu    sync.Mutex
+	tools [][]string
+}
+
+func (b *stagedConfigBackend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	raw, _ := io.ReadAll(r.Body)
+	var body struct {
+		Tools []struct {
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	_ = json.Unmarshal(raw, &body)
+	names := make([]string, 0, len(body.Tools))
+	for _, tool := range body.Tools {
+		names = append(names, tool.Function.Name)
+	}
+	b.mu.Lock()
+	b.tools = append(b.tools, names)
+	turn := len(b.tools)
+	b.mu.Unlock()
+
+	message := map[string]any{"role": "assistant", "content": "Done."}
+	finish := "stop"
+	if b.script && turn <= 2 {
+		call := map[string]any{"name": "config_set", "arguments": `{"commands":["set agent.max_turns=19"]}`}
+		if turn == 2 {
+			call = map[string]any{"name": "config_commit", "arguments": "{}"}
+		}
+		message = map[string]any{
+			"role": "assistant", "content": "",
+			"tool_calls": []map[string]any{{"id": fmt.Sprintf("call_%d", turn), "type": "function", "function": call}},
+		}
+		finish = "tool_calls"
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id": fmt.Sprintf("chatcmpl-%d", turn), "object": "chat.completion", "model": "stub",
+		"choices": []map[string]any{{"index": 0, "finish_reason": finish, "message": message}},
+		"usage":   map[string]int{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+	})
+}
+
+func (b *stagedConfigBackend) offered() [][]string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([][]string(nil), b.tools...)
+}
+
+// newConsoleOverStub writes a config.yaml in a temp home whose only model is
+// served by the stub backend and builds the console exactly as Run does: real
+// manager, real store, real agent, no LLM.
+func newConsoleOverStub(t *testing.T, backend http.Handler) (*App, *config.Config) {
+	t.Helper()
+	ts := httptest.NewServer(backend)
+	t.Cleanup(ts.Close)
+	home, cwd := t.TempDir(), t.TempDir()
+	yaml := "agent:\n  model: stub/model\n  max_turns: 35\n" +
+		"providers:\n  - name: stub\n    type: openai\n    api_base: " + ts.URL + "\n    api_key: test\n" +
+		"models:\n  - model: stub/model\n    max_tokens: 200\n    stream: false\n" +
+		"tools:\n  permission_mode: bypass\n" +
+		"rules:\n  auto_discover: false\n"
+	path := filepath.Join(home, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadFromCLI(config.CLIPaths{Home: home, CWD: cwd, Config: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &session.FileStore{Root: filepath.Join(home, "sessions")}
+	app := buildApp(cfg, store, slog.New(slog.DiscardHandler), &bddTerminal{cols: 80, rows: 24}, "dark", true)
+	t.Cleanup(app.Close)
+	return app, cfg
+}
+
+// runConsoleTurn opens a session and runs one prompt through the manager, so
+// the turn goes through the runner buildApp installed.
+func runConsoleTurn(t *testing.T, app *App, text string) {
+	t.Helper()
+	ctx := context.Background()
+	res, err := app.mgr.HandleSessionNew(ctx, acp.SessionNewParams{CWD: app.config().Paths.CWD})
+	if err != nil {
+		t.Fatalf("session/new: %v", err)
+	}
+	params := acp.SessionPromptParams{SessionID: res.SessionID, Prompt: []acp.ContentBlock{{Type: "text", Text: text}}}
+	if _, err := app.mgr.HandleSessionPromptWithSender(ctx, params, app.Sender(), nil); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+}
+
+// The console offers the whole staged config family, so the model can change
+// Coddy's own configuration from the terminal as it can over ACP and HTTP.
+// Without the runtime reloader the agent hides everything but config_get.
+func TestConsoleTurnOffersStagedConfigTools(t *testing.T) {
+	backend := &stagedConfigBackend{}
+	app, _ := newConsoleOverStub(t, backend)
+	runConsoleTurn(t, app, "which config tools do you have?")
+	offered := backend.offered()
+	if len(offered) == 0 {
+		t.Fatal("the stub backend saw no request")
+	}
+	for _, name := range []string{"config_get", "config_set", "config_changes", "config_commit", "config_revert", "config_rollback"} {
+		if !slices.Contains(offered[0], name) {
+			t.Errorf("%s missing from the console turn's tools: %v", name, offered[0])
+		}
+	}
+}
+
+// A committed change hot-reloads the console itself: the app reads the new
+// file and queues the refresh of its model catalog, footer, and header.
+func TestConsoleAdoptsTheConfigAfterCommit(t *testing.T) {
+	backend := &stagedConfigBackend{script: true}
+	app, startup := newConsoleOverStub(t, backend)
+	runConsoleTurn(t, app, "set agent.max_turns to 19")
+	if got := len(backend.offered()); got != 3 {
+		t.Fatalf("stub calls = %d, want stage, commit, and the final answer", got)
+	}
+	if app.config() == startup {
+		t.Fatal("the console still holds the startup config after config_commit")
+	}
+	if got := app.config().Agent.MaxTurns; got != 19 {
+		t.Fatalf("live agent.max_turns = %d, want 19", got)
+	}
+
+	var reloaded *updateMsg
+	for reloaded == nil {
+		select {
+		case msg := <-app.updatesCh:
+			if _, ok := msg.update.(configReloaded); ok {
+				reloaded = &msg
+			}
+		default:
+			t.Fatal("no configReloaded update reached the UI queue")
+		}
+	}
+	app.applyLoopMessage(*reloaded)
+	if ids := app.modelIDs(); !slices.Contains(ids, "stub/model") {
+		t.Fatalf("model catalog after the reload = %v", ids)
 	}
 }

--- a/external/cli/localshell.go
+++ b/external/cli/localshell.go
@@ -97,7 +97,7 @@ func (a *App) startLocalShell(command string) {
 	a.curShell, a.lastShell = box, box
 	box.SetExpanded(a.expanded)
 
-	cmd, err := shell.StartOperatorCommand(command, a.cfg.Paths.CWD)
+	cmd, err := shell.StartOperatorCommand(command, a.config().Paths.CWD)
 	if err != nil {
 		box.Finish(-1, err)
 		a.curShell = nil

--- a/external/cli/run.go
+++ b/external/cli/run.go
@@ -166,11 +166,11 @@ func Run(args []string, deps CommandDeps) error {
 			return PrintPrompt(ctx, h, popts)
 		}
 		lateSender := &lateBoundSender{}
+		var mgr *session.Manager
 		runner := func(rctx context.Context, st *session.State, prompt []acp.ContentBlock, snd acp.UpdateSender) (string, error) {
-			loop := agent.NewAgent(cfg, st, snd, log)
-			return loop.Run(rctx, prompt)
+			return newTurnAgent(mgr, nil, st, snd, log).Run(rctx, prompt)
 		}
-		mgr := session.NewManager(cfg, lateSender, runner, log, cfg.Paths.CWD, store)
+		mgr = session.NewManager(cfg, lateSender, runner, log, cfg.Paths.CWD, store)
 		lateSender.inner = &printSender{mgr: mgr, cfg: cfg, out: os.Stdout, errOut: os.Stderr}
 		return PrintPrompt(ctx, mgr, popts)
 	}
@@ -222,18 +222,38 @@ func Run(args []string, deps CommandDeps) error {
 
 // buildApp wires the manager triple (store -> manager -> app) with the app's
 // sender registered as the manager's server sender, so replay, mode, config,
-// and slash-catalog updates reach the console.
+// and slash-catalog updates reach the console. The runner only executes
+// inside manager prompt handling, so mgr and app are set by the time it runs.
 func buildApp(cfg *config.Config, store *session.FileStore, log *slog.Logger, term appTerminal, themeName string, plain bool) *App {
 	var app *App
+	var mgr *session.Manager
 	runner := func(ctx context.Context, st *session.State, prompt []acp.ContentBlock, snd acp.UpdateSender) (string, error) {
-		loop := agent.NewAgent(cfg, st, snd, log)
-		return loop.Run(ctx, prompt)
+		return newTurnAgent(mgr, app, st, snd, log).Run(ctx, prompt)
 	}
 	lateSender := &lateBoundSender{}
-	mgr := session.NewManager(cfg, lateSender, runner, log, cfg.Paths.CWD, store)
+	mgr = session.NewManager(cfg, lateSender, runner, log, cfg.Paths.CWD, store)
 	app = newApp(cfg, mgr, log, term, themeName, plain)
 	lateSender.inner = app.Sender()
 	return app
+}
+
+// newTurnAgent builds the ReAct agent for one local console turn on the
+// manager's live configuration and wires the staged config flow to the
+// manager's runtime reload, as cmd/coddy does for ACP and external/httpserver
+// for HTTP. Without the reloader the agent hides config_set through
+// config_rollback and the model can only read Coddy's configuration. After a
+// successful reload the app (nil in print mode) adopts the new config so its
+// model catalog, footer, and header follow the file.
+func newTurnAgent(mgr *session.Manager, app *App, st *session.State, snd acp.UpdateSender, log *slog.Logger) *agent.Agent {
+	loop := agent.NewAgent(mgr.Cfg(), st, snd, log)
+	loop.SetConfigReloader(func(ctx context.Context) ([]string, error) {
+		warnings, err := mgr.ReloadConfigForSession(ctx, st)
+		if err == nil && app != nil {
+			app.replaceConfig(mgr.Cfg(), st)
+		}
+		return warnings, err
+	})
+	return loop
 }
 
 // warnInsecureRemote flags a bearer token about to travel over plain http to

--- a/external/cli/sender.go
+++ b/external/cli/sender.go
@@ -59,7 +59,7 @@ func (s *sender) RequestPermission(ctx context.Context, params acp.PermissionReq
 		// Local fallback only: a remote server sends a permission event
 		// precisely because ITS policy wants a human answer, so the local
 		// bypass setting must never auto-approve it.
-		if cfg := s.app.cfg; cfg != nil {
+		if cfg := s.app.config(); cfg != nil {
 			mode = cfg.Tools.ResolvedPermMode()
 		}
 	}

--- a/external/cli/slash.go
+++ b/external/cli/slash.go
@@ -117,13 +117,13 @@ func (a *App) switchTheme(name string) {
 	a.header = newHeader(a.theme)
 	a.header.SetExpanded(a.expanded)
 	a.populateHeader()
-	a.foot = newFooter(a.theme, a.cfg.Paths.CWD)
+	a.foot = newFooter(a.theme, a.config().Paths.CWD)
 	a.refreshFooterModel()
 	a.foot.SetSession("", a.modeID)
 	a.editor = tui.NewEditor(a.term, tui.EditorTheme{BorderColor: a.theme.FgFn(roleBorderMuted)}, 0)
 	a.editor.OnSubmit = a.onSubmit
 	a.editor.OnChange = a.onEditorChange
-	provider := newCompletionProvider(a.cfg.Paths.CWD, a.slashCatalog)
+	provider := newCompletionProvider(a.config().Paths.CWD, a.slashCatalog)
 	a.editor.SetAutocomplete(provider, selectListTheme(a.theme), tui.SelectListLayout{MinPrimaryColumnWidth: 12, MaxPrimaryColumnWidth: 32}, a.screen.RequestRender)
 
 	root := a.screen.Root
@@ -150,7 +150,7 @@ func (a *App) openResumeSelector() {
 	}
 	sessionID := a.sessionID
 	go func() {
-		cwd := a.cfg.Paths.CWD
+		cwd := a.config().Paths.CWD
 		res, err := a.mgr.HandleSessionList(context.Background(), acp.SessionListParams{CWD: &cwd})
 		if err != nil {
 			_ = a.Sender().SendSessionUpdate(sessionID, statusErr{msg: "resume: " + err.Error()})
@@ -234,7 +234,7 @@ func (a *App) startResumeWorker(old, id string) {
 	a.workers.Add(1)
 	go func() {
 		defer a.workers.Done()
-		cwd := a.cfg.Paths.CWD
+		cwd := a.config().Paths.CWD
 		res, err := a.mgr.HandleSessionLoad(a.workCtx, acp.SessionLoadParams{SessionID: id, CWD: cwd})
 		if err != nil {
 			_ = a.Sender().SendSessionUpdate(id, statusErr{msg: "resume: " + err.Error(), always: true})

--- a/external/cli/updates.go
+++ b/external/cli/updates.go
@@ -39,6 +39,21 @@ func (a *App) applyLoopMessage(msg updateMsg) {
 			a.appendStatus(roleDim, "Operation aborted")
 		}
 		return
+	case configReloaded:
+		// The process configuration changed for every session, so the header
+		// and footer always re-read it; the option set is per session and is
+		// adopted only when the committing turn belongs to the visible one.
+		if u.opts != nil && (msg.sessionID == "" || a.sessionID == "" || msg.sessionID == a.sessionID) {
+			a.configOpts = u.opts
+			for _, opt := range u.opts {
+				if opt.ID == "model" {
+					a.modelID = opt.CurrentValue
+				}
+			}
+		}
+		a.refreshFooterModel()
+		a.populateHeader()
+		return
 	case sessionSwitched:
 		a.switching = false
 		a.adoptSession(u.res.SessionID, u.res.Modes, u.res.ConfigOptions)


### PR DESCRIPTION
## Summary

`examples/cli/cli_e2e_config.py` could not pass in the interactive console: on 2026-09-03 the screen dump showed the model reasoning "I don't have the staging tools ... I only have config_get" and the turn timing out.

**Cause 1, the console.** `external/cli/run.go` created the ReAct agent with `agent.NewAgent(cfg, st, snd, log)` in both places (print mode and `buildApp`) and never called `loop.SetConfigReloader(...)`. `currentToolDefinitions` in `internal/agent/react.go` hides `config_set`, `config_changes`, `config_commit`, `config_revert` and `config_rollback` when no reloader is wired, so the model only ever saw `config_get`. ACP (`cmd/coddy/main.go`) and HTTP (`external/httpserver/commands.go`, `permission_resume.go`) had the wiring; the console did not.

**Cause 2, the e2e driver.** `examples/cli/cli_tui_driver.py` detected the end of a turn by waiting for the `Working...` label to disappear. The live status line (65bcba5) replaced that label with step phrases (`Waiting for the model`, `Reading README.md · 3s`), so `wait_idle` returned immediately, the next prompt hit `A turn is already running`, and the script failed on the commit check before the model had done anything. This masked cause 1 and breaks every script that used `wait_idle` or `wait_for("Working...")`.

## Change

- `external/cli/run.go`: `newTurnAgent` builds the agent on the manager's live `Cfg()` and wires `SetConfigReloader` to `ReloadConfigForSession`; used by the interactive console and by `-p/--prompt`.
- `external/cli/app.go`: the config lives in an `atomic.Pointer` read through `a.config()` (turn workers read it while the UI goroutine swaps it); `replaceConfig` stores the reloaded config and posts an internal `configReloaded` update.
- `external/cli/updates.go`: `configReloaded` adopts the session's rebuilt option set (model catalog via `BuildACPConfigOptions`) and refreshes the footer and the header's `[Context]` / `[Skills]` / `[Rules]` / `[MCP]` sections.
- `external/cli/chat_test.go`: two unit tests over an httptest OpenAI stub with `stream: false`. One asserts a console turn offers the whole config family; the other drives `config_set` + `config_commit` and checks the app holds the reloaded config and queued the UI refresh. The first test fails without the reloader (only `config_get` offered).
- `examples/cli/cli_tui_driver.py`: a turn is running while a braille spinner frame is on screen or the session's `.coddy-turn.lock` is flocked; new `wait_turn_started`, `wait_idle` rewritten on top of it. `cli_smoke`, `cli_e2e_compact`, `cli_e2e_skills_slash` and `capture` use `wait_turn_started` instead of `wait_for("Working...")`.
- `docs/cli.md`: self-configuration paragraph (tools offered, hot reload of the model catalog, footer and header; `-p` parity; `--remote` leaves the reload to the server).

## Verification

- `go test -tags cli ./external/cli/...` and `-tags cli,scheduler,memory` for `external/cli` and `cmd`: green.
- `make test`: 498 ok, 0 FAIL. `make lint`: 0 issues.
- Live e2e with `make build TAGS="cli scheduler memory"` against `neuraldeep/qwen3.8-27b`: `cli_smoke.py` PASS; `cli_e2e_config.py` PASS, the kept session shows `load_skill`, `config_get`, `config_set`, `config_changes`, `config_commit`, `config_rollback`, `config.yaml` went 35 -> 19 -> 35 with the `.prev` snapshot swapped as documented.
- Not rerun live: `cli_e2e_compact`, `cli_e2e_skills_slash`, `capture` (same one-line replacement of the wait).

No UI (`external/ui`) or HTTP surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
