### PR TITLE
Publish deb, rpm and a Homebrew cask, and make coddy update defer to them

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -114,7 +114,7 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         run: make ui-build
 
-      - name: Cross-compile release binaries
+      - name: Cross-compile release binaries, build packages, render the cask
         if: steps.gate.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.git_tag.outputs.tag }}
@@ -146,7 +146,14 @@ jobs:
             if [ "$goos" = "windows" ]; then
               (cd "$bindir" && zip -q "$DIST/${stem}.zip" "$binname")
             else
-              tar -C "$bindir" -czf "$DIST/${stem}.tar.gz" "$binname"
+              # The macOS archives are what the Homebrew cask installs, so the
+              # man page and the completions travel beside the binary. Every
+              # consumer that wants only the executable - `coddy update`, the
+              # install script - takes it out by name and ignores the rest.
+              cp packaging/man/coddy.1 "$bindir/coddy.1"
+              cp packaging/completions/coddy.bash "$bindir/coddy.bash"
+              cp packaging/completions/coddy.zsh "$bindir/coddy.zsh"
+              tar -C "$bindir" -czf "$DIST/${stem}.tar.gz" coddy coddy.1 coddy.bash coddy.zsh
             fi
           }
 
@@ -156,8 +163,26 @@ jobs:
           build_target darwin amd64
           build_target darwin arm64
 
+          # The deb and rpm wrap the Linux binaries built above rather than
+          # compiling their own: packaging must not double the slowest step of
+          # the release, and shipping a package whose binary differs from the
+          # archive of the same tag would be worse than slow.
+          for arch in amd64 arm64; do
+            scripts/build-packages.sh \
+              --version "${VERSION}" \
+              --arch "$arch" \
+              --out "$DIST" \
+              --binary "$DIST/_staging/coddy_${VERSION}_linux_${arch}/coddy"
+          done
+
+          # The cask pins the checksum of the macOS archives, so it is rendered
+          # from the ones just built rather than from a published release.
+          scripts/build-homebrew-cask.sh --version "${VERSION}" --out "$DIST"
+
           rm -rf "$DIST/_staging"
-          (cd "$DIST" && sha256sum coddy_*.tar.gz coddy_*.zip > SHA256SUMS)
+          # `coddy update` verifies every asset it downloads against this list,
+          # packages included.
+          (cd "$DIST" && sha256sum coddy_*.tar.gz coddy_*.zip coddy_*.deb coddy_*.rpm > SHA256SUMS)
           ls -la "$DIST"
 
       - name: Upload assets to GitHub Release

--- a/.github/workflows/tests-on-pr.yaml
+++ b/.github/workflows/tests-on-pr.yaml
@@ -88,6 +88,27 @@ jobs:
       - name: Run console TUI tests (fake terminal, no pty)
         run: go test -tags=cli ./external/cli/...
 
+  # The packages are only built on a release tag, so without this job a broken
+  # nfpm recipe would first be seen by whoever cuts the release. Lean build tags:
+  # this proves the packaging, not the binary, and skipping the npm step keeps
+  # the job short.
+  packages:
+    name: Linux packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build deb and rpm
+        run: make deb rpm PKG_TAGS="http scheduler memory cli"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Short map for automation-friendly contributors.
 | `external/ui` | Embedded SPA (`go:embed`) when built with **`tags=http,ui`**. |
 | `external/memory` | Long-term memory copilot (**`-tags memory`**; see README there). |
 | `external/cli` | Interactive console TUI (**`-tags cli`**): bare **`coddy`** on a terminal, pi-style rendering in **`external/cli/tui`**. Guide: **`docs/cli.md`**. |
+| `packaging` | Distribution package sources: the **nfpm** recipe (**`nfpm.yaml`**) for the Linux **`.deb`** and **`.rpm`**, the Homebrew cask template (**`homebrew/coddy.rb.tmpl`**), the man page (**`man/coddy.1`**), bash and zsh completions, and the post-install script. A package installs a binary and its documentation and nothing else - **no service, no system account, no `/etc`** - because Coddy's state lives in the invoking user's **`~/.coddy`**. Built by **`scripts/build-packages.sh`** and **`scripts/build-homebrew-cask.sh`** (**`make deb`**, **`make rpm`**, **`make brew`**) and published as release assets beside the archives. Guides: **`docs/install.md`**, **`docs/build.md`** (Distribution packages), **`docs/update.md`** (installations owned by a package manager). |
 | `external/gateway` | Messenger gateway (**`-tags gateway.telegram`** or **`-tags gateway`**): Telegram bot adapter, session store, proxy support. Full guide: **`docs/gateway.md`**, rules: **`.cursor/rules/gateway.mdc`**. |
 
 ## Builds
@@ -26,6 +27,8 @@ Short map for automation-friendly contributors.
 Run **`make build TAGS=http`** for the HTTP gateway only (**`coddy http`** REST and **`/docs`**, no **npm**). Run **`make build TAGS=cli`** for the interactive console (**bare `coddy`** on a terminal; see **`docs/cli.md`**). Run **`make build TAGS="http ui"`** to link the embedded SPA (**Makefile** runs **ui-build** before **go build**). Recommended full image matches **`Dockerfile`** (**`make build TAGS="http ui scheduler memory cli"`**). Default **`make build`** omits HTTPServer, scheduler, and memory to keep dependency surface lean.
 
 Primary conversational surface for bundled UI lives at **`POST /v1/responses`** with **`stream:true`**. Prefer it over **`POST /v1/chat/completions`** when shipping Coddy-hosted experiences.
+
+Run **`make deb`** / **`make rpm`** for the Linux packages (**`PKG_ARCHS`**, **`PKG_TAGS`**, **`DIST_DIR`** knobs; nfpm is fetched on demand, nothing to install) and **`make brew VERSION=X.Y.Z`** to render the Homebrew cask for a release. CI builds the Linux packages on every pull request.
 
 Swagger lives at **`/docs/`**, OpenAPI YAML at **`/openapi.yaml`**.
 
@@ -82,6 +85,13 @@ Codex code review reads this section and applies it to changed files. Keep entri
 
 - Do not read, merge, or execute project-local configuration (`.coddy/mcp.json`, MCP server definitions, hook scripts) without routing it through `TrustGate` in `internal/mcp`. Opening an untrusted checkout must not by itself grant code execution. Safe path: gate the read on the workspace trust decision and persist the approval through `TrustStore`.
 - The same holds for project-scope subagent definitions (`.coddy/agents`, `.claude/agents` under the workspace): they load and spawn only as `subagents.project_trust` allows, a receipt in `subagents.TrustStore` is bound to the file digest, and a definition must never widen what the parent could do - `permission_mode`, `tools` and `disallowed_tools` only narrow, and the mandatory exclusions stay. Safe path: resolve the definition once, decide trust on that value with `subagents.Decide`, and derive the child's tool set with `subagents.EffectiveTools`.
+
+### Packaging
+
+- Do not add or rename a CLI subcommand without updating **`packaging/man/coddy.1`** and **`packaging/completions/coddy.bash`** / **`coddy.zsh`** in the same change. The packages and the Homebrew cask ship those files as the documentation of the command set, and nothing else keeps them in step with **`printUsage`**.
+- Do not move **`/usr/bin/coddy`** or add a second packaged copy of the binary. **`coddy update`** asks **`dpkg-query -S`** / **`rpm -qf`** who owns the executable it is about to replace, and a packaged file that no database claims would be silently overwritten. Safe path: keep the single **`contents`** entry in **`packaging/nfpm.yaml`**.
+- Do not add a service unit, a system account, or files under **`/etc`** to a package. Coddy's state is per-user under **`~/.coddy`**; a packaged daemon would need a home of its own and a config nobody can edit. The package installs the binary, the man page, the completions and the licence, and the user decides what to run.
+- Do not add a file to the release **`.tar.gz`** layout without checking the Homebrew cask: **`packaging/homebrew/coddy.rb.tmpl`** links artefacts out of that archive by name.
 
 ### Embedded UI
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-acp test test-opencode-rules check-windows lint lint-windows clean install print-version hooks
+.PHONY: build build-acp test test-opencode-rules check-windows lint lint-windows clean install print-version hooks deb rpm brew
 
 # ---- Build options (extend when you add optional Go build tags) ----
 #   TAGS   optional extra `go build -tags` values (space-separated).
@@ -67,10 +67,13 @@ print-version:
 
 # Install binary: /usr/local/bin for root, ~/.local/bin for regular users.
 INSTALL_DIR := $(if $(filter 0,$(shell id -u)),/usr/local/bin,$(HOME)/.local/bin)
+MAN_DIR := $(if $(filter 0,$(shell id -u)),/usr/local/share/man/man1,$(HOME)/.local/share/man/man1)
 
 # Install build/coddy onto PATH. Reuses an existing binary; builds FULL_TAGS only when missing.
+# The man page goes with it, so `man coddy` works for a from-source install too;
+# `make packages` is the same page, compressed, inside the deb and rpm.
 install:
-	@mkdir -p $(INSTALL_DIR)
+	@mkdir -p $(INSTALL_DIR) $(MAN_DIR)
 	@if [ ! -f $(BINARY) ]; then \
 		echo "No $(BINARY); building with TAGS=\"$(FULL_TAGS)\""; \
 		$(MAKE) build TAGS="$(FULL_TAGS)"; \
@@ -78,7 +81,39 @@ install:
 		echo "Installing existing $(BINARY)"; \
 	fi
 	cp $(BINARY) $(INSTALL_DIR)/coddy
-	@echo "Installed to $(INSTALL_DIR)/coddy"
+	cp packaging/man/coddy.1 $(MAN_DIR)/coddy.1
+	@echo "Installed to $(INSTALL_DIR)/coddy and $(MAN_DIR)/coddy.1"
+
+# ---- Distribution packages ----
+#   PKG_ARCHS  architectures to package, space or comma separated (default: host)
+#   PKG_TAGS   go build tags for the packaged binary (default: the release set)
+#   DIST_DIR   where the packages land (default: dist)
+#
+# `deb` and `rpm` build Linux packages from packaging/nfpm.yaml through
+# scripts/build-packages.sh; the release workflow calls the same script with the
+# binaries it has already cross-compiled. nfpm is fetched on demand.
+#
+# `brew` renders the Homebrew cask (packaging/homebrew/coddy.rb.tmpl) for the
+# macOS archives of a release. It needs those archives, so pass the version of a
+# published release: make brew VERSION=1.0.11
+PKG_ARCHS ?= $(shell go env GOARCH)
+PKG_TAGS ?= $(FULL_TAGS)
+DIST_DIR ?= dist
+
+# Same rule as `build`: embedded assets must exist before a binary claims to
+# carry them.
+ifneq ($(and $(findstring http,$(PKG_TAGS)),$(findstring ui,$(PKG_TAGS))),)
+deb rpm: ui-build
+endif
+
+deb:
+	TAGS="$(PKG_TAGS)" scripts/build-packages.sh --version "$(VERSION)" --arch "$(PKG_ARCHS)" --out "$(DIST_DIR)" --formats deb
+
+rpm:
+	TAGS="$(PKG_TAGS)" scripts/build-packages.sh --version "$(VERSION)" --arch "$(PKG_ARCHS)" --out "$(DIST_DIR)" --formats rpm
+
+brew:
+	scripts/build-homebrew-cask.sh --version "$(VERSION)" --out "$(DIST_DIR)"
 
 # Test the project plugin that attaches Cursor rules to OpenCode sessions.
 test-opencode-rules:
@@ -131,7 +166,7 @@ check-windows:
 
 # Clean build artifacts.
 clean:
-	rm -rf $(BUILD_DIR)
+	rm -rf $(BUILD_DIR) $(DIST_DIR)
 
 # Run the linter (requires golangci-lint). The second pass compiles the
 # cli-tagged console surface, which the untagged pass never sees.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Creates **`~/.coddy/config.yaml`** from the release **`config.example.yaml`** wh
 
 > **Windows.** The binary lands at `%LOCALAPPDATA%\Programs\coddy\coddy.exe`; config and sessions live under `%USERPROFILE%\.coddy\` (use `$env:USERPROFILE`, not `$HOME`). Runtime commands select `pwsh`, then Windows PowerShell, then `cmd.exe`; Unix builds select `bash`, then `sh`. The installing terminal does not see the updated `PATH` — open a new one or refresh it in place. Details: [`docs/install.md`](docs/install.md#windows).
 
+**Linux packages** - every release also publishes a **`.deb`** and an **`.rpm`** (x86_64 and arm64), carrying the binary, the man page and the shell completions:
+
+```bash
+curl -fsSLO https://github.com/coddy-project/coddy-agent/releases/latest/download/coddy_1.0.10_linux_amd64.deb
+sudo apt-get install ./coddy_1.0.10_linux_amd64.deb     # dnf install ./coddy_1.0.10_linux_amd64.rpm
+```
+
+**macOS** - the same release publishes a Homebrew cask:
+
+```bash
+brew install --cask coddy
+```
+
+Prefer a package on a machine you administer: the files are tracked by the package manager, and **`coddy update`** defers to it instead of overwriting a tracked binary. Details: **[`docs/install.md`](docs/install.md#linux-packages-deb-rpm)**.
+
 Then set a provider key in **`~/.coddy/config.yaml`** (or **`OPENAI_API_KEY`** in the environment) and run **`coddy http`** for the UI, or **`coddy acp`** for an editor client.
 
 **Docker** - same full binary in **`ghcr.io/coddy-project/coddy-agent`**: **`docker compose up -d`** (see [Docker](#docker)).
@@ -213,7 +228,7 @@ Extended narrative and Docker alignment - **[docs/build.md](docs/build.md)**.
 
 ### Docker
 
-Release images are published on **[GitHub Container Registry](https://github.com/coddy-project/coddy-agent/pkgs/container/coddy-agent)** as **`ghcr.io/coddy-project/coddy-agent`** (tags such as **`latest`** and **`X.Y.Z`**, **linux/amd64** and **linux/arm64**). Each SemVer git tag also gets **GitHub Release** archives (Linux, Windows, macOS Intel and Apple Silicon) - see **[docs/build.md](docs/build.md#release-binaries-ci)**. The default image includes **`http`**, **`ui`**, **`scheduler`**, **`memory`**, **`cli`**, and **`gateway`** - a superset of **`make build TAGS="http ui scheduler memory cli"`**.
+Release images are published on **[GitHub Container Registry](https://github.com/coddy-project/coddy-agent/pkgs/container/coddy-agent)** as **`ghcr.io/coddy-project/coddy-agent`** (tags such as **`latest`** and **`X.Y.Z`**, **linux/amd64** and **linux/arm64**). Each SemVer git tag also gets **GitHub Release** archives (Linux, Windows, macOS Intel and Apple Silicon), Linux **`.deb`** / **`.rpm`** packages, and a Homebrew cask - see **[docs/build.md](docs/build.md#release-binaries-ci)**. The default image includes **`http`**, **`ui`**, **`scheduler`**, **`memory`**, **`cli`**, and **`gateway`** - a superset of **`make build TAGS="http ui scheduler memory cli"`**.
 
 **1. Config and workspace** (from the repo root, or any directory where you keep **`config.yaml`**):
 
@@ -296,7 +311,7 @@ Other setups (Anthropic, NeuralDeep, Ollama, a non-default **`api_base`**, and e
 
 ## How to update
 
-Official CLI binaries are published on **[GitHub Releases](https://github.com/coddy-project/coddy-agent/releases)** (assets such as **`coddy_0.9.3_linux_amd64.tar.gz`**). Each release matches the full feature set from **`make build TAGS="http ui scheduler memory cli"`**.
+Official CLI binaries are published on **[GitHub Releases](https://github.com/coddy-project/coddy-agent/releases)** (assets such as **`coddy_0.9.3_linux_amd64.tar.gz`**, plus **`.deb`** and **`.rpm`** packages for Linux). Each release matches the full feature set from **`make build TAGS="http ui scheduler memory cli"`**.
 
 **`coddy update`** downloads the archive for your OS/architecture and replaces the binary you invoked (symlinks resolved). That is the usual path after **`make install`** (**`~/.local/bin/coddy`**) or when you run **`./build/coddy update`** to refresh a local build artifact.
 
@@ -337,6 +352,15 @@ coddy http --help     # only when the binary includes -tags=http (release builds
 | **`-y`** / **`--yes`** | Install without confirmation. |
 | **`--version X.Y.Z`** | Install a specific release, not only "latest". |
 | **`--repo owner/name`** | Alternate GitHub repo (default **`coddy-project/coddy-agent`**). |
+
+**Installed from a `.deb`, an `.rpm` or Homebrew?**
+
+Coddy will not overwrite a file a package manager owns. As an ordinary user, **`coddy update`** names the command that upgrades the package and changes nothing; as **root** on a **`.deb`** or **`.rpm`** install, it downloads the release package for your architecture and installs it through **`apt-get`**, **`dnf`**, **`zypper`** or whichever tool the system has:
+
+```bash
+sudo coddy update -y          # deb / rpm
+brew upgrade --cask coddy     # Homebrew
+```
 
 **Notes**
 
@@ -566,8 +590,8 @@ See [Architecture docs](docs/architecture.md) for full details.
 
 ## Documentation
 
-- [Install](docs/install.md) - installer script options, Windows paths, manual placement
-- [Build from source](docs/build.md) - prerequisites, **`make build`**, **`TAGS`** vs **`go build -tags`**, **`build/coddy`**
+- [Install](docs/install.md) - installer script options, Linux **`.deb`** / **`.rpm`** packages, the Homebrew cask, Windows paths, manual placement
+- [Build from source](docs/build.md) - prerequisites, **`make build`**, **`TAGS`** vs **`go build -tags`**, **`build/coddy`**, **`make deb`** / **`rpm`** / **`brew`**
 - [Updating Coddy](docs/update.md) - **`coddy update`**, release assets, **`PATH`** vs **`make install`**
 - [Docker](docs/docker.md) - GHCR image, **`docker compose`**, bundled UI at **`http://127.0.0.1:12345/`**
 - [Console TUI](docs/cli.md) - bare **`coddy`** in a terminal (**`-tags cli`**): layout, keys, flags, print mode, captures

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ curl -fsSL https://coddy.dev/install.sh | bash
 irm https://coddy.dev/install.ps1 | iex
 ```
 
-Creates **`~/.coddy/config.yaml`** from the release **`config.example.yaml`** when missing. Puts **`coddy`** on **`PATH`** (Unix: `~/.local/bin`; Windows: `%LOCALAPPDATA%\Programs\coddy`). Full installer options: **[`docs/install.md`](docs/install.md)**.
+Creates **`~/.coddy/config.yaml`** from the release **`config.example.yaml`** when missing. Puts **`coddy`** on **`PATH`** (Unix: `~/.local/bin`; Windows: `%LOCALAPPDATA%\Programs\coddy`). On Linux and macOS it also installs the man page and the bash and zsh completions, and wires them into your login shell's rc file (**`--no-shell-setup`** opts out). Full installer options: **[`docs/install.md`](docs/install.md)**.
 
 > **Windows.** The binary lands at `%LOCALAPPDATA%\Programs\coddy\coddy.exe`; config and sessions live under `%USERPROFILE%\.coddy\` (use `$env:USERPROFILE`, not `$HOME`). Runtime commands select `pwsh`, then Windows PowerShell, then `cmd.exe`; Unix builds select `bash`, then `sh`. The installing terminal does not see the updated `PATH` — open a new one or refresh it in place. Details: [`docs/install.md`](docs/install.md#windows).
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -44,13 +44,81 @@ The [**Dockerfile**](../Dockerfile) uses the same idea: comma-separated tags via
 - If **`build/coddy`** already exists (for example after **`make build TAGS="http ui scheduler memory cli"`**), it is installed as-is without rebuilding.
 - If the binary is missing, **`make install`** runs **`make build TAGS="http ui scheduler memory cli"`** first.
 
-- **root** - **`/usr/local/bin/coddy`**
-- **non-root** - **`~/.local/bin/coddy`** (ensure that directory is on **`PATH`**)
+- **root** - **`/usr/local/bin/coddy`**, man page in **`/usr/local/share/man/man1`**
+- **non-root** - **`~/.local/bin/coddy`** (ensure that directory is on **`PATH`**), man page in **`~/.local/share/man/man1`**
 
 ```bash
 make build TAGS="http ui scheduler memory cli"
 make install
 ```
+
+## Distribution packages
+
+**`make deb`** and **`make rpm`** build the Linux packages a release publishes; **`make brew`**
+renders the Homebrew cask for one.
+
+```bash
+make deb
+make rpm
+```
+
+Output: **`dist/coddy_<version>_linux_<arch>.deb`** and **`.rpm`**. Knobs:
+
+| Variable | Default | What |
+|----------|---------|------|
+| **`PKG_ARCHS`** | host **`GOARCH`** | architectures to package, e.g. **`"amd64 arm64"`** |
+| **`PKG_TAGS`** | **`http ui scheduler memory cli`** | build tags for the packaged binary |
+| **`DIST_DIR`** | **`dist`** | where the packages land |
+
+```bash
+make deb PKG_ARCHS="amd64 arm64"
+make rpm PKG_TAGS="http cli"      # lean binary, no npm step
+```
+
+The recipe is **`packaging/nfpm.yaml`**, driven by **`scripts/build-packages.sh`**, which stages the
+man page (**`packaging/man/coddy.1`**), the shell completions (**`packaging/completions/`**),
+**`config.example.yaml`** and **`LICENSE`** into one directory and runs
+[nfpm](https://nfpm.goreleaser.com/) over it. nfpm is not a module dependency: the script uses the
+**`nfpm`** on **`PATH`** when there is one and otherwise fetches the pinned version with
+**`go run`**, so there is nothing to install first.
+
+The package installs a binary and its documentation and nothing else - no service, no system
+account, no files under **`/etc`** - because Coddy's state lives in the invoking user's
+**`~/.coddy`**.
+
+Version strings are normalised for the two formats by **`scripts/package-version.sh`** - rpm forbids
+**`-`** in a version and dpkg reads the last one as the start of the Debian revision, so
+**`1.0.8-5-gb6b7d31-dirty`** is packaged as **`1.0.8+5.gb6b7d31.dirty`**, which both accept and both
+sort after **`1.0.8`**.
+
+### Homebrew cask
+
+```bash
+make brew VERSION=1.0.11
+```
+
+**`scripts/build-homebrew-cask.sh`** fills **`packaging/homebrew/coddy.rb.tmpl`** with the version
+and the SHA-256 of both macOS archives, writing **`dist/coddy.rb`**. It takes those archives from
+**`DIST_DIR`** when they are there (which is the case in the release job, right after the
+cross-compile) and downloads them from the GitHub release otherwise - a cask pins checksums, so it
+can only be rendered for a version whose archives exist.
+
+Install the rendered file to try it:
+
+```bash
+brew install --cask dist/coddy.rb
+```
+
+The cask links **`coddy`**, **`coddy.1`** and both completion scripts, which is why the release
+**`darwin`** and **`linux`** archives carry those files beside the binary. Its **`livecheck`** block
+tracks GitHub releases, so once the cask is accepted into
+[homebrew/cask](https://github.com/Homebrew/homebrew-cask) Homebrew's own automation opens the
+version bumps; until then each release publishes **`coddy.rb`** as an asset, and
+**`brew install --cask <url>`** installs from it.
+
+What the packages install, and how they interact with **`coddy update`**, is documented in
+[install.md](install.md#linux-packages-deb-rpm) and
+[update.md](update.md#installations-owned-by-a-package-manager).
 
 ## Update from GitHub Releases
 
@@ -130,7 +198,14 @@ On each SemVer git tag **`X.Y.Z`** that is on **`main`**, the [**Release binarie
 | **`coddy_X.Y.Z_windows_amd64.zip`** | Windows x86_64 (**`coddy.exe`**) |
 | **`coddy_X.Y.Z_darwin_amd64.tar.gz`** | macOS Intel |
 | **`coddy_X.Y.Z_darwin_arm64.tar.gz`** | macOS Apple Silicon |
-| **`SHA256SUMS`** | Checksums for the archives above |
+| **`coddy_X.Y.Z_linux_amd64.deb`**, **`coddy_X.Y.Z_linux_arm64.deb`** | Debian, Ubuntu and derivatives |
+| **`coddy_X.Y.Z_linux_amd64.rpm`**, **`coddy_X.Y.Z_linux_arm64.rpm`** | Fedora, RHEL, openSUSE and derivatives |
+| **`coddy.rb`** | Homebrew cask for the macOS archives of this tag |
+| **`SHA256SUMS`** | Checksums for every archive and package above |
+
+The **`.tar.gz`** archives carry the man page and the shell completions beside the binary; the
+packages wrap the Linux binaries the same job just built rather than compiling their own, so the
+**`.deb`**, the **`.rpm`** and the **`.tar.gz`** of one tag hold byte-identical executables.
 
 Tags match the full feature set: **`http`**, **`ui`**, **`scheduler`**, **`memory`**. Manual run after a tag exists:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,6 +18,115 @@ irm https://coddy.dev/install.ps1 | iex
 
 Creates **`~/.coddy/config.yaml`** from the release **`config.example.yaml`** when missing.
 
+## Linux packages (deb, rpm)
+
+Every release publishes a **`.deb`** and an **`.rpm`** for **x86_64** and **arm64** beside the
+archives, so Coddy can be installed the way the rest of the system is - and removed the same way.
+Prefer this over the install script on a machine you administer: the files are tracked by the
+package database, the man page and shell completions are wired up for you, and `coddy update`
+knows not to fight your package manager.
+
+**Debian, Ubuntu and derivatives**
+
+```bash
+curl -fsSLO https://github.com/coddy-project/coddy-agent/releases/latest/download/coddy_1.0.10_linux_amd64.deb
+sudo apt-get install ./coddy_1.0.10_linux_amd64.deb
+```
+
+**Fedora, RHEL, openSUSE and derivatives**
+
+```bash
+curl -fsSLO https://github.com/coddy-project/coddy-agent/releases/latest/download/coddy_1.0.10_linux_amd64.rpm
+sudo dnf install ./coddy_1.0.10_linux_amd64.rpm
+```
+
+Replace **`1.0.10`** with the release you want and **`amd64`** with **`arm64`** on 64-bit ARM. The
+[releases page](https://github.com/coddy-project/coddy-agent/releases) lists what each tag
+published, and **`SHA256SUMS`** beside them covers the packages too:
+
+```bash
+sha256sum -c --ignore-missing SHA256SUMS
+```
+
+### What the package installs
+
+| Path | What |
+|------|------|
+| **`/usr/bin/coddy`** | The full binary (**`http`**, **`ui`**, **`scheduler`**, **`memory`**, **`cli`**) |
+| **`/usr/share/man/man1/coddy.1.gz`** | **`man coddy`** |
+| **`/usr/share/bash-completion/completions/coddy`** | bash completion |
+| **`/usr/share/zsh/site-functions/_coddy`** | zsh completion |
+| **`/usr/share/doc/coddy/config.example.yaml`** | starting point for **`~/.coddy/config.yaml`** |
+| **`/usr/share/doc/coddy/LICENSE`**, **`copyright`** | licence |
+
+That is the whole package: a binary and its documentation. No service, no system account, nothing
+under **`/etc`**. Configuration, sessions, skills and credentials stay in the invoking user's
+**`~/.coddy`**, so one installed package serves every user on the machine, each with their own
+state, and what to run - the console, the HTTP gateway, an editor over ACP - stays your decision.
+
+### First run
+
+```bash
+mkdir -p ~/.coddy
+cp /usr/share/doc/coddy/config.example.yaml ~/.coddy/config.yaml
+# set a provider key in ~/.coddy/config.yaml
+coddy
+```
+
+### Upgrading and removing
+
+Upgrade through the package manager, or let Coddy fetch the release package for you as root - both
+end in the same place, and **`coddy update`** as an ordinary user will say so rather than silently
+replacing a packaged file (see [update.md](update.md#installations-owned-by-a-package-manager)):
+
+```bash
+sudo apt-get install ./coddy_<newer>_linux_amd64.deb   # or dnf install ./...rpm
+sudo coddy update -y                                   # downloads and installs the package
+```
+
+```bash
+sudo apt-get remove coddy    # or: sudo dnf remove coddy
+rm -rf ~/.coddy              # only if you also want the sessions and config gone
+```
+
+There is no apt or dnf repository to subscribe to: the packages are release assets, so a new version
+arrives when you install the newer file or run **`sudo coddy update`**, not from a background
+**`apt upgrade`**.
+
+### Building the packages yourself
+
+```bash
+make deb
+make rpm
+```
+
+See [build.md](build.md#distribution-packages).
+
+## macOS (Homebrew)
+
+```bash
+brew install --cask coddy
+```
+
+The cask installs the same **`coddy`** binary the macOS archive carries, plus **`man coddy`** and the
+bash and zsh completions. Upgrade and removal go through Homebrew:
+
+```bash
+brew upgrade --cask coddy
+brew uninstall --cask coddy      # brew zap --cask coddy also removes ~/.coddy
+```
+
+**`coddy update`** recognises a Homebrew install and points back at **`brew upgrade`** rather than
+replacing a file Homebrew tracks. Homebrew refuses to run under **`sudo`**, so there is no
+privileged shortcut there.
+
+> Until the cask is accepted into **homebrew/cask**, install it from the release asset:
+> **`brew install --cask https://github.com/coddy-project/coddy-agent/releases/latest/download/coddy.rb`**.
+> Every release publishes that file with the checksums of the macOS archives of the same tag.
+
+If macOS blocks the first run because the binary is not notarised, clear the quarantine flag:
+**`xattr -d com.apple.quarantine "$(which coddy)"`**.
+
 ## After install
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,6 +18,28 @@ irm https://coddy.dev/install.ps1 | iex
 
 Creates **`~/.coddy/config.yaml`** from the release **`config.example.yaml`** when missing.
 
+On Linux and macOS the script installs more than the binary. The release archive carries the man
+page and the bash and zsh completions beside **`coddy`**, so they land in the **`share`** directory
+of the same prefix (**`~/.local/bin`** -> **`~/.local/share`**), and a user-level install then writes
+one guarded block to the rc file of your login shell:
+
+| What the block does | Why |
+|---|---|
+| adds the install directory to **`PATH`** | a new shell has never heard of **`~/.local/bin`** |
+| adds the data directory to **`MANPATH`** | so **`man coddy`** finds the page |
+| prepends the completions directory to zsh's **`fpath`** and registers **`_coddy`** | zsh searches system directories only |
+| sources the bash completion file | **`bash-completion`** may not be installed |
+
+The block is rewritten between its markers on every run rather than appended to, so re-running the
+installer never duplicates it. Skip it with **`--no-shell-setup`**. A system prefix
+(**`--install-dir /usr/local/bin`**) gets no block at all: those directories are already on
+**`PATH`**, in the man search path and in zsh's default **`fpath`**.
+
+```bash
+source ~/.zshrc   # or open a new terminal
+coddy -v
+```
+
 ## Linux packages (deb, rpm)
 
 Every release publishes a **`.deb`** and an **`.rpm`** for **x86_64** and **arm64** beside the

--- a/docs/update.md
+++ b/docs/update.md
@@ -8,7 +8,7 @@ Every download is checked against the `SHA256SUMS` asset the release publishes b
 
 ## What gets installed
 
-CI publishes one archive per platform on each SemVer tag **`X.Y.Z`**:
+CI publishes one archive per platform on each SemVer tag **`X.Y.Z`**, plus Linux distribution packages:
 
 | Archive | Platform |
 |---------|----------|
@@ -17,6 +17,12 @@ CI publishes one archive per platform on each SemVer tag **`X.Y.Z`**:
 | **`coddy_X.Y.Z_windows_amd64.zip`** | Windows x86_64 (**`coddy.exe`**) |
 | **`coddy_X.Y.Z_darwin_amd64.tar.gz`** | macOS Intel |
 | **`coddy_X.Y.Z_darwin_arm64.tar.gz`** | macOS Apple Silicon |
+| **`coddy_X.Y.Z_linux_amd64.deb`** | Debian, Ubuntu and derivatives, x86_64 |
+| **`coddy_X.Y.Z_linux_arm64.deb`** | Debian, Ubuntu and derivatives, arm64 |
+| **`coddy_X.Y.Z_linux_amd64.rpm`** | Fedora, RHEL, openSUSE and derivatives, x86_64 |
+| **`coddy_X.Y.Z_linux_arm64.rpm`** | Fedora, RHEL, openSUSE and derivatives, arm64 |
+
+The Linux and macOS archives carry the man page and the bash and zsh completions beside the binary; the packages install the same files where the system expects them - see [Install](install.md#linux-packages-deb-rpm). Every release also publishes **`coddy.rb`**, the Homebrew cask for the two macOS archives of that tag.
 
 Each binary is built with **`http`**, **`ui`**, **`scheduler`**, and **`memory`** (same as **`make build TAGS="http ui scheduler memory"`** and the default Docker image). See [Build from source](build.md#release-binaries-ci) for the release pipeline.
 
@@ -28,6 +34,23 @@ Each binary is built with **`http`**, **`ui`**, **`scheduler`**, and **`memory`*
 - When you run **`./build/coddy update`**, it updates **`build/coddy`** in the repo.
 
 This differs from **`make install`**, which always copies to **`~/.local/bin`** or **`/usr/local/bin`**. To update the binary on **`PATH`**, invoke the same **`coddy`** that **`which coddy`** prints.
+
+## Installations owned by a package manager
+
+A **`coddy`** that **`apt`** or **`dnf`** put on disk is listed in the package database, file by file. Overwriting **`/usr/bin/coddy`** in place would leave that database describing a build that is gone, the next **`apt upgrade`** or **`dnf reinstall`** would quietly put the old version back, and **`dpkg --verify`** would report a checksum mismatch nobody asked for. So **`coddy update`** does not replace a packaged executable. It asks **`dpkg-query -S`** and **`rpm -qf`** who owns the file it is about to write and takes one of two other routes:
+
+- **as an ordinary user** - it changes nothing, names the package that owns the installation, and prints the command that upgrades it (**`sudo apt-get install --only-upgrade coddy`**, **`sudo dnf upgrade coddy`**, ...). The exit code is **1**, so a script notices;
+- **as root** - it downloads the **`.deb`** or **`.rpm`** for this architecture, verifies it against **`SHA256SUMS`** like any other asset, and hands it to the package manager it found (**`apt-get`**, **`apt`**, **`dnf`**, **`yum`**, **`zypper`**, else **`dpkg`** or **`rpm`**). The package database stays correct.
+
+**Homebrew** is recognised too, on macOS and on Linux: an executable that resolves into a **`Caskroom`** or **`Cellar`** directory belongs to brew. There is no privileged route there - Homebrew refuses to run under **`sudo`** - so both root and an ordinary user are pointed at **`brew upgrade --cask coddy`**.
+
+```bash
+sudo coddy update -y
+```
+
+Ownership is asked of the package database, not guessed from the path, so a binary you copied out of **`/usr/bin`** keeps updating itself, a distribution's own rebuild of Coddy is recognised like ours, and a build under **`~/.local/bin`** is untouched by any of this.
+
+A release published before this pipeline has archives but no packages. Root is told exactly that and pointed back at the package manager, rather than being handed an archive that would overwrite the packaged file.
 
 ## Commands
 
@@ -83,6 +106,8 @@ coddy update --help
 | **`make build TAGS="..."`** | You need custom tags or local changes not in releases. |
 | **Docker** | **`docker compose pull`** / image tag **`X.Y.Z`** on [GHCR](https://github.com/coddy-project/coddy-agent/pkgs/container/coddy-agent). |
 | **`go install ...@latest`** | Quick install without release assets; default module tags only (no **`http`** / UI unless you build from source). |
+| **`apt` / `dnf` / `zypper`** | You installed the **`.deb`** or **`.rpm`**; install the newer package file, or run **`sudo coddy update`** to have it fetched for you. |
+| **`brew upgrade --cask coddy`** | You installed the Homebrew cask. |
 
 ## Limitations
 
@@ -91,4 +116,5 @@ coddy update --help
 - The Windows helper deletes itself through the Coddy it just installed. Installing a release older than that handoff - `coddy update --version` walking backwards - starts the older build directly instead, and its helper stays in `%TEMP%` until the next `coddy update` sweeps it.
 - Asset downloads resume after a temporary connection failure (up to three attempts). GitHub supports the HTTP range requests Coddy uses to resume; a server that does not support ranges is downloaded again from the beginning, and one that resumes at the wrong offset fails the download rather than installing a spliced archive.
 - **`coddy update`** needs outbound HTTPS to **`api.github.com`** and the asset CDN (GitHub release downloads).
-- Config under **`$CODDY_HOME`** is not modified; only the binary is replaced.
+- The package route is Linux-only (Homebrew installs are reported, never upgraded by Coddy), and the package manager runs non-interactively, so an upgrade that would remove another package fails instead of asking. Run the package manager yourself in that case.
+- Config under **`$CODDY_HOME`** is not modified; only the binary, or the package that carries it, is replaced.

--- a/features/update_packages.feature
+++ b/features/update_packages.feature
@@ -1,0 +1,40 @@
+Feature: Updating a Coddy installed from a system package
+  A Coddy that apt or dnf put on disk is owned by the package database. Replacing
+  that file in place would leave the database describing a build that is no longer
+  there, so self-update installs the release package instead - and only a process
+  that can write to the package database may do it. Homebrew refuses to run under
+  sudo at all, so a brew install has no privileged route and always ends at the
+  brew command that upgrades it.
+
+  Scenario: Without root privileges Coddy points at the package manager
+    Given Coddy was installed from a deb package
+    And Coddy runs without root privileges
+    When Coddy tries to install the update
+    Then Coddy reports that a package manager owns the installation
+    And Coddy names the command that upgrades the package
+    And the installed executable is left untouched
+
+  Scenario: Root installs the release package instead of replacing the binary
+    Given Coddy was installed from a deb package
+    And Coddy runs as root
+    When Coddy installs the update
+    Then Coddy downloads the release package for this platform
+    And Coddy hands the package to the system package manager
+    And Coddy reports the release it installed
+    And the installed executable is left untouched
+
+  Scenario: A Homebrew install is sent back to brew
+    Given Coddy was installed by Homebrew
+    And Coddy runs as root
+    When Coddy tries to install the update
+    Then Coddy reports that a package manager owns the installation
+    And Coddy names the command that upgrades the package
+    And the installed executable is left untouched
+
+  Scenario: Root installs the release package on an rpm system
+    Given Coddy was installed from an rpm package
+    And Coddy runs as root
+    When Coddy installs the update
+    Then Coddy downloads the release package for this platform
+    And Coddy hands the package to the system package manager
+    And Coddy reports the release it installed

--- a/internal/update/bdd_update_packages_test.go
+++ b/internal/update/bdd_update_packages_test.go
@@ -122,24 +122,29 @@ func (s *packageFeatureState) runsWithoutRoot() error {
 }
 
 // env answers as a host where the package database owns s.dest and the chosen
-// front-end is the only package tool installed.
+// front-end is the only package tool installed. A Homebrew host has neither
+// dpkg nor rpm, so nothing but the path can identify that install - which is
+// the point of the scenario.
 func (s *packageFeatureState) env() packageEnv {
 	owner := "dpkg-query"
-	if s.format == formatRPM {
+	switch s.format {
+	case formatRPM:
 		owner = "rpm"
+	case formatBrew:
+		owner = ""
 	}
 	return packageEnv{
 		GOOS:    "linux",
 		Geteuid: func() int { return s.euid },
 		LookPath: func(name string) (string, error) {
-			if name == owner || name == s.manager {
+			if owner != "" && (name == owner || name == s.manager) {
 				return "/usr/bin/" + name, nil
 			}
 			return "", errors.New("not found")
 		},
 		Query: func(_ context.Context, name string, args ...string) (string, error) {
 			path := args[len(args)-1]
-			if path != s.dest {
+			if owner == "" || path != s.dest {
 				return "", errors.New("not owned")
 			}
 			if name == "dpkg-query" {

--- a/internal/update/bdd_update_packages_test.go
+++ b/internal/update/bdd_update_packages_test.go
@@ -1,0 +1,272 @@
+package update
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+const installedPayload = "the installed build of Coddy"
+
+// packageFeatureState stands up a release that publishes distribution packages
+// beside the archives, and a host whose package database owns the executable.
+type packageFeatureState struct {
+	assetName string
+	body      []byte
+	dest      string
+	dir       string
+	euid      int
+	format    packageFormat
+	installed []string
+	manager   string
+	out       bytes.Buffer
+	runErr    error
+	server    *httptest.Server
+	served    int
+}
+
+func (s *packageFeatureState) reset() {
+	if s.server != nil {
+		s.server.Close()
+	}
+	if s.dir != "" {
+		_ = os.RemoveAll(s.dir)
+	}
+	*s = packageFeatureState{}
+}
+
+func (s *packageFeatureState) installedFromDeb() error {
+	return s.installedFromPackage(formatDeb, "apt-get")
+}
+
+func (s *packageFeatureState) installedFromRPM() error {
+	return s.installedFromPackage(formatRPM, "dnf")
+}
+
+func (s *packageFeatureState) installedByHomebrew() error {
+	return s.installedFromPackage(formatBrew, "brew")
+}
+
+func (s *packageFeatureState) installedFromPackage(format packageFormat, manager string) error {
+	s.format, s.manager = format, manager
+	assetFormat := format
+	if assetFormat == formatBrew {
+		// brew never downloads a package here; the release still has to look
+		// like a real one.
+		assetFormat = formatDeb
+	}
+	assetName, err := PackageAssetFileName(featureReleaseTag, string(assetFormat), "amd64")
+	if err != nil {
+		return err
+	}
+	s.assetName = assetName
+	s.body = []byte("the release " + string(format) + " of Coddy")
+
+	s.dir, err = os.MkdirTemp("", "coddy-package-feature-*")
+	if err != nil {
+		return err
+	}
+	// The path a package manager would own. For dpkg and rpm what matters is
+	// that the database claims it, not where it sits; Homebrew is recognised
+	// from the path itself, so that one has to look like a Caskroom.
+	s.dest = filepath.Join(s.dir, "coddy")
+	if format == formatBrew {
+		s.dest = filepath.Join(s.dir, "Caskroom", "coddy", featureReleaseTag, "coddy")
+		if err := os.MkdirAll(filepath.Dir(s.dest), 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(s.dest, []byte(installedPayload), 0o755); err != nil {
+		return err
+	}
+
+	sum := sha256.Sum256(s.body)
+	sums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/" + DefaultRepo + "/releases/latest":
+			_, _ = fmt.Fprintf(w, `{"tag_name":%q,"assets":[{"name":%q,"browser_download_url":"http://%s/asset"},{"name":%q,"browser_download_url":"http://%s/sums"}]}`,
+				featureReleaseTag, assetName, r.Host, checksumAssetName, r.Host)
+		case "/asset":
+			s.served++
+			_, _ = w.Write(s.body)
+		case "/sums":
+			_, _ = w.Write([]byte(sums))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return nil
+}
+
+func (s *packageFeatureState) runsAsRoot() error {
+	s.euid = 0
+	return nil
+}
+
+func (s *packageFeatureState) runsWithoutRoot() error {
+	s.euid = 1000
+	return nil
+}
+
+// env answers as a host where the package database owns s.dest and the chosen
+// front-end is the only package tool installed.
+func (s *packageFeatureState) env() packageEnv {
+	owner := "dpkg-query"
+	if s.format == formatRPM {
+		owner = "rpm"
+	}
+	return packageEnv{
+		GOOS:    "linux",
+		Geteuid: func() int { return s.euid },
+		LookPath: func(name string) (string, error) {
+			if name == owner || name == s.manager {
+				return "/usr/bin/" + name, nil
+			}
+			return "", errors.New("not found")
+		},
+		Query: func(_ context.Context, name string, args ...string) (string, error) {
+			path := args[len(args)-1]
+			if path != s.dest {
+				return "", errors.New("not owned")
+			}
+			if name == "dpkg-query" {
+				return "coddy: " + path + "\n", nil
+			}
+			return "coddy", nil
+		},
+		Install: func(_ context.Context, out io.Writer, name string, args ...string) error {
+			s.installed = append([]string{name}, args...)
+			_, _ = fmt.Fprintf(out, "%s: installed\n", name)
+			return nil
+		},
+	}
+}
+
+func (s *packageFeatureState) run() error {
+	env := s.env()
+	s.runErr = Run(context.Background(), Options{
+		APIBase:        s.server.URL,
+		Repo:           DefaultRepo,
+		CurrentVersion: "0.9.67",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		InstallPath:    s.dest,
+		Yes:            true,
+		Stdout:         &s.out,
+		packageEnv:     &env,
+	})
+	return nil
+}
+
+func (s *packageFeatureState) installsTheUpdate() error {
+	_ = s.run()
+	return s.runErr
+}
+
+func (s *packageFeatureState) triesToInstallTheUpdate() error {
+	return s.run()
+}
+
+func (s *packageFeatureState) reportsPackageManagerOwnership() error {
+	if !errors.Is(s.runErr, ErrPackageManaged) {
+		return fmt.Errorf("error = %v, want one wrapping ErrPackageManaged", s.runErr)
+	}
+	if !strings.Contains(s.runErr.Error(), s.dest) {
+		return fmt.Errorf("error does not name the installed file: %v", s.runErr)
+	}
+	return nil
+}
+
+func (s *packageFeatureState) namesTheUpgradeCommand() error {
+	want := packageUpgradeHint(systemPackage{Format: s.format, Name: "coddy", Manager: s.manager})
+	if !strings.Contains(s.runErr.Error(), want) {
+		return fmt.Errorf("error does not name %q: %v", want, s.runErr)
+	}
+	return nil
+}
+
+func (s *packageFeatureState) executableIsUntouched() error {
+	got, err := os.ReadFile(s.dest)
+	if err != nil {
+		return err
+	}
+	if string(got) != installedPayload {
+		return fmt.Errorf("installed executable = %q, want it left at %q", got, installedPayload)
+	}
+	return nil
+}
+
+func (s *packageFeatureState) downloadsTheReleasePackage() error {
+	if s.served != 1 {
+		return fmt.Errorf("package asset served %d times, want 1", s.served)
+	}
+	return nil
+}
+
+func (s *packageFeatureState) handsThePackageToTheManager() error {
+	if len(s.installed) == 0 {
+		return fmt.Errorf("no package manager was invoked")
+	}
+	if s.installed[0] != s.manager {
+		return fmt.Errorf("invoked %q, want %q", s.installed[0], s.manager)
+	}
+	file := s.installed[len(s.installed)-1]
+	if filepath.Base(file) != s.assetName {
+		return fmt.Errorf("installed %q, want the downloaded %q", file, s.assetName)
+	}
+	return nil
+}
+
+func (s *packageFeatureState) reportsTheInstalledRelease() error {
+	if !strings.Contains(s.out.String(), "Installed "+featureReleaseTag) {
+		return fmt.Errorf("output does not report the release: %q", s.out.String())
+	}
+	return nil
+}
+
+func TestUpdatePackagesFeature(t *testing.T) {
+	s := &packageFeatureState{}
+	t.Cleanup(s.reset)
+
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				s.reset()
+				return ctx, nil
+			})
+			sc.Step(`^Coddy was installed from a deb package$`, s.installedFromDeb)
+			sc.Step(`^Coddy was installed from an rpm package$`, s.installedFromRPM)
+			sc.Step(`^Coddy was installed by Homebrew$`, s.installedByHomebrew)
+			sc.Step(`^Coddy runs as root$`, s.runsAsRoot)
+			sc.Step(`^Coddy runs without root privileges$`, s.runsWithoutRoot)
+			sc.Step(`^Coddy installs the update$`, s.installsTheUpdate)
+			sc.Step(`^Coddy tries to install the update$`, s.triesToInstallTheUpdate)
+			sc.Step(`^Coddy reports that a package manager owns the installation$`, s.reportsPackageManagerOwnership)
+			sc.Step(`^Coddy names the command that upgrades the package$`, s.namesTheUpgradeCommand)
+			sc.Step(`^the installed executable is left untouched$`, s.executableIsUntouched)
+			sc.Step(`^Coddy downloads the release package for this platform$`, s.downloadsTheReleasePackage)
+			sc.Step(`^Coddy hands the package to the system package manager$`, s.handsThePackageToTheManager)
+			sc.Step(`^Coddy reports the release it installed$`, s.reportsTheInstalledRelease)
+		},
+		Options: &godog.Options{
+			Format: "progress",
+			Paths:  []string{"../../features/update_packages.feature"},
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("update packages feature failed")
+	}
+}

--- a/internal/update/packages.go
+++ b/internal/update/packages.go
@@ -1,0 +1,302 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ErrPackageManaged reports that the executable about to be replaced belongs to
+// a system package. Overwriting it would leave dpkg or rpm describing a build
+// that is no longer on disk, and the next `apt upgrade` would silently undo the
+// update, so the package flow refuses to touch the file and says what to run
+// instead.
+var ErrPackageManaged = errors.New("coddy is installed by a system package manager")
+
+// packageFormat is the distribution package format an installation came from.
+type packageFormat string
+
+const (
+	formatDeb  packageFormat = "deb"
+	formatRPM  packageFormat = "rpm"
+	formatBrew packageFormat = "brew"
+)
+
+// systemPackage describes an installed coddy that a package database owns.
+type systemPackage struct {
+	// Format is the package format that carried the file.
+	Format packageFormat
+	// Name is the package name as its manager knows it, usually "coddy".
+	Name string
+	// Manager is the front-end used to install and upgrade the package.
+	Manager string
+}
+
+// packageEnv is the host as the package flow sees it. Tests replace every field
+// so the whole flow runs without a package manager, without root, and without
+// touching anything outside the test's temp directory.
+type packageEnv struct {
+	GOOS     string
+	Geteuid  func() int
+	LookPath func(name string) (string, error)
+	// Query runs a package database lookup and returns its stdout. A non-zero
+	// exit means the file is not owned, which is an answer, not a failure.
+	Query func(ctx context.Context, name string, args ...string) (string, error)
+	// Install hands a package file to the package manager, streaming its
+	// output to the caller's writer.
+	Install func(ctx context.Context, out io.Writer, name string, args ...string) error
+}
+
+// defaultPackageEnv talks to the real host.
+func defaultPackageEnv() packageEnv {
+	return packageEnv{
+		GOOS:     runtime.GOOS,
+		Geteuid:  os.Geteuid,
+		LookPath: exec.LookPath,
+		Query: func(ctx context.Context, name string, args ...string) (string, error) {
+			out, err := exec.CommandContext(ctx, name, args...).Output()
+			return string(out), err
+		},
+		Install: func(ctx context.Context, out io.Writer, name string, args ...string) error {
+			cmd := exec.CommandContext(ctx, name, args...)
+			cmd.Stdout, cmd.Stderr = out, out
+			return cmd.Run()
+		},
+	}
+}
+
+// PackageAssetFileName returns the release package CI publishes for a Linux
+// distribution format, named like the archives beside it so one release listing
+// reads the same way for every asset.
+func PackageAssetFileName(version, format, goarch string) (string, error) {
+	switch packageFormat(format) {
+	case formatDeb, formatRPM:
+	default:
+		return "", fmt.Errorf("unsupported package format %q", format)
+	}
+	switch goarch {
+	case "amd64", "arm64":
+	default:
+		return "", fmt.Errorf("unsupported package platform linux/%s", goarch)
+	}
+	return fmt.Sprintf("coddy_%s_linux_%s.%s", version, goarch, format), nil
+}
+
+// detectSystemPackage reports whether path is a file a package manager put on
+// disk, and how to talk to that manager. Ownership is asked of the package
+// database rather than guessed from the path, so a binary copied out of
+// /usr/bin keeps updating itself and a distribution rebuild is recognised the
+// same as our own package.
+func detectSystemPackage(ctx context.Context, env packageEnv, path string) (systemPackage, bool) {
+	if strings.TrimSpace(path) == "" {
+		return systemPackage{}, false
+	}
+	if name, ok := homebrewOwner(path); ok {
+		return systemPackage{Format: formatBrew, Name: name, Manager: "brew"}, true
+	}
+	if env.GOOS != "linux" {
+		return systemPackage{}, false
+	}
+	if name, ok := debPackageOwner(ctx, env, path); ok {
+		return systemPackage{Format: formatDeb, Name: name, Manager: packageFrontEnd(env, formatDeb)}, true
+	}
+	if name, ok := rpmPackageOwner(ctx, env, path); ok {
+		return systemPackage{Format: formatRPM, Name: name, Manager: packageFrontEnd(env, formatRPM)}, true
+	}
+	return systemPackage{}, false
+}
+
+// homebrewOwner recognises a binary Homebrew installed. The executable on PATH
+// is a symlink into the Caskroom (casks) or the Cellar (formulae), and the
+// caller resolves symlinks before asking, so the prefix is visible in the path
+// itself - no `brew` process, and no answer that depends on brew being on PATH
+// at all. The directory below Caskroom or Cellar is the package name.
+func homebrewOwner(path string) (string, bool) {
+	for _, marker := range []string{"/Caskroom/", "/Cellar/"} {
+		_, rest, ok := strings.Cut(path, marker)
+		if !ok {
+			continue
+		}
+		name, _, _ := strings.Cut(rest, "/")
+		if name = strings.TrimSpace(name); name != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// debPackageOwner asks dpkg which package shipped path. dpkg-query prints
+// "coddy: /usr/bin/coddy", and lists several packages when more than one
+// declares the file.
+func debPackageOwner(ctx context.Context, env packageEnv, path string) (string, bool) {
+	if _, err := env.LookPath("dpkg-query"); err != nil {
+		return "", false
+	}
+	out, err := env.Query(ctx, "dpkg-query", "-S", path)
+	if err != nil {
+		return "", false
+	}
+	name, _, ok := strings.Cut(strings.TrimSpace(out), ":")
+	if !ok {
+		return "", false
+	}
+	name, _, _ = strings.Cut(name, ",")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+// rpmPackageOwner asks rpm which package shipped path, formatting the answer
+// down to the bare package name.
+func rpmPackageOwner(ctx context.Context, env packageEnv, path string) (string, bool) {
+	if _, err := env.LookPath("rpm"); err != nil {
+		return "", false
+	}
+	out, err := env.Query(ctx, "rpm", "-qf", "--queryformat", "%{NAME}", path)
+	if err != nil {
+		return "", false
+	}
+	name := strings.TrimSpace(out)
+	// rpm answers a miss on stdout with a zero exit on some builds.
+	if name == "" || strings.Contains(name, " ") {
+		return "", false
+	}
+	return name, true
+}
+
+// packageFrontEnd picks the highest-level tool present for a format. The
+// low-level tool is the fallback rather than the first choice: apt and dnf
+// resolve dependencies, dpkg and rpm only report them.
+func packageFrontEnd(env packageEnv, format packageFormat) string {
+	candidates := []string{"dnf", "zypper", "yum", "rpm"}
+	fallback := "rpm"
+	if format == formatDeb {
+		candidates = []string{"apt-get", "apt", "dpkg"}
+		fallback = "dpkg"
+	}
+	for _, name := range candidates {
+		if _, err := env.LookPath(name); err == nil {
+			return name
+		}
+	}
+	return fallback
+}
+
+// packageInstallCommand builds the non-interactive upgrade for one downloaded
+// package file.
+func packageInstallCommand(manager, file string) []string {
+	switch manager {
+	case "apt-get", "apt":
+		return []string{manager, "install", "-y", "--allow-downgrades", file}
+	case "dpkg":
+		return []string{"dpkg", "--install", file}
+	case "dnf", "yum":
+		return []string{manager, "install", "-y", file}
+	case "zypper":
+		return []string{"zypper", "--non-interactive", "install", "--allow-unsigned-rpm", file}
+	default:
+		return []string{"rpm", "--upgrade", "--oldpackage", file}
+	}
+}
+
+// packageUpgradeHint is the command a user without root privileges is told to
+// run. Repository front-ends can upgrade from a configured repository; dpkg and
+// rpm can only install a file, so those point back at `sudo coddy update`,
+// which downloads that file.
+func packageUpgradeHint(pkg systemPackage) string {
+	if pkg.Format == formatBrew {
+		return fmt.Sprintf("brew upgrade --cask %s", pkg.Name)
+	}
+	switch pkg.Manager {
+	case "apt-get", "apt":
+		return fmt.Sprintf("sudo %s install --only-upgrade %s", pkg.Manager, pkg.Name)
+	case "dnf", "yum":
+		return fmt.Sprintf("sudo %s upgrade %s", pkg.Manager, pkg.Name)
+	case "zypper":
+		return fmt.Sprintf("sudo zypper update %s", pkg.Name)
+	default:
+		return "sudo coddy update"
+	}
+}
+
+// packageManagedError explains what owns the installation and how to move it
+// forward. The guidance travels inside the error so it is printed once, on the
+// stream the caller reports failures on.
+func packageManagedError(pkg systemPackage, current, latest, dest string) error {
+	// Homebrew refuses to run under sudo, so there is no privileged route to
+	// offer there - the upgrade command is the whole answer.
+	trailer := "\n\nOr let Coddy fetch and install the release package for you:\n\n    sudo coddy update"
+	if pkg.Format == formatBrew {
+		trailer = ""
+	}
+	return fmt.Errorf("%w\n\n"+
+		"coddy %s at %s belongs to the %q package, and %s is available.\n"+
+		"Replacing that file would leave the package database describing a build that is gone,\n"+
+		"so nothing was changed.\n\n"+
+		"Upgrade it with your package manager:\n\n"+
+		"    %s%s",
+		ErrPackageManaged, current, dest, pkg.Name, latest, packageUpgradeHint(pkg), trailer)
+}
+
+// installSystemPackage downloads the release package for this host and hands it
+// to the package manager. The caller has already established that the running
+// executable is package-managed and that this process may write to the package
+// database.
+func installSystemPackage(ctx context.Context, opts Options, env packageEnv, pkg systemPackage, rel *ghRelease, latest string, out io.Writer, client *http.Client) error {
+	assetName, err := PackageAssetFileName(latest, string(pkg.Format), opts.GOARCH)
+	if err != nil {
+		return err
+	}
+	asset, err := pickAsset(rel, assetName)
+	if err != nil {
+		return fmt.Errorf("%w; upgrade the %q package with your package manager instead", err, pkg.Name)
+	}
+
+	if !opts.Yes {
+		_, _ = fmt.Fprintf(out, "Update the %q package %s -> %s with %s? [y/N] ", pkg.Name, opts.CurrentVersion, latest, pkg.Manager)
+		ok, err := readYesNo(os.Stdin)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			_, _ = fmt.Fprintln(out, "cancelled")
+			return nil
+		}
+	}
+
+	_, _ = fmt.Fprintf(out, "Downloading %s ...\n", asset.Name)
+	data, err := downloadURL(ctx, client, asset.BrowserDownloadURL, newDownloadProgress(out, asset.Name))
+	if err != nil {
+		return err
+	}
+	if err := verifyAssetChecksum(ctx, client, rel, asset.Name, data, out); err != nil {
+		return err
+	}
+
+	dir, err := os.MkdirTemp("", "coddy-package-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	file := filepath.Join(dir, asset.Name)
+	if err := os.WriteFile(file, data, 0o644); err != nil {
+		return err
+	}
+
+	argv := packageInstallCommand(pkg.Manager, file)
+	_, _ = fmt.Fprintf(out, "Installing with %s ...\n", pkg.Manager)
+	if err := env.Install(ctx, out, argv[0], argv[1:]...); err != nil {
+		return fmt.Errorf("%s: %w", strings.Join(argv, " "), err)
+	}
+	_, _ = fmt.Fprintf(out, "Installed %s (%s package %q via %s)\n", latest, pkg.Format, pkg.Name, pkg.Manager)
+	return nil
+}

--- a/internal/update/packages.go
+++ b/internal/update/packages.go
@@ -119,6 +119,10 @@ func detectSystemPackage(ctx context.Context, env packageEnv, path string) (syst
 // itself - no `brew` process, and no answer that depends on brew being on PATH
 // at all. The directory below Caskroom or Cellar is the package name.
 func homebrewOwner(path string) (string, bool) {
+	// Homebrew is a Unix-only tool, but the path handed in comes from the host
+	// this process runs on, so normalise the separator before matching rather
+	// than assuming one.
+	path = filepath.ToSlash(path)
 	for _, marker := range []string{"/Caskroom/", "/Cellar/"} {
 		_, rest, ok := strings.Cut(path, marker)
 		if !ok {

--- a/internal/update/packages_test.go
+++ b/internal/update/packages_test.go
@@ -1,0 +1,258 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPackageAssetFileName(t *testing.T) {
+	for _, tc := range []struct {
+		format string
+		goarch string
+		want   string
+	}{
+		{"deb", "amd64", "coddy_1.2.3_linux_amd64.deb"},
+		{"deb", "arm64", "coddy_1.2.3_linux_arm64.deb"},
+		{"rpm", "amd64", "coddy_1.2.3_linux_amd64.rpm"},
+		{"rpm", "arm64", "coddy_1.2.3_linux_arm64.rpm"},
+	} {
+		got, err := PackageAssetFileName("1.2.3", tc.format, tc.goarch)
+		if err != nil {
+			t.Fatalf("%s/%s: %v", tc.format, tc.goarch, err)
+		}
+		if got != tc.want {
+			t.Fatalf("%s/%s = %q, want %q", tc.format, tc.goarch, got, tc.want)
+		}
+	}
+
+	if _, err := PackageAssetFileName("1.2.3", "apk", "amd64"); err == nil {
+		t.Fatal("unsupported format accepted")
+	}
+	if _, err := PackageAssetFileName("1.2.3", "deb", "riscv64"); err == nil {
+		t.Fatal("unsupported architecture accepted")
+	}
+}
+
+// lookPathFor answers as a host where only the named tools are installed.
+func lookPathFor(names ...string) func(string) (string, error) {
+	return func(name string) (string, error) {
+		if slices.Contains(names, name) {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func TestPackageFrontEndPrefersTheResolvingTool(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		format  packageFormat
+		present []string
+		want    string
+	}{
+		{"apt over dpkg", formatDeb, []string{"dpkg", "apt-get"}, "apt-get"},
+		{"apt when apt-get is absent", formatDeb, []string{"dpkg", "apt"}, "apt"},
+		{"dpkg alone", formatDeb, []string{"dpkg"}, "dpkg"},
+		{"deb fallback with nothing installed", formatDeb, nil, "dpkg"},
+		{"dnf over rpm", formatRPM, []string{"rpm", "dnf"}, "dnf"},
+		{"zypper when dnf is absent", formatRPM, []string{"rpm", "zypper", "yum"}, "zypper"},
+		{"rpm fallback with nothing installed", formatRPM, nil, "rpm"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := packageFrontEnd(packageEnv{LookPath: lookPathFor(tc.present...)}, tc.format)
+			if got != tc.want {
+				t.Fatalf("front end = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPackageInstallCommandIsNonInteractive(t *testing.T) {
+	for _, tc := range []struct {
+		manager string
+		want    string
+	}{
+		{"apt-get", "apt-get install -y --allow-downgrades /tmp/coddy.deb"},
+		{"apt", "apt install -y --allow-downgrades /tmp/coddy.deb"},
+		{"dpkg", "dpkg --install /tmp/coddy.deb"},
+		{"dnf", "dnf install -y /tmp/coddy.deb"},
+		{"yum", "yum install -y /tmp/coddy.deb"},
+		{"zypper", "zypper --non-interactive install --allow-unsigned-rpm /tmp/coddy.deb"},
+		{"rpm", "rpm --upgrade --oldpackage /tmp/coddy.deb"},
+	} {
+		got := strings.Join(packageInstallCommand(tc.manager, "/tmp/coddy.deb"), " ")
+		if got != tc.want {
+			t.Fatalf("%s: command = %q, want %q", tc.manager, got, tc.want)
+		}
+	}
+}
+
+// A low-level tool cannot upgrade from a repository, so the hint has to send
+// the user back through Coddy, which downloads the file the tool needs.
+func TestPackageUpgradeHintFallsBackToCoddyForFileOnlyTools(t *testing.T) {
+	for _, tc := range []struct {
+		manager string
+		want    string
+	}{
+		{"apt-get", "sudo apt-get install --only-upgrade coddy"},
+		{"dnf", "sudo dnf upgrade coddy"},
+		{"zypper", "sudo zypper update coddy"},
+		{"dpkg", "sudo coddy update"},
+		{"rpm", "sudo coddy update"},
+	} {
+		got := packageUpgradeHint(systemPackage{Name: "coddy", Manager: tc.manager})
+		if got != tc.want {
+			t.Fatalf("%s: hint = %q, want %q", tc.manager, got, tc.want)
+		}
+	}
+}
+
+func TestDetectSystemPackage(t *testing.T) {
+	const owned = "/usr/bin/coddy"
+
+	debEnv := func(out string, err error) packageEnv {
+		return packageEnv{
+			GOOS:     "linux",
+			LookPath: lookPathFor("dpkg-query", "apt-get"),
+			Query:    func(context.Context, string, ...string) (string, error) { return out, err },
+		}
+	}
+
+	t.Run("dpkg ownership", func(t *testing.T) {
+		pkg, ok := detectSystemPackage(context.Background(), debEnv("coddy: /usr/bin/coddy\n", nil), owned)
+		if !ok {
+			t.Fatal("owned file reported as unmanaged")
+		}
+		if pkg.Format != formatDeb || pkg.Name != "coddy" || pkg.Manager != "apt-get" {
+			t.Fatalf("package = %+v", pkg)
+		}
+	})
+
+	t.Run("several packages declare the file", func(t *testing.T) {
+		pkg, ok := detectSystemPackage(context.Background(), debEnv("coddy, coddy-extras: /usr/bin/coddy\n", nil), owned)
+		if !ok || pkg.Name != "coddy" {
+			t.Fatalf("package = %+v, ok = %v; want the first listed package", pkg, ok)
+		}
+	})
+
+	t.Run("dpkg reports no owner", func(t *testing.T) {
+		if _, ok := detectSystemPackage(context.Background(), debEnv("", errors.New("exit 1")), owned); ok {
+			t.Fatal("unowned file reported as package-managed")
+		}
+	})
+
+	t.Run("rpm ownership", func(t *testing.T) {
+		env := packageEnv{
+			GOOS:     "linux",
+			LookPath: lookPathFor("rpm", "dnf"),
+			Query:    func(context.Context, string, ...string) (string, error) { return "coddy", nil },
+		}
+		pkg, ok := detectSystemPackage(context.Background(), env, owned)
+		if !ok || pkg.Format != formatRPM || pkg.Manager != "dnf" {
+			t.Fatalf("package = %+v, ok = %v", pkg, ok)
+		}
+	})
+
+	// Some rpm builds answer a miss on stdout with a zero exit ("file ... is
+	// not owned by any package"), which must not be read as a package name.
+	t.Run("rpm reports a miss on stdout", func(t *testing.T) {
+		env := packageEnv{
+			GOOS:     "linux",
+			LookPath: lookPathFor("rpm"),
+			Query: func(context.Context, string, ...string) (string, error) {
+				return "file /usr/bin/coddy is not owned by any package", nil
+			},
+		}
+		if _, ok := detectSystemPackage(context.Background(), env, owned); ok {
+			t.Fatal("rpm miss text read as a package name")
+		}
+	})
+
+	t.Run("no package tools installed", func(t *testing.T) {
+		env := packageEnv{GOOS: "linux", LookPath: lookPathFor()}
+		if _, ok := detectSystemPackage(context.Background(), env, owned); ok {
+			t.Fatal("host without dpkg or rpm reported a package")
+		}
+	})
+
+	// Homebrew is read off the resolved path, so it needs no package tool at
+	// all and works the same on macOS and on Linux.
+	t.Run("homebrew cask and cellar", func(t *testing.T) {
+		for _, path := range []string{
+			"/opt/homebrew/Caskroom/coddy/1.0.11/coddy",
+			"/usr/local/Cellar/coddy/1.0.11/bin/coddy",
+			"/home/dev/.linuxbrew/Caskroom/coddy/1.0.11/coddy",
+		} {
+			env := packageEnv{GOOS: "darwin", LookPath: lookPathFor()}
+			pkg, ok := detectSystemPackage(context.Background(), env, path)
+			if !ok || pkg.Format != formatBrew || pkg.Name != "coddy" || pkg.Manager != "brew" {
+				t.Fatalf("%s: package = %+v, ok = %v", path, pkg, ok)
+			}
+			if got := packageUpgradeHint(pkg); got != "brew upgrade --cask coddy" {
+				t.Fatalf("%s: hint = %q", path, got)
+			}
+		}
+	})
+
+	t.Run("a path that only mentions a cellar", func(t *testing.T) {
+		env := packageEnv{GOOS: "darwin", LookPath: lookPathFor()}
+		if _, ok := detectSystemPackage(context.Background(), env, "/home/dev/Cellar-notes/coddy"); ok {
+			t.Fatal("an unrelated path was read as a Homebrew install")
+		}
+	})
+
+	t.Run("not linux", func(t *testing.T) {
+		env := packageEnv{
+			GOOS:     "darwin",
+			LookPath: lookPathFor("dpkg-query"),
+			Query:    func(context.Context, string, ...string) (string, error) { return "coddy: x", nil },
+		}
+		if _, ok := detectSystemPackage(context.Background(), env, owned); ok {
+			t.Fatal("package database queried outside linux")
+		}
+	})
+
+	t.Run("no install path", func(t *testing.T) {
+		env := packageEnv{
+			GOOS:     "linux",
+			LookPath: lookPathFor("dpkg-query"),
+			Query: func(context.Context, string, ...string) (string, error) {
+				t.Fatal("package database queried without a path")
+				return "", nil
+			},
+		}
+		if _, ok := detectSystemPackage(context.Background(), env, "  "); ok {
+			t.Fatal("empty path reported as package-managed")
+		}
+	})
+}
+
+// A release older than the packaging pipeline publishes archives only. Root has
+// to learn that from the update rather than from a bare "no asset" line.
+func TestInstallSystemPackageWithoutAPackageAsset(t *testing.T) {
+	rel := &ghRelease{TagName: "0.9.70", Assets: []releaseAsset{
+		{Name: "coddy_0.9.70_linux_amd64.tar.gz", BrowserDownloadURL: "http://example.invalid/a"},
+	}}
+	env := packageEnv{
+		GOOS:    "linux",
+		Geteuid: func() int { return 0 },
+		Install: func(context.Context, io.Writer, string, ...string) error {
+			t.Fatal("package manager invoked without a package to install")
+			return nil
+		},
+	}
+	pkg := systemPackage{Format: formatDeb, Name: "coddy", Manager: "apt-get"}
+	opts := Options{GOARCH: "amd64", Yes: true}
+
+	err := installSystemPackage(context.Background(), opts, env, pkg, rel, "0.9.70", io.Discard, nil)
+	if err == nil {
+		t.Fatal("missing package asset accepted")
+	}
+	if !strings.Contains(err.Error(), "coddy_0.9.70_linux_amd64.deb") || !strings.Contains(err.Error(), "package manager") {
+		t.Fatalf("error does not explain the missing package: %v", err)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -35,6 +35,10 @@ type Options struct {
 
 	// windowsInstaller replaces the Windows helper launcher in deterministic tests.
 	windowsInstaller windowsUpdateInstaller
+
+	// packageEnv replaces the package database, the package manager, and the
+	// effective user id in deterministic tests.
+	packageEnv *packageEnv
 }
 
 // Run checks GitHub releases and optionally installs a newer binary.
@@ -76,6 +80,31 @@ func Run(ctx context.Context, opts Options) error {
 		return ErrUpdateAvailable
 	}
 
+	dest := strings.TrimSpace(opts.InstallPath)
+	if dest == "" {
+		dest, err = resolveExecutablePath()
+		if err != nil {
+			return err
+		}
+	}
+
+	// A package manager owning this file changes what an update even is: the
+	// unit to replace is the package, not the executable inside it.
+	if opts.GOOS == "linux" || opts.GOOS == "darwin" {
+		env := defaultPackageEnv()
+		if opts.packageEnv != nil {
+			env = *opts.packageEnv
+		}
+		if pkg, ok := detectSystemPackage(ctx, env, dest); ok {
+			// Homebrew has no privileged route - it refuses to run as root -
+			// so every brew install ends at the same guidance.
+			if pkg.Format == formatBrew || env.Geteuid() != 0 {
+				return packageManagedError(pkg, opts.CurrentVersion, latest, dest)
+			}
+			return installSystemPackage(ctx, opts, env, pkg, rel, latest, out, client)
+		}
+	}
+
 	assetName, err := AssetFileName(latest, opts.GOOS, opts.GOARCH)
 	if err != nil {
 		return err
@@ -83,14 +112,6 @@ func Run(ctx context.Context, opts Options) error {
 	asset, err := pickAsset(rel, assetName)
 	if err != nil {
 		return err
-	}
-
-	dest := strings.TrimSpace(opts.InstallPath)
-	if dest == "" {
-		dest, err = resolveExecutablePath()
-		if err != nil {
-			return err
-		}
 	}
 
 	if !opts.Yes {

--- a/packaging/completions/coddy.bash
+++ b/packaging/completions/coddy.bash
@@ -1,0 +1,59 @@
+# bash completion for coddy
+#
+# Keep the command list in sync with printUsage() in cmd/coddy/main.go.
+
+_coddy() {
+    local cur prev commands
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    commands="cli acp http gateway sessions skills plugin mcp codex providers rules agents hooks update"
+
+    if [ "${COMP_CWORD}" -eq 1 ]; then
+        COMPREPLY=($(compgen -W "${commands} -h --help -v --version -c --continue -p --prompt --resume" -- "${cur}"))
+        return
+    fi
+
+    case "${COMP_WORDS[1]}" in
+        sessions)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "list export" -- "${cur}"))
+            [ "${COMP_CWORD}" -gt 2 ] && COMPREPLY=($(compgen -W "--format --out --no-tools --no-thinking" -- "${cur}"))
+            ;;
+        skills)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "list enable disable add sync remove" -- "${cur}"))
+            ;;
+        plugin)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "marketplace install remove enable disable" -- "${cur}"))
+            [ "${COMP_CWORD}" -eq 3 ] && [ "${prev}" = marketplace ] &&
+                COMPREPLY=($(compgen -W "list add remove sync" -- "${cur}"))
+            ;;
+        mcp)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "list trust untrust" -- "${cur}"))
+            [ "${COMP_CWORD}" -gt 2 ] && COMPREPLY=($(compgen -W "--cwd" -- "${cur}"))
+            ;;
+        codex)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "login status logout" -- "${cur}"))
+            [ "${COMP_CWORD}" -gt 2 ] && COMPREPLY=($(compgen -W "--provider --home" -- "${cur}"))
+            ;;
+        providers)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "list login logout" -- "${cur}"))
+            [ "${COMP_CWORD}" -gt 2 ] && COMPREPLY=($(compgen -W "--device --no-config --home" -- "${cur}"))
+            ;;
+        rules)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "list" -- "${cur}"))
+            [ "${COMP_CWORD}" -gt 2 ] && COMPREPLY=($(compgen -W "--cwd" -- "${cur}"))
+            ;;
+        agents|hooks)
+            [ "${COMP_CWORD}" -eq 2 ] && COMPREPLY=($(compgen -W "list trust untrust" -- "${cur}"))
+            [ "${COMP_CWORD}" -gt 2 ] && COMPREPLY=($(compgen -W "--cwd" -- "${cur}"))
+            ;;
+        update)
+            COMPREPLY=($(compgen -W "--check -y --yes --version --repo --no-restart" -- "${cur}"))
+            ;;
+        cli|acp|http|gateway)
+            COMPREPLY=($(compgen -W "--config --home --cwd --log-level --log-output --log-file --log-format --remote --remote-token" -- "${cur}"))
+            ;;
+    esac
+}
+
+complete -F _coddy coddy

--- a/packaging/completions/coddy.zsh
+++ b/packaging/completions/coddy.zsh
@@ -1,0 +1,70 @@
+#compdef coddy
+#
+# zsh completion for coddy
+#
+# Keep the command list in sync with printUsage() in cmd/coddy/main.go.
+
+_coddy() {
+    local -a commands
+    commands=(
+        'cli:interactive console TUI'
+        'acp:Agent Client Protocol server on stdio'
+        'http:OpenAI-compatible HTTP gateway and web UI'
+        'gateway:messenger gateway'
+        'sessions:list or export stored sessions'
+        'skills:manage skills'
+        'plugin:manage plugins and marketplaces'
+        'mcp:list and trust MCP servers'
+        'codex:manage codex provider credentials'
+        'providers:manage provider credentials'
+        'rules:list project rules'
+        'agents:list and trust subagents'
+        'hooks:list and trust lifecycle hooks'
+        'update:install the latest release'
+    )
+
+    _arguments -C \
+        '(-h --help)'{-h,--help}'[print the command list]' \
+        '(-v --version)'{-v,--version}'[print the version]' \
+        '(-c --continue)'{-c,--continue}'[continue the latest session here]' \
+        '(-p --prompt)'{-p,--prompt}'[run one prompt and exit]:prompt:' \
+        '--resume[pick a session to resume]' \
+        '1: :->command' \
+        '*:: :->argument'
+
+    case $state in
+        command)
+            _describe -t commands 'coddy command' commands
+            ;;
+        argument)
+            case $words[1] in
+                sessions) _values 'subcommand' list export ;;
+                skills)   _values 'subcommand' list enable disable add sync remove ;;
+                plugin)   _values 'subcommand' marketplace install remove enable disable ;;
+                mcp|agents|hooks) _values 'subcommand' list trust untrust ;;
+                codex)    _values 'subcommand' login status logout ;;
+                providers) _values 'subcommand' list login logout ;;
+                rules)    _values 'subcommand' list ;;
+                update)
+                    _arguments \
+                        '--check[report whether a newer release exists]' \
+                        '(-y --yes)'{-y,--yes}'[install without confirmation]' \
+                        '--version[install a specific release tag]:tag:' \
+                        '--repo[GitHub repository to take releases from]:repo:' \
+                        '--no-restart[Windows only: do not start Coddy again]'
+                    ;;
+                cli|acp|http|gateway)
+                    _arguments \
+                        '--config[path to config.yaml]:file:_files' \
+                        '--home[agent state directory]:directory:_files -/' \
+                        '--cwd[default session working directory]:directory:_files -/' \
+                        '--log-level[debug|info|warn|error]:level:(debug info warn error)' \
+                        '--remote[drive a remote coddy http server]:remote:' \
+                        '--remote-token[bearer token for --remote]:token:'
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_coddy "$@"

--- a/packaging/homebrew/coddy.rb.tmpl
+++ b/packaging/homebrew/coddy.rb.tmpl
@@ -1,0 +1,41 @@
+# Homebrew cask template for Coddy.
+#
+# Not installable as it stands: scripts/build-homebrew-cask.sh fills the version
+# and the two checksums from the macOS archives of a release and writes the
+# result to dist/coddy.rb. Run `make brew VERSION=X.Y.Z`.
+#
+# The cask takes the same darwin archives `coddy update` takes, so a brew
+# install and a manual one are the same binary. The archives carry the man page
+# and the shell completions beside it, which is what the artifacts below link.
+#
+# The `zap` stanza names ~/.coddy - sessions, skills, credentials and the
+# config. Only `brew zap` removes it; `brew uninstall` leaves it alone.
+#
+# Everything above the `cask` line is stripped when the file is rendered, so the
+# published cask stays comment-free the way homebrew/cask expects.
+
+cask "coddy" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "__VERSION__"
+  sha256 arm:   "__SHA256_ARM64__",
+         intel: "__SHA256_AMD64__"
+
+  url "https://github.com/coddy-project/coddy-agent/releases/download/#{version}/coddy_#{version}_darwin_#{arch}.tar.gz",
+      verified: "github.com/coddy-project/coddy-agent/"
+  name "Coddy Agent"
+  desc "Coding agent with a console, an editor protocol and an HTTP gateway"
+  homepage "https://coddy.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "coddy"
+  manpage "coddy.1"
+  binary "coddy.bash", target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/coddy"
+  binary "coddy.zsh",  target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_coddy"
+
+  zap trash: "~/.coddy"
+end

--- a/packaging/man/coddy.1
+++ b/packaging/man/coddy.1
@@ -1,0 +1,270 @@
+.\" Manual page for coddy.
+.\" Keep the command list in sync with printUsage() in cmd/coddy/main.go.
+.TH CODDY 1 "2026-09-09" "Coddy" "User Commands"
+.SH NAME
+coddy \- coding agent with a console, an editor protocol, an HTTP gateway and a messenger gateway
+.SH SYNOPSIS
+.B coddy
+.RI [ command ]
+.RI [ options ]
+.br
+.B coddy
+.RB [ \-c | \-\-continue ]
+.RB [ \-p
+.IR PROMPT ]
+.br
+.B coddy
+.RB [ \-h | \-\-help ]
+.RB [ \-v | \-\-version ]
+.SH DESCRIPTION
+.B coddy
+is a coding agent built around a ReAct loop: the model reasons, calls tools, and
+observes the results. One agent core is reachable through four surfaces that all
+share the same sessions under
+.BR $CODDY_HOME :
+an interactive console, an Agent Client Protocol (ACP) server for editors, an
+OpenAI\-compatible HTTP gateway with an embedded web UI, and a messenger gateway.
+.PP
+Run with no arguments on a terminal,
+.B coddy
+opens the interactive console. Optional surfaces are Go build tags, so a binary
+may not carry every command below; a missing one says so and names the tag to
+rebuild with. The packages published for Linux carry all of them.
+.SH COMMANDS
+.TP
+.B cli
+Interactive console TUI. Bare
+.B coddy
+on a terminal does the same.
+.TP
+.B acp
+Agent Client Protocol server on stdio, for editors and ACP clients.
+.TP
+.B http
+OpenAI\-compatible HTTP gateway, REST API under
+.IR /coddy ,
+Swagger UI at
+.IR /docs ,
+and the embedded web UI at
+.IR / .
+.TP
+.B gateway
+Messenger gateway (Telegram).
+.TP
+.BI "sessions list"
+List stored sessions.
+.TP
+.BI "sessions export " id
+Write a stored session to a file:
+.BI \-\-format " md|html|json|jsonl" ,
+.BI \-\-out " PATH" ,
+.BR \-\-no\-tools ,
+.BR \-\-no\-thinking .
+.TP
+.B "skills list | enable | disable | add | sync | remove"
+Manage skills: slash commands and
+.I SKILL.md
+packs from
+.IR skills.dirs .
+.B add
+takes an
+.IR owner/repo ,
+a git URL, or a marketplace URL.
+.TP
+.B "plugin marketplace list | add | remove | sync"
+Manage skill marketplaces.
+.TP
+.B "plugin install | remove | enable | disable"
+Manage installed plugins.
+.TP
+.B "mcp list | trust | untrust"
+List merged MCP servers and approve or revoke project\-local
+.I .coddy/mcp.json
+declarations for a workspace.
+.TP
+.B "codex login | status | logout"
+Manage the OAuth credentials of a
+.I codex
+provider.
+.TP
+.B "providers list | login | logout"
+Manage provider credentials, including the browser and device login flows.
+.TP
+.B "rules list"
+Show the project rules discovered under the session working directory.
+.TP
+.B "agents list | trust | untrust"
+List subagent definitions and approve or revoke project\-scope ones.
+.TP
+.B "hooks list | trust | untrust"
+List lifecycle hooks and approve or revoke project\-scope hook files.
+.TP
+.B update
+Install the latest release. See
+.B SELF\-UPDATE
+below.
+.SH OPTIONS
+Every command parses its own flags;
+.BI "coddy " command " \-\-help"
+prints them. The options accepted before any command are:
+.TP
+.BR \-h ", " \-\-help
+Print the command list and exit.
+.TP
+.BR \-v ", " \-\-version
+Print the version and exit.
+.TP
+.BR \-c ", " \-\-continue
+Console: continue the most recent session for this directory.
+.TP
+.BR \-p ", " \-\-prompt " " \fIPROMPT\fR
+Console: run one prompt, print the answer, and exit.
+.TP
+.B \-\-resume
+Console: pick a session to resume.
+.PP
+Flags shared by the long\-running surfaces
+.RB ( cli ", " acp ", " http ", " gateway )
+include
+.BI \-\-config " PATH" ,
+.BI \-\-home " DIR" ,
+.BI \-\-cwd " DIR" ,
+.BI \-\-log\-level " debug|info|warn|error" ,
+and
+.BI \-\-remote " NAME|HOST:PORT|URL"
+with
+.BI \-\-remote\-token " TOKEN"
+to drive a remote
+.B coddy http
+server instead of a local agent.
+.SH SELF\-UPDATE
+.B coddy update
+downloads the release assets published on GitHub, verifies them against the
+release
+.I SHA256SUMS
+list, and replaces the executable it is running.
+.TP
+.B \-\-check
+Report whether a newer release exists and exit
+.B 1
+if one does.
+.TP
+.BR \-y ", " \-\-yes
+Install without the confirmation prompt.
+.TP
+.BI \-\-version " X.Y.Z"
+Install a specific release tag instead of the latest.
+.TP
+.BI \-\-repo " owner/name"
+Take releases from another GitHub repository.
+.TP
+.B \-\-no\-restart
+Windows only: install the update but do not start Coddy again.
+.PP
+When the executable belongs to a
+.BR deb (5)
+or rpm package,
+.B coddy update
+does not overwrite it: that would leave the package database describing a build
+that is gone. Run as an ordinary user it names the package manager command that
+upgrades it; run as
+.B root
+it downloads the release package for this architecture and installs it through
+.BR apt\-get (8),
+.BR dnf (8),
+.BR zypper (8),
+.BR dpkg (1)
+or
+.BR rpm (8),
+whichever the system provides.
+.PP
+A Coddy installed by Homebrew is treated the same way: nothing is replaced, and
+.B "brew upgrade \-\-cask coddy"
+is named instead. Homebrew refuses to run under
+.BR sudo ,
+so there is no privileged path there.
+.SH ENVIRONMENT
+.TP
+.B CODDY_HOME
+Agent state directory: configuration, sessions, skills, logs. Default
+.IR ~/.coddy .
+.TP
+.B CODDY_CWD
+Default session working directory when a client sends none. Default: the process
+working directory.
+.TP
+.B CODDY_CONFIG
+Configuration file to load. Default
+.IR $CODDY_HOME/config.yaml .
+.TP
+.B CODDY_HTTP_TOKEN
+Bearer token required by
+.BR "coddy http" .
+.TP
+.B CODDY_REMOTE_TOKEN
+Bearer token used by
+.BI \-\-remote .
+.PP
+Provider keys are read from the environment as well
+.RB ( OPENAI_API_KEY
+and the equivalents of the other providers), and from
+.IR $CODDY_HOME/.env .
+.SH FILES
+.TP
+.I ~/.coddy/config.yaml
+Main configuration. A commented starting point is installed as
+.IR /usr/share/doc/coddy/config.example.yaml .
+.TP
+.I ~/.coddy/sessions/
+Persisted sessions, one directory per session.
+.TP
+.I ~/.coddy/skills/
+Installed skills.
+.TP
+.I .coddy/rules/, .cursor/rules/, .claude/rules/, .codex/rules/, AGENTS.md
+Project rules, discovered under the session working directory.
+.TP
+.I .coddy/mcp.json, .coddy/agents/, .coddy/hooks.json
+Project\-local MCP servers, subagents and hooks. Each needs a one\-time approval
+before Coddy reads or runs it.
+.SH EXAMPLES
+Start the console in the current repository:
+.PP
+.RS 4
+.B coddy
+.RE
+.PP
+Ask one question and exit:
+.PP
+.RS 4
+.B coddy \-p "what does internal/agent do?"
+.RE
+.PP
+Serve the web UI and REST API on the default port:
+.PP
+.RS 4
+.B coddy http
+.RE
+.PP
+Wire an editor to Coddy over ACP:
+.PP
+.RS 4
+.B coddy acp
+.RE
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+A command failed, or
+.B coddy update \-\-check
+found a newer release.
+.SH SEE ALSO
+Project documentation:
+.UR https://coddy.dev
+.UE ,
+.UR https://github.com/coddy-project/coddy-agent
+.UE .
+.SH AUTHOR
+Pavel Rykov and the Coddy contributors.

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,90 @@
+# nfpm recipe for the Linux packages published on every release tag.
+#
+# The package installs a binary and its documentation, nothing else: no service,
+# no system account, no files under /etc. Coddy keeps every piece of state in the
+# invoking user's ~/.coddy, so one installed package serves every user on the
+# machine and what to run is the user's decision, not the packager's.
+#
+# Not built by hand: scripts/build-packages.sh stages every file listed below
+# into one directory, exports PKG_ARCH and PKG_VERSION, and runs nfpm from that
+# directory - nfpm expands environment variables in scalar fields but treats
+# "contents.src" as a literal glob, so the sources here are relative names.
+# Run `make packages`.
+#
+# https://nfpm.goreleaser.com/configuration/
+
+name: coddy
+arch: ${PKG_ARCH}
+platform: linux
+version: ${PKG_VERSION}
+# The version comes from a git tag or from `git describe`, already normalised
+# for deb and rpm by the build script. nfpm must not reinterpret it.
+version_schema: none
+release: "1"
+section: devel
+priority: optional
+maintainer: Pavel Rykov <paul@drteam.rocks>
+vendor: Coddy project
+homepage: https://coddy.dev
+license: MIT
+description: |
+  Coding agent with a console, an editor protocol and an HTTP gateway.
+  Coddy runs a ReAct loop - the model reasons, calls tools, observes results -
+  behind four surfaces that share one session store: an interactive console,
+  an Agent Client Protocol server for editors, an OpenAI-compatible HTTP
+  gateway with an embedded web UI, and a messenger gateway. It speaks to
+  OpenAI, Anthropic, Ollama and any OpenAI-compatible API, merges MCP servers,
+  and reads project rules, skills, subagents and hooks from the repository it
+  is working in.
+
+contents:
+  - src: coddy
+    dst: /usr/bin/coddy
+    file_info:
+      mode: 0755
+
+  - src: coddy.1.gz
+    dst: /usr/share/man/man1/coddy.1.gz
+    file_info:
+      mode: 0644
+
+  - src: coddy.bash
+    dst: /usr/share/bash-completion/completions/coddy
+    file_info:
+      mode: 0644
+
+  - src: coddy.zsh
+    dst: /usr/share/zsh/site-functions/_coddy
+    file_info:
+      mode: 0644
+
+  # Plain files, not nfpm's "doc" type: that type is rpm-only, and a deb built
+  # from it silently ships without /usr/share/doc - which is where the
+  # post-install message sends the user for a starting config.
+  - src: config.example.yaml
+    dst: /usr/share/doc/coddy/config.example.yaml
+    file_info:
+      mode: 0644
+
+  - src: LICENSE
+    dst: /usr/share/doc/coddy/LICENSE
+    file_info:
+      mode: 0644
+
+  # Debian policy expects the licence at this exact path.
+  - src: LICENSE
+    dst: /usr/share/doc/coddy/copyright
+    file_info:
+      mode: 0644
+
+scripts:
+  postinstall: postinstall.sh
+
+deb:
+  # dpkg-query -S on /usr/bin/coddy is what `coddy update` asks to learn that
+  # this file is package-managed; nothing here may move the binary elsewhere.
+  fields:
+    Bugs: https://github.com/coddy-project/coddy-agent/issues
+
+rpm:
+  summary: Coding agent with a console, an editor protocol and an HTTP gateway

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Runs as root after the package is unpacked, on install and on upgrade.
+# Coddy keeps every piece of state under the invoking user's $CODDY_HOME, so
+# there is nothing to create system-wide here: the message points the user at
+# the one file they do have to write themselves.
+set -e
+
+# Debian passes "configure", rpm passes the number of installed copies. Only the
+# first install needs the hint; an upgrade already has a config.
+case "${1:-}" in
+    1|configure)
+        if [ -n "${SUDO_USER:-}" ] && [ -f "$(getent passwd "${SUDO_USER}" | cut -d: -f6)/.coddy/config.yaml" ]; then
+            exit 0
+        fi
+        cat <<'EOF'
+
+Coddy is installed. Create your configuration:
+
+    mkdir -p ~/.coddy
+    cp /usr/share/doc/coddy/config.example.yaml ~/.coddy/config.yaml
+
+Then set a provider key in it and start a surface:
+
+    coddy               # interactive console
+    coddy http          # web UI and REST API
+
+Manual: man coddy   Docs: https://coddy.dev
+
+EOF
+        ;;
+esac
+
+exit 0

--- a/scripts/build-homebrew-cask.sh
+++ b/scripts/build-homebrew-cask.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Render the Homebrew cask for one release.
+#
+# A cask pins the checksum of every archive it installs, so this needs the
+# actual macOS archives of the version being packaged. It uses the ones in the
+# output directory when they are there - which is the case inside the release
+# job, right after the cross-compile - and downloads them from the GitHub
+# release otherwise.
+#
+# Usage:
+#   scripts/build-homebrew-cask.sh [options]
+#
+#   --version VER   release to render (default: `make -s print-version`)
+#   --out DIR       where coddy.rb lands, and where archives are looked for
+#                   (default: dist)
+#   --repo OWNER/N  GitHub repository to download archives from
+#                   (default: coddy-project/coddy-agent)
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root"
+
+out="dist"
+version=""
+repo="coddy-project/coddy-agent"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) version="$2"; shift 2 ;;
+        --out) out="$2"; shift 2 ;;
+        --repo) repo="$2"; shift 2 ;;
+        -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$version" ]; then
+    version=$(make -s print-version)
+fi
+
+mkdir -p "$out"
+out=$(cd "$out" && pwd)
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# checksum_for prints the sha256 of one macOS archive, taking it from the output
+# directory when it is already there.
+checksum_for() {
+    local arch="$1"
+    local name="coddy_${version}_darwin_${arch}.tar.gz"
+    local file="${out}/${name}"
+
+    if [ ! -f "$file" ]; then
+        file="${work}/${name}"
+        echo "downloading ${name}" >&2
+        if ! curl -fsSL -o "$file" "https://github.com/${repo}/releases/download/${version}/${name}"; then
+            echo "no ${name} in ${out} and none published at ${version}" >&2
+            echo "build the release archives first, or pass --version of a published release" >&2
+            exit 1
+        fi
+    fi
+    sha256sum "$file" | cut -d' ' -f1
+}
+
+sha_arm64=$(checksum_for arm64)
+sha_amd64=$(checksum_for amd64)
+
+# The template header explains how the file is rendered; the published cask
+# starts at the `cask` line and carries none of it.
+sed \
+    -e "s|__VERSION__|${version}|g" \
+    -e "s|__SHA256_ARM64__|${sha_arm64}|g" \
+    -e "s|__SHA256_AMD64__|${sha_amd64}|g" \
+    packaging/homebrew/coddy.rb.tmpl |
+    sed -n '/^cask /,$p' > "${out}/coddy.rb"
+
+echo "wrote ${out}/coddy.rb for ${version}"
+echo "install it locally with: brew install --cask ${out}/coddy.rb"

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Build the Linux packages published on a release tag (deb and rpm).
+#
+# The binary is built here unless --binary hands one over, which is what CI
+# does: the release workflow has already cross-compiled every target, and
+# rebuilding them would double the slowest step of the release for nothing.
+#
+# Usage:
+#   scripts/build-packages.sh [options]
+#
+#   --arch LIST       comma or space separated GOARCH list (default: amd64)
+#   --version VER     raw version to package (default: `make -s print-version`)
+#   --formats LIST    package formats (default: deb,rpm)
+#   --out DIR         where the packages land (default: dist)
+#   --binary PATH     use this coddy binary instead of building one
+#                     (only valid with a single --arch)
+#
+# Environment:
+#   TAGS          go build tags for the binary built here
+#                 (default: "http ui scheduler memory cli", the release set)
+#   NFPM          nfpm command to use (default: nfpm on PATH, else `go run`)
+#   NFPM_VERSION  pinned nfpm module version for the `go run` fallback
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root"
+
+archs="amd64"
+formats="deb,rpm"
+out="dist"
+version=""
+binary=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --arch|--archs) archs="$2"; shift 2 ;;
+        --version) version="$2"; shift 2 ;;
+        --formats) formats="$2"; shift 2 ;;
+        --out) out="$2"; shift 2 ;;
+        --binary) binary="$2"; shift 2 ;;
+        -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+archs=$(echo "$archs" | tr ',' ' ')
+formats=$(echo "$formats" | tr ',' ' ')
+
+TAGS="${TAGS:-http ui scheduler memory cli}"
+NFPM_VERSION="${NFPM_VERSION:-v2.45.0}"
+
+if [ -z "$version" ]; then
+    version=$(make -s print-version)
+fi
+pkg_version=$("$root/scripts/package-version.sh" "$version")
+
+if [ -n "$binary" ] && [ "$(echo "$archs" | wc -w)" -ne 1 ]; then
+    echo "--binary takes a single --arch, got: $archs" >&2
+    exit 2
+fi
+
+# nfpm is a single static binary and is not a module dependency of this repo:
+# take it from PATH when it is there, otherwise run the pinned version.
+if [ -n "${NFPM:-}" ]; then
+    nfpm=$NFPM
+elif command -v nfpm >/dev/null 2>&1; then
+    nfpm=nfpm
+else
+    nfpm="go run github.com/goreleaser/nfpm/v2/cmd/nfpm@${NFPM_VERSION}"
+fi
+
+mkdir -p "$out"
+out=$(cd "$out" && pwd)
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+# Everything except the binary is architecture-independent, so stage it once.
+gzip -9 -n -c packaging/man/coddy.1 > "$stage/coddy.1.gz"
+cp packaging/completions/coddy.bash "$stage/coddy.bash"
+cp packaging/completions/coddy.zsh "$stage/coddy.zsh"
+cp packaging/scripts/postinstall.sh "$stage/postinstall.sh"
+cp config.example.yaml "$stage/config.example.yaml"
+cp LICENSE "$stage/LICENSE"
+
+for arch in $archs; do
+    if [ -n "$binary" ]; then
+        cp "$binary" "$stage/coddy"
+    else
+        echo "building coddy for linux/${arch} with tags \"${TAGS}\""
+        GOOS=linux GOARCH="$arch" CGO_ENABLED=0 go build \
+            -tags "$TAGS" \
+            -trimpath \
+            -ldflags "-s -w -X github.com/EvilFreelancer/coddy-agent/internal/version.Version=${version}" \
+            -o "$stage/coddy" \
+            ./cmd/coddy/
+    fi
+    chmod 0755 "$stage/coddy"
+
+    for format in $formats; do
+        target="${out}/coddy_${version}_linux_${arch}.${format}"
+        echo "packaging ${target}"
+        # nfpm globs contents relative to its working directory, so it runs
+        # where the staged files are and takes the recipe by absolute path.
+        (
+            cd "$stage"
+            PKG_ARCH="$arch" PKG_VERSION="$pkg_version" \
+                $nfpm package \
+                    --config "${root}/packaging/nfpm.yaml" \
+                    --packager "$format" \
+                    --target "$target"
+        )
+    done
+done
+
+ls -la "$out"

--- a/scripts/package-version.sh
+++ b/scripts/package-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Turn the repository version string into one deb and rpm both accept.
+#
+# `make print-version` yields a plain tag on a release (1.0.8) but a git
+# describe elsewhere (1.0.8-5-gb6b7d31-dirty). rpm forbids "-" in a version
+# entirely, and dpkg reads the last "-" as the start of the Debian revision, so
+# the describe form has to be folded into the upstream part. "+" is legal in
+# both and sorts after the bare tag, which is what a build made after that tag
+# should do.
+#
+#   1.0.8                  -> 1.0.8
+#   v1.0.8                 -> 1.0.8
+#   1.0.8-5-gb6b7d31-dirty -> 1.0.8+5.gb6b7d31.dirty
+#   dev                    -> 0.0.0+dev
+#
+# Usage: scripts/package-version.sh <version>
+set -euo pipefail
+
+raw="${1:-}"
+if [ -z "$raw" ]; then
+    echo "usage: $0 <version>" >&2
+    exit 2
+fi
+
+raw="${raw#v}"
+
+# Split the leading X.Y.Z from whatever git appended to it.
+if [[ "$raw" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(.*)$ ]]; then
+    core="${BASH_REMATCH[1]}"
+    rest="${BASH_REMATCH[2]}"
+else
+    core="0.0.0"
+    rest="-${raw}"
+fi
+
+if [ -z "$rest" ]; then
+    echo "$core"
+    exit 0
+fi
+
+# Everything after the release version becomes one build suffix: strip the
+# separator git used, then reduce the rest to dot-joined alphanumerics.
+rest="${rest#-}"
+rest=$(echo "$rest" | tr -c '[:alnum:]' '.' | sed 's/\.\{1,\}/./g; s/^\.//; s/\.$//')
+
+if [ -z "$rest" ]; then
+    echo "$core"
+else
+    echo "${core}+${rest}"
+fi


### PR DESCRIPTION
## Why

Coddy could only be installed by unpacking an archive onto `PATH`, so on a machine that has a package manager it was the one thing nothing tracked - no `man coddy`, no completions, no clean uninstall, and an update that rewrites a file behind the system's back.

## What ships

Every release tag now publishes, beside the archives:

| Asset | Platform |
|---|---|
| `coddy_X.Y.Z_linux_amd64.deb`, `coddy_X.Y.Z_linux_arm64.deb` | Debian, Ubuntu and derivatives |
| `coddy_X.Y.Z_linux_amd64.rpm`, `coddy_X.Y.Z_linux_arm64.rpm` | Fedora, RHEL, openSUSE and derivatives |
| `coddy.rb` | Homebrew cask for the two macOS archives of the tag |

A package installs **a binary and its documentation and nothing else**: `/usr/bin/coddy`, `/usr/share/man/man1/coddy.1.gz`, bash and zsh completions, the licence and `config.example.yaml`. No service, no system account, no files under `/etc` - Coddy keeps its state in the invoking user's `~/.coddy`, so one installed package serves every user on the machine and what to run stays their decision.

The release `.tar.gz` archives now carry the man page and the completions beside the binary, which is what the cask links. `coddy update` and `install.sh` take the executable out by name and ignore the rest.

## `coddy update` on a packaged install

Replacing a file dpkg or rpm owns would leave the package database describing a build that is gone, and the next `apt upgrade` would silently undo the update. So the updater asks who owns the executable it is about to write - `dpkg-query -S`, `rpm -qf`, or a `Caskroom`/`Cellar` path for Homebrew - and takes a different route when someone answers:

- **ordinary user**: nothing is touched; the error names the package and the command that upgrades it, and exits 1 so a script notices;
- **root**: downloads the `.deb` or `.rpm` for this architecture, verifies it against `SHA256SUMS` like any other asset, and hands it to `apt-get`, `apt`, `dnf`, `yum`, `zypper`, `dpkg` or `rpm`, whichever the system has;
- **Homebrew**: always ends at `brew upgrade --cask coddy` - brew refuses to run under `sudo`, so there is no privileged route.

Ownership is asked of the package database rather than guessed from the path, so a binary copied out of `/usr/bin` keeps updating itself, a distribution's own rebuild is recognised like ours, and `~/.local/bin` is untouched.

```
$ coddy update -y
coddy is installed by a system package manager

coddy 0.9.0 at /usr/bin/coddy belongs to the "coddy" package, and 1.0.10 is available.
Replacing that file would leave the package database describing a build that is gone,
so nothing was changed.

Upgrade it with your package manager:

    sudo apt-get install --only-upgrade coddy

Or let Coddy fetch and install the release package for you:

    sudo coddy update
```

## Building

```bash
make deb
make rpm
make brew VERSION=1.0.11
```

`packaging/` holds the nfpm recipe, the man page, the completions, the Homebrew cask template and the post-install script; `scripts/build-packages.sh` and `scripts/build-homebrew-cask.sh` drive them. nfpm is fetched on demand (`go run` at a pinned version) rather than added to `go.mod`. `scripts/package-version.sh` folds a `git describe` string into a version both formats accept (`1.0.8-5-gb6b7d31-dirty` -> `1.0.8+5.gb6b7d31.dirty`).

## CI

- **Tests on PR** gains a `Linux packages` job that builds the deb and the rpm with lean tags, so a broken recipe is caught here rather than by whoever cuts the release.
- **Release binaries** wraps the Linux binaries it already cross-compiled (the `.deb`, the `.rpm` and the `.tar.gz` of one tag hold byte-identical executables), renders the cask from the macOS archives it just built, and lists the packages in `SHA256SUMS` so `coddy update` can verify them.

## Verified

- `features/update_packages.feature` (4 scenarios) covers the non-root guidance, the root install on deb and rpm, and the Homebrew route; unit tests in `internal/update/packages_test.go` cover front-end selection, install commands, rpm's zero-exit miss text, and a release with no package asset.
- `make test`, `make lint`, `make check-windows`, `make lint-windows` - all green.
- Installed the built `.deb` in `debian:13-slim` and the `.rpm` in `fedora:42`: files land where the table says, `man coddy` renders, `dpkg-query -S`/`rpm -qf` claim the binary, and `coddy update` prints the apt-get and dnf guidance as a normal user and reaches the package route as root.
- Rendered cask checked with `ruby -c`.

## Issues

- Addresses #152. The cask itself and its publishing are here; `brew install --cask coddy` starts resolving by name once it is accepted into `homebrew/cask`, and until then `brew install --cask <release asset>` works.
- Groundwork for #153 and #154: the release archives now carry `coddy.1`, `coddy.bash` and `coddy.zsh`, which is what coddy.dev's `install.sh` needs before it can install a completion or a man page at all. The installer side is a separate PR in the site repo.

## Follow-up

The cask has to be accepted into `homebrew/cask` before `brew install --cask coddy` resolves by name; until then each release publishes `coddy.rb` and `brew install --cask <url>` works. Its `livecheck` block tracks GitHub releases, so Homebrew's automation opens the version bumps afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
