### PR TITLE
test(cli): drain the turn worker before walking the session bundle

### DIFF
--- a/external/cli/bdd_cli_tui_test.go
+++ b/external/cli/bdd_cli_tui_test.go
@@ -747,8 +747,15 @@ func (s *cliTUIState) noAgentTurnReceived(text string) error {
 }
 
 // persistedSessionCarriesNoTrace checks the live message list and every file
-// of the session bundle: a hidden command must not reach either.
+// of the session bundle: a hidden command must not reach either. The walk
+// starts only once the turn worker has returned: after the runner ends it
+// still rewrites session.json (activity bookkeeping) through a temp file, and
+// a walk that lists that temp file loses it to the rename before the read
+// ("The system cannot find the file specified" on Windows CI).
 func (s *cliTUIState) persistedSessionCarriesNoTrace(text string) error {
+	if err := s.waitWorkersIdle(5 * time.Second); err != nil {
+		return err
+	}
 	if st := s.app.mgr.SessionByID(s.app.sessionID); st != nil {
 		for _, msg := range st.GetMessages() {
 			if strings.Contains(msg.Content, text) {
@@ -770,6 +777,23 @@ func (s *cliTUIState) persistedSessionCarriesNoTrace(text string) error {
 		}
 		return nil
 	})
+}
+
+// waitWorkersIdle blocks until every app worker (the turn, the `!!` poller)
+// has returned, so nothing writes into the session bundle while a step reads
+// it. Unlike App.JoinWorkers it reports a timeout instead of moving on.
+func (s *cliTUIState) waitWorkersIdle(timeout time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		s.app.workers.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("app workers still busy after %s", timeout)
+	}
 }
 
 func (s *cliTUIState) operatorTypesWithoutSending(text string) error {


### PR DESCRIPTION
## Summary

The Windows CI job "Test suite (Windows)", step "Run console TUI tests (fake terminal, no pty)", failed once on 2026-09-03 (run 33799303760, first attempt) in `TestCLITUIFeature/A_!!_command_runs_locally_and_stays_out_of_the_agent_context` with:

```
open C:\Users\RUNNER~1\AppData\Local\Temp\coddy-cli-bdd-...\sessions\sess_...\session.json.tmp.2590154089: The system cannot find the file specified.
```

It passed on rerun with no code change. The same signature was seen on PR #127 and PR #109, so this is a recurring race in the harness, not in the change under test.

**Cause.** The first-attempt log shows the failing step is "the persisted session carries no trace" in `external/cli/bdd_cli_tui_test.go`, not the teardown (the harness never removes the temp home). The step walks the session directory with `filepath.WalkDir` and reads every file while the turn worker is still writing. The stub runner signals `turnEnds` from its defer before `HandleSessionPromptWithSender` returns; the manager's deferred `state.BumpActivitySeq()` then runs a synchronous `FileStore.Save`, which rewrites `session.json` through a temp file plus rename (`writeBytesAtomic`). The walk lists `session.json.tmp.NNN`, the rename removes it, and `os.ReadFile` on the listed name fails. Windows file operations are slow enough to hit that window regularly; on Linux it is microseconds wide, which is why `-count=20` never reproduced it there.

## Change

- `external/cli/bdd_cli_tui_test.go`: `persistedSessionCarriesNoTrace` waits for the app's worker WaitGroup to drain before walking the bundle, through a new `waitWorkersIdle` helper. Unlike `App.JoinWorkers` it returns an error on timeout instead of silently continuing into the racy walk. The step comment records why the drain is there.

No production code, HTTP surface, or UI changes. Test harness only.

## Verification

- Linux reproduction of the race: with a temporary 30 ms hold after `CreateTemp` in `writeBytesAtomic` and 20 ms per entry in the walk, the old step failed with the same error in every run and the new step passed in every run under identical delays. Both temporary edits reverted; the diff is the harness fix alone.
- `go test -tags=cli ./external/cli/... -count=20`: green (both `external/cli` and `external/cli/tui`).
- `make check-windows`: green across all tag combinations.
- `golangci-lint run --build-tags cli ./external/cli/...`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
