### PR TITLE
test: pin the grandchild's creation before the child retires it

### DIFF
--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -1434,6 +1434,21 @@ func TestSpawnSubagentChildBackgroundCommandNeverNotifies(t *testing.T) {
 	}
 }
 
+// gateStep holds the model until gate is closed, then runs next, so a scripted
+// turn can be pinned behind work it started. Unlike waitStep it gives up after
+// testWait, so a gate that never opens fails the test instead of parking the
+// package until its own timeout.
+func gateStep(t *testing.T, gate <-chan struct{}, next scriptStep) scriptStep {
+	return func(messages []llm.Message, defs []llm.ToolDefinition, onChunk func(llm.StreamChunk)) *llm.Response {
+		select {
+		case <-gate:
+		case <-time.After(testWait):
+			t.Errorf("a gated step waited %s and its gate never opened", testWait)
+		}
+		return next(messages, defs, onChunk)
+	}
+}
+
 // A detached grandchild spawned by a child with notify_on_finish: true is
 // launched with the flag off, and is stopped when the child retires.
 func TestSpawnSubagentChildSpawnNeverNotifies(t *testing.T) {
@@ -1449,7 +1464,19 @@ func TestSpawnSubagentChildSpawnNeverNotifies(t *testing.T) {
 				"agent": "reviewer", "prompt": "nested", "description": "nested",
 				"background": true, "notify_on_finish": true, "expected_seconds": 5,
 			})
-			return scripted(toolStep(llm.ToolCall{ID: "call_nested", Name: tools.ToolSpawnAgent, InputJSON: string(args)}), answerStep("REPORT: middle"))
+			// The middle child holds its report until the grandchild's turn
+			// is under way. A child's bundle is written by the last step of
+			// its creation, and a retirement that lands while it is still
+			// being created cancels that creation and rolls the half-written
+			// bundle back, on purpose - see
+			// TestSpawnSubagentStopAndTimeoutReachAChildStillBeingCreated.
+			// The leaf provider is entered only once the grandchild is past
+			// that point, so gating on it is what makes the bundle asserted
+			// below exist at all.
+			return scripted(
+				toolStep(llm.ToolCall{ID: "call_nested", Name: tools.ToolSpawnAgent, InputJSON: string(args)}),
+				gateStep(t, leafProv.started, answerStep("REPORT: middle")),
+			)
 		}
 		return leafProv
 	})


### PR DESCRIPTION
`TestSpawnSubagentChildSpawnNeverNotifies` (`internal/agent/subagent_test.go`) is a load-sensitive flake on `main`. It fails at the second `rig.assertRetired`, for the grandchild, with `child bundle sub_xxxx: session not found on disk`.

## Cause

The bundle is not written late, it is absent, and it never arrives. In a failing run the grandchild's session id has no `subagent session created` log line at all.

The middle child's `finish()` calls `pool.StopSession`, which cancels the grandchild's run context. A cancellation that lands while `CreateSubagentSession` is still running fails the creation at one of its `ctx.Err()` checks, and the deferred rollback removes the half-written session directory. The bundle is only written by the synchronous `store.Save` at the very end of that function.

That rollback is deliberate, and `TestSpawnSubagentStopAndTimeoutReachAChildStillBeingCreated` already pins it down by asserting a child stopped during creation leaves no bundles. So the two obvious fixes are both wrong. Polling for the bundle in `assertRetired` would only fail slower, and making the bundle durable before the pool marks the task finished would contradict that existing test.

The retirement path itself is fine. The `not live` half of `assertRetired` is already ordered, since `Stop` blocks on `<-t.done`, which closes only after `supervise` reaped a handle whose `Wait` returns after the child's `finish()`.

## Fix

The test assumed the grandchild always won the race to `Save`. It now makes the ordering explicit: the middle child holds its `REPORT: middle` answer behind the leaf provider's `started` channel, via a new `gateStep`. The leaf provider is entered only once `CreateSubagentSession` returned, so the middle retires a grandchild that is running rather than one still being built, which is the case the test meant to describe.

`gateStep` gives up after `testWait`, unlike the neighbouring `waitStep`, so a gate that never opens fails the test instead of parking the package until its own timeout.

## Verification

Same load, same binary shape, only the test changed:

| | processes failing |
|---|---|
| before | 6 of 10 |
| after | 0 of 10 |

- `go test ./internal/agent -count=1` — ok, 26.8s
- 10 parallel processes × `-count=10` of `TestSpawnSubagent`, 100 runs, all PASS; the pre-fix binary under the identical loop failed 6 of 10 processes, every one at the same line
- `go test ./internal/agent -run TestSpawnSubagent -race -count=3` — ok
- `make lint` — 0 issues across all four tag combinations

Reproduction loop:

```
for i in $(seq 1 10); do (go test ./internal/agent -run 'TestSpawnSubagent' -count=10 > /tmp/flake-$i.log 2>&1) & done; wait
grep -h "FAIL" /tmp/flake-*.log
```