### PR TITLE
test(ui/i18n): expect English theme names under the Russian locale

### DIFF
--- a/external/ui/src/ui/i18n/i18n.test.ts
+++ b/external/ui/src/ui/i18n/i18n.test.ts
@@ -109,8 +109,12 @@ test("themeLabel resolves every known theme id", () => {
   setLocale("en");
   expect(themeLabel("dark")).toBe("Dark");
   expect(themeLabel("rose-pine")).toBe("Rosé Pine");
+  // Theme names are product names and stay English in every locale (the ru
+  // dictionary keeps them verbatim since 3a5e873), so a locale switch must
+  // not change them.
   setLocale("ru");
-  expect(themeLabel("dark")).toBe("Тёмная");
+  expect(themeLabel("dark")).toBe("Dark");
+  expect(themeLabel("rose-pine")).toBe("Rosé Pine");
 });
 
 test("themeLabel returns the id itself for unknown themes", () => {


### PR DESCRIPTION
## What

The vitest suite in `external/ui` failed on a single assertion. `ui/i18n/i18n.test.ts > themeLabel resolves every known theme id` expected `themeLabel("dark")` to be "Тёмная" after `setLocale("ru")`, but commit 3a5e873 ("Translations fixed on Russian language") deliberately changed the Russian dictionary so theme names stay English (Dark, Light, Midnight next to Solarized Dark, Monokai, Nord and Rosé Pine, which were never translated). The test now expects "Dark" under the Russian locale and pins "Rosé Pine" there as well, so a locale switch is asserted to leave theme names unchanged. A short comment in the test records the rule.

Only the test moved. The dictionary is the intended source of truth, and neither `DESIGN.md` nor `docs/ui.md` claims that theme names are localised.

## Why CI did not catch it

vitest is not part of `make test`, and neither the Makefile nor the CI workflows run the UI suite, so the assertion drifted unnoticed after 3a5e873.

## Verification

Run from `external/ui` on this branch:

| Run | Result |
|---|---|
| `npx vitest run ui/i18n/i18n.test.ts` before the change | 1 failed, 12 passed |
| `npx vitest run ui/i18n/i18n.test.ts` after the change | 13 passed |
| `npx vitest run` (whole suite) | 150 files, 970 tests passed |

`prettier --check` on the edited file is clean, and the pre-commit gate ran `make lint` with 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
