### PR TITLE
fix(acp): honour permission answers in the protocol's response shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ Coddy is an **ACP server** (`coddy acp`). **Obsidian**, **VS Code**, **Zed**, sc
 
 Configure clients with the **absolute path** to the binary rather than relying on `PATH` — some harnesses spawn the agent via `cmd /c` or `sh -c` without the user `PATH` (on Windows: `%LOCALAPPDATA%\Programs\coddy\coddy.exe`; see [`docs/install.md`](docs/install.md#windows)).
 
+**Zed** — add one entry to `settings.json`, then pick **Coddy** under *External Agents* in the agent panel's new-thread menu:
+
+```json
+"agent_servers": {
+  "Coddy": {
+    "type": "custom",
+    "command": "/home/you/.local/bin/coddy",
+    "args": ["acp"]
+  }
+}
+```
+
+Coddy's own modes (`agent` / `plan` / `ask`), its configured models, and its permission policy appear in Zed's composer, and its skills show up as slash commands.
+
 Protocol details: **`docs/acp-protocol.md`**. Harness examples: **`examples/acp/`**.
 
 ## Quick Start

--- a/docs/acp-protocol.md
+++ b/docs/acp-protocol.md
@@ -592,17 +592,19 @@ These requests are sent only when `permission_mode` is `ask` (commands and write
 }
 ```
 
-**Response:**
+**Response:** the protocol nests the outcome in its own object, which is what editors such as Zed send:
+
 ```json
 {
   "jsonrpc": "2.0",
   "id": 10,
   "result": {
-    "outcome": "allow",
-    "optionId": "allow"
+    "outcome": { "outcome": "selected", "optionId": "allow" }
   }
 }
 ```
+
+A dismissed request answers `{ "outcome": { "outcome": "cancelled" } }`. Coddy also accepts the flat form its own surfaces and some editor extensions send (`{"outcome": "selected", "optionId": "allow"}`), and reads both the same way: the call proceeds unless the outcome is `cancelled` or the chosen `optionId` is `reject`. Picking `allow_always` (or the program-wide `allow_always_<program>` option) also stores a session grant, so the same command does not ask again.
 
 ## Question Requests (Agent -> Client, expects response)
 

--- a/features/acp_permission_answers.feature
+++ b/features/acp_permission_answers.feature
@@ -1,0 +1,28 @@
+Feature: Permission answers from an editor are honoured
+  Editors that speak the Agent Client Protocol answer a permission request by nesting the
+  outcome in its own object, while Coddy's own surfaces send it flat. Both shapes mean the
+  same thing, so an approval from Zed must run the tool call exactly like an approval from
+  the console. Reading a nested approval as a refusal is the worst possible failure: the
+  operator clicks Allow, the agent is told "permission denied by user", and it reports that
+  the workspace forbids shell access.
+
+  Scenario: An editor's approval in the protocol response shape is honoured
+    Given a session with no command grants
+    When the agent asks permission to run "git status --short"
+    And the editor answers "allow" the way the protocol nests its outcome
+    Then the answer lets the command run
+
+  Scenario: A program-wide approval from an editor widens the grant
+    Given a session with no command grants
+    When the agent asks permission to run "git status --short"
+    And the editor answers "allow_always_program" the way the protocol nests its outcome
+    Then the answer lets the command run
+    And the session grants "git status"
+    And running "git status -sb" no longer needs permission
+
+  Scenario: A rejection from an editor still refuses the call
+    Given a session with no command grants
+    When the agent asks permission to run "git status --short"
+    And the editor answers "reject" the way the protocol nests its outcome
+    Then the answer refuses the command
+    And running "git status --short" still needs permission

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -2,6 +2,7 @@ package acp_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/EvilFreelancer/coddy-agent/internal/acp"
@@ -151,5 +152,67 @@ func TestStopReasonConstants(t *testing.T) {
 		if string(c) == "" {
 			t.Errorf("empty stop reason constant")
 		}
+	}
+}
+
+// A permission approval must survive both response shapes: the protocol nests
+// the outcome in its own object (Zed), Coddy's own surfaces send it flat.
+// Decoding the nested form used to fail, and the caller read that failure as a
+// cancellation, so every approval became "permission denied by user".
+func TestPermissionResultAcceptsBothWireShapes(t *testing.T) {
+	cases := []struct {
+		name        string
+		payload     string
+		wantOutcome string
+		wantOption  string
+	}{
+		{
+			name:        "nested selected",
+			payload:     `{"outcome":{"outcome":"selected","optionId":"allow"}}`,
+			wantOutcome: "selected",
+			wantOption:  "allow",
+		},
+		{
+			name:        "nested allow always",
+			payload:     `{"outcome":{"outcome":"selected","optionId":"allow_always_program"}}`,
+			wantOutcome: "selected",
+			wantOption:  "allow_always_program",
+		},
+		{
+			name:        "nested cancelled",
+			payload:     `{"outcome":{"outcome":"cancelled"}}`,
+			wantOutcome: "cancelled",
+		},
+		{
+			name:        "flat selected",
+			payload:     `{"outcome":"selected","optionId":"allow"}`,
+			wantOutcome: "selected",
+			wantOption:  "allow",
+		},
+		{
+			name:        "flat reject",
+			payload:     `{"outcome":"selected","optionId":"reject"}`,
+			wantOutcome: "selected",
+			wantOption:  "reject",
+		},
+		{
+			name:        "flat cancelled",
+			payload:     `{"outcome":"cancelled"}`,
+			wantOutcome: "cancelled",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got acp.PermissionResult
+			if err := json.Unmarshal([]byte(tc.payload), &got); err != nil {
+				t.Fatalf("unmarshal %s: %v", tc.payload, err)
+			}
+			if got.Outcome != tc.wantOutcome {
+				t.Errorf("outcome: got %q, want %q", got.Outcome, tc.wantOutcome)
+			}
+			if got.OptionID != tc.wantOption {
+				t.Errorf("optionId: got %q, want %q", got.OptionID, tc.wantOption)
+			}
+		})
 	}
 }

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -1,5 +1,7 @@
 package acp
 
+import "encoding/json"
+
 // Protocol version supported by this agent.
 const ProtocolVersion = 1
 
@@ -471,6 +473,53 @@ type PermissionOption struct {
 type PermissionResult struct {
 	Outcome  string `json:"outcome"`
 	OptionID string `json:"optionId"`
+}
+
+// UnmarshalJSON accepts both response shapes seen from ACP clients.
+//
+// The protocol nests the outcome in its own object, which is what Zed sends:
+//
+//	{"outcome": {"outcome": "selected", "optionId": "allow"}}
+//	{"outcome": {"outcome": "cancelled"}}
+//
+// Coddy's own surfaces (console, web UI, remote client) and some editor
+// extensions send the flat form instead:
+//
+//	{"outcome": "selected", "optionId": "allow"}
+//
+// Decoding the nested form into a plain string used to fail, and the caller
+// read that failure as a cancellation - every approval from a spec-compliant
+// client turned into "permission denied by user".
+func (p *PermissionResult) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Outcome  json.RawMessage `json:"outcome"`
+		OptionID string          `json:"optionId"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	p.Outcome = ""
+	p.OptionID = wire.OptionID
+	if len(wire.Outcome) == 0 {
+		return nil
+	}
+	var flat string
+	if err := json.Unmarshal(wire.Outcome, &flat); err == nil {
+		p.Outcome = flat
+		return nil
+	}
+	var nested struct {
+		Outcome  string `json:"outcome"`
+		OptionID string `json:"optionId"`
+	}
+	if err := json.Unmarshal(wire.Outcome, &nested); err != nil {
+		return err
+	}
+	p.Outcome = nested.Outcome
+	if nested.OptionID != "" {
+		p.OptionID = nested.OptionID
+	}
+	return nil
 }
 
 // ---- ACP session/request_question ----

--- a/internal/agent/react.go
+++ b/internal/agent/react.go
@@ -982,7 +982,7 @@ func (a *Agent) executeToolCall(ctx context.Context, tc llm.ToolCall, env *tools
 			Options: permission.Options(tc.Name, tc.InputJSON),
 		})
 
-		if err != nil || permResult == nil || permResult.Outcome == "cancelled" || permResult.OptionID == "reject" {
+		if err != nil || !permission.Approved(permResult) {
 			_ = a.server.SendSessionUpdate(sessionID, acp.ToolCallStatusUpdate{
 				SessionUpdate: acp.UpdateTypeToolCallUpdate,
 				ToolCallID:    tc.ID,

--- a/internal/agent/resume_permission.go
+++ b/internal/agent/resume_permission.go
@@ -42,7 +42,7 @@ func (a *Agent) ResumeAfterPermission(ctx context.Context, toolCallID string, pe
 	if sd != "" {
 		_ = session.ClearPendingPermission(sd)
 	}
-	if perm.Outcome == "cancelled" || perm.OptionID == "reject" {
+	if !permission.Approved(perm) {
 		toolResultMsg := llm.Message{
 			Role:       llm.RoleTool,
 			Content:    "permission denied by user",

--- a/internal/permission/bdd_acp_permission_answers_test.go
+++ b/internal/permission/bdd_acp_permission_answers_test.go
@@ -1,0 +1,156 @@
+package permission
+
+// Godog harness for features/acp_permission_answers.feature: feeds the raw JSON
+// an ACP client puts on the wire through the same decode and decision path the
+// agent loop uses, so the scenarios describe what the operator's click buys
+// them without involving a model, an editor, or a real shell.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/acp"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
+	"github.com/EvilFreelancer/coddy-agent/internal/tooling"
+)
+
+type acpPermissionAnswersState struct {
+	state   *session.State
+	command string
+	result  *acp.PermissionResult
+}
+
+func (s *acpPermissionAnswersState) reset() {
+	s.state = &session.State{}
+	s.command = ""
+	s.result = nil
+}
+
+func (s *acpPermissionAnswersState) sessionWithoutGrants() error {
+	s.reset()
+	if got := s.state.GetPermissionCommandGrants(); len(got) != 0 {
+		return fmt.Errorf("fresh session already carries grants %v", got)
+	}
+	return nil
+}
+
+func (s *acpPermissionAnswersState) argsJSON() string {
+	args, err := json.Marshal(struct {
+		Command string `json:"command"`
+	}{Command: s.command})
+	if err != nil {
+		return `{}`
+	}
+	return string(args)
+}
+
+func (s *acpPermissionAnswersState) asksPermission(command string) error {
+	s.command = command
+	if len(Options("run_command", s.argsJSON())) == 0 {
+		return fmt.Errorf("permission dialog offered no options at all")
+	}
+	return nil
+}
+
+// editorAnswers decodes the response body an ACP editor sends, which nests the
+// outcome in its own object, and applies it the way the agent loop does.
+func (s *acpPermissionAnswersState) editorAnswers(optionID string) error {
+	offered := Options("run_command", s.argsJSON())
+	if !slices.ContainsFunc(offered, func(o acp.PermissionOption) bool { return o.OptionID == optionID }) {
+		return fmt.Errorf("the dialog for %q offers no option %q", s.command, optionID)
+	}
+	body := fmt.Sprintf(`{"outcome":{"outcome":"selected","optionId":%q}}`, optionID)
+	var result acp.PermissionResult
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return fmt.Errorf("decoding the editor's answer %s: %w", body, err)
+	}
+	s.result = &result
+	if Approved(&result) {
+		RecordAllowAlways(s.state, "run_command", s.argsJSON(), "/repo", &result)
+	}
+	return nil
+}
+
+func (s *acpPermissionAnswersState) answerLetsCommandRun() error {
+	if s.result == nil {
+		return fmt.Errorf("no answer was decoded")
+	}
+	if !Approved(s.result) {
+		return fmt.Errorf("answer %+v was read as a refusal, want an approval", *s.result)
+	}
+	return nil
+}
+
+func (s *acpPermissionAnswersState) answerRefusesCommand() error {
+	if s.result == nil {
+		return fmt.Errorf("no answer was decoded")
+	}
+	if Approved(s.result) {
+		return fmt.Errorf("answer %+v was read as an approval, want a refusal", *s.result)
+	}
+	return nil
+}
+
+func (s *acpPermissionAnswersState) sessionGrants(grant string) error {
+	grants := s.state.GetPermissionCommandGrants()
+	if slices.Contains(grants, grant) {
+		return nil
+	}
+	return fmt.Errorf("session grants %v do not include %q", grants, grant)
+}
+
+func (s *acpPermissionAnswersState) allowed(command string) bool {
+	return CommandAllowedWithSession(&tooling.Env{}, s.state.GetPermissionCommandGrants(), command)
+}
+
+func (s *acpPermissionAnswersState) noLongerNeedsPermission(command string) error {
+	if !s.allowed(command) {
+		return fmt.Errorf("%q still needs permission under grants %v", command, s.state.GetPermissionCommandGrants())
+	}
+	return nil
+}
+
+func (s *acpPermissionAnswersState) stillNeedsPermission(command string) error {
+	if s.allowed(command) {
+		return fmt.Errorf("%q runs without permission under grants %v", command, s.state.GetPermissionCommandGrants())
+	}
+	return nil
+}
+
+func initializeACPPermissionAnswersScenario(sc *godog.ScenarioContext) {
+	s := &acpPermissionAnswersState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		s.reset()
+		return ctx, nil
+	})
+
+	sc.Step(`^a session with no command grants$`, s.sessionWithoutGrants)
+	sc.Step(`^the agent asks permission to run "([^"]*)"$`, s.asksPermission)
+	sc.Step(`^the editor answers "([^"]*)" the way the protocol nests its outcome$`, s.editorAnswers)
+	sc.Step(`^the answer lets the command run$`, s.answerLetsCommandRun)
+	sc.Step(`^the answer refuses the command$`, s.answerRefusesCommand)
+	sc.Step(`^the session grants "([^"]*)"$`, s.sessionGrants)
+	sc.Step(`^running "([^"]*)" no longer needs permission$`, s.noLongerNeedsPermission)
+	sc.Step(`^running "([^"]*)" still needs permission$`, s.stillNeedsPermission)
+}
+
+func TestACPPermissionAnswersFeature(t *testing.T) {
+	suite := godog.TestSuite{
+		Name:                "acp-permission-answers",
+		ScenarioInitializer: initializeACPPermissionAnswersScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/acp_permission_answers.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("acp permission answers feature suite failed")
+	}
+}

--- a/internal/permission/grants.go
+++ b/internal/permission/grants.go
@@ -88,7 +88,7 @@ func RecordAllowAlways(st *session.State, toolName, argsJSON, cwd string, res *a
 	if st == nil || res == nil {
 		return
 	}
-	if res.OptionID != "allow_always" && res.OptionID != OptionAllowAlwaysProgram {
+	if res.OptionID != OptionAllowAlways && res.OptionID != OptionAllowAlwaysProgram {
 		return
 	}
 	toolName = strings.TrimSpace(toolName)
@@ -115,4 +115,18 @@ func RecordAllowAlways(st *session.State, toolName, argsJSON, cwd string, res *a
 			st.AddWriteGrantIfNew(k)
 		}
 	}
+}
+
+// Approved reports whether a client's answer to a permission request lets the
+// tool call proceed. A cancelled request and the reject option are the only
+// refusals; every other selected option is an approval, so a client that
+// answers in the protocol's nested shape is honoured like Coddy's own surfaces.
+func Approved(res *acp.PermissionResult) bool {
+	if res == nil {
+		return false
+	}
+	if res.Outcome == OutcomeCancelled {
+		return false
+	}
+	return res.OptionID != OptionReject
 }

--- a/internal/permission/program.go
+++ b/internal/permission/program.go
@@ -10,6 +10,18 @@ import (
 // one exact command to the program it invokes.
 const OptionAllowAlwaysProgram = "allow_always_program"
 
+// OptionAllow, OptionAllowAlways and OptionReject are the ids of the choices
+// every permission dialog offers; a client answers with one of them.
+const (
+	OptionAllow       = "allow"
+	OptionAllowAlways = "allow_always"
+	OptionReject      = "reject"
+)
+
+// OutcomeCancelled is the outcome a client reports when the request was
+// dismissed instead of answered.
+const OutcomeCancelled = "cancelled"
+
 // shellMetacharacters are the characters that let one command line run more than
 // one command, redirect it, or substitute another. A grant is only ever offered
 // for a command free of all of them: approving "curl https://example.com" must
@@ -91,8 +103,8 @@ func ProgramGrant(cmd string) (string, bool) {
 // once per call.
 func Options(toolName, argsJSON string) []acp.PermissionOption {
 	options := []acp.PermissionOption{
-		{OptionID: "allow", Name: "Allow", Kind: "allow_once"},
-		{OptionID: "allow_always", Name: "Allow always", Kind: "allow_always"},
+		{OptionID: OptionAllow, Name: "Allow", Kind: "allow_once"},
+		{OptionID: OptionAllowAlways, Name: "Allow always", Kind: "allow_always"},
 	}
 	if strings.TrimSpace(toolName) == "run_command" {
 		if grant, ok := ProgramGrant(ExtractRunCommand(argsJSON)); ok {
@@ -103,7 +115,7 @@ func Options(toolName, argsJSON string) []acp.PermissionOption {
 			})
 		}
 	}
-	return append(options, acp.PermissionOption{OptionID: "reject", Name: "Reject", Kind: "reject_once"})
+	return append(options, acp.PermissionOption{OptionID: OptionReject, Name: "Reject", Kind: "reject_once"})
 }
 
 // isPlainInvocation reports whether cmd is a single command with no shell


### PR DESCRIPTION
## Problem

Every permission approval coming from an ACP client that follows the protocol was silently turned into a refusal. Wiring Coddy into **Zed** (`agent_servers` → `coddy acp`) and clicking **Allow** produced `permission denied by user`, and the model then told the operator that the workspace forbids shell access:

> I'm unable to execute any shell commands - every attempt is being denied by user permissions. This appears to be a global restriction on shell access in this environment.

Captured from the wire with a stdio proxy in front of `coddy acp`:

```
A->C {"id":1,"method":"session/request_permission","params":{...,"options":[{"optionId":"allow",...}]}}
C->A {"jsonrpc":"2.0","id":1,"result":{"outcome":{"outcome":"selected","optionId":"allow"}}}
A->C {"method":"session/update","params":{"update":{"sessionUpdate":"tool_call_update","status":"cancelled"}}}
```

The protocol nests the outcome in its own object. `PermissionResult` declared `Outcome` as a plain `string`, so decoding that response failed, `handleResponse` fell back to `{Outcome: "cancelled"}`, and the agent loop read the cancellation as a denial. Coddy's own surfaces (console, web UI, remote client) and the VS Code ACP extension send the flat `{"outcome": "selected", "optionId": "allow"}` shape, which is why this never showed up before.

## Fix

- `PermissionResult.UnmarshalJSON` accepts both shapes: the protocol's nested object and the flat form Coddy's own surfaces send.
- The allow/deny decision moves into `permission.Approved`, shared by the live turn (`react.go`) and the resumed-permission path (`resume_permission.go`), instead of two copies of the same condition.
- Option ids get named constants (`OptionAllow`, `OptionAllowAlways`, `OptionReject`, `OutcomeCancelled`).

## Tests

- `features/acp_permission_answers.feature` — new spec: an editor's approval in the protocol shape runs the call, a program-wide approval widens the grant, a rejection still refuses. Harness: `internal/permission/bdd_acp_permission_answers_test.go`.
- `internal/acp/server_test.go` — table test over both wire shapes (selected / allow always / cancelled, nested and flat).
- Both fail on the old decoder (`cannot unmarshal object into Go struct field PermissionResult.outcome of type string`) and pass with the fix.
- Verified end to end in Zed 1.18.1 against a real `coddy acp`: before the fix every approval came back `permission denied by user`; after it the approved command runs and the turn completes.

## Docs

- `docs/acp-protocol.md` — the permission response section now shows the nested shape, notes the accepted flat form, and states the decision rule.
- `README.md` — Zed setup snippet for `agent_servers` in the editor integration section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
