### PR TITLE
ci: install ripgrep from a pinned release instead of apt

### DIFF
--- a/.github/workflows/tests-on-pr.yaml
+++ b/.github/workflows/tests-on-pr.yaml
@@ -33,8 +33,32 @@ jobs:
           cache: npm
           cache-dependency-path: external/ui/package-lock.json
 
+      # The grep and glob filesystem tools prefer system ripgrep and fall back
+      # to a built-in Go engine, so without rg on the runner the suite only ever
+      # exercises the fallback half. The runner image does not ship it, and
+      # installing it with apt costs an `apt-get update`, which refreshes every
+      # source the image carries - including third-party ones this project never
+      # uses. On 2026-09-09 Google's chrome-stable index started serving a
+      # Packages.gz whose hash did not match its Release file, apt exited 100,
+      # and every pull request died in twenty seconds before `make test` ran.
+      # A pinned release tarball needs only github.com, which the checkout
+      # already depends on, and hands every run the same rg build.
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        env:
+          RIPGREP_VERSION: "15.2.0"
+          RIPGREP_SHA256: "33e15bcf1624b25cdd2a55813a47a2f95dbe126268203e76aa6a585d1e7b149c"
+        run: |
+          set -euo pipefail
+          probe="$(command -v rg || true)"
+          echo "system rg before install: ${probe:-none}"
+          dir="ripgrep-${RIPGREP_VERSION}-x86_64-unknown-linux-musl"
+          cd "${RUNNER_TEMP}"
+          curl -fsSL --retry 3 --retry-all-errors -o "${dir}.tar.gz" \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/${dir}.tar.gz"
+          echo "${RIPGREP_SHA256}  ${dir}.tar.gz" | sha256sum --check --strict -
+          tar -xzf "${dir}.tar.gz" "${dir}/rg"
+          sudo install -m 0755 "${dir}/rg" /usr/local/bin/rg
+          rg --version
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
## Problem

`.github/workflows/tests-on-pr.yaml` installed ripgrep with

```
sudo apt-get update && sudo apt-get install -y ripgrep
```

`apt-get update` refreshes **every** source configured on the runner image, including `https://dl.google.com/linux/chrome-stable/deb`, which this project does not use. On 2026-09-09 that index started serving a `Packages.gz` whose hash did not match its `Release` file:

```
E: Failed to fetch .../chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

apt exits 100, the `&&` short-circuits, and the job dies in ~21 s before `make test` runs. Seen on [run 34384823125](https://github.com/coddy-project/coddy-agent/actions/runs/34384823125) (PR #163) and reproduced on a re-run, so it is the upstream index, not a blip. Every PR was hostage to it.

## What was checked first

Whether the step could simply go away, per the runner image manifest rather than a guess:

- `images/ubuntu/toolsets/toolset-2404.json` lists the image's apt packages under `vital_packages`, `common_packages` and `cmd_packages` - ripgrep is in none of them;
- `images/ubuntu/Ubuntu2404-Readme.md` (image `20260831.293.1`) does not mention it either.

So `rg` is **not** on `ubuntu-latest`, and the step is doing real work. It is worth keeping: `grep` and `glob` in `internal/tools/fs` prefer system ripgrep and only fall back to the built-in Go engine, so a runner without `rg` exercises just the fallback half of both tools - and `glob` calls `exec.LookPath("rg")` directly, so no unit test can reach its ripgrep branch with a fake.

## Fix

Install a pinned ripgrep release tarball, verified against its published sha256, and drop apt entirely:

- no third-party apt index can break the job again, and no Ubuntu archive hiccup either;
- the only host involved is `github.com`, which `actions/checkout` already depends on;
- every run gets the same `rg` build (15.2.0) instead of whatever the archive currently carries (24.04 ships 14.1.0);
- `curl --retry 3 --retry-all-errors` covers a transient download.

The step logs `command -v rg` before installing, so the "not on the image" finding above is visible in the run log rather than taken on trust.

## Scope

`.github/workflows/tests-on-pr.yaml` line 37 was the **only** apt call anywhere under `.github/workflows/`; `docker-build-push.yaml`, `release-binaries.yaml` and `tag-on-merge.yaml` install nothing, there is no `.github/actions/`, and the `Dockerfile` has no apt either. Nothing else needed the same treatment.

## Verification

- the install step was dry-run locally end to end (download, sha256 check, extract, install, `rg --version` -> 15.2.0);
- the full `make test` matrix was run with `rg` masked out, confirming the suite does not *break* without ripgrep - it only loses coverage, which is why the step stays;
- the real CI run on this PR is the confirmation that matters, and it is attached below.