### PR TITLE
fix(swarm): keep a proxied stream alive when the request body is closed

### DIFF
--- a/external/swarm/bdd_mount_test.go
+++ b/external/swarm/bdd_mount_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -47,7 +48,13 @@ type mountFeatureState struct {
 	status int
 	body   []byte
 	chunks []string
-	gaps   []time.Duration
+	// delivered carries the client's word that the chunk the node just wrote
+	// has arrived. The node waits on it before producing the next one, which
+	// is what turns "the relay streams" into something the scenario can prove
+	// rather than time.
+	delivered chan struct{}
+	streamErr error
+	stalled   bool
 }
 
 func (s *mountFeatureState) reset() {
@@ -61,8 +68,34 @@ func (s *mountFeatureState) reset() {
 	}
 	s.mu.Lock()
 	s.seen = nil
+	s.stalled = false
 	s.mu.Unlock()
-	s.status, s.body, s.chunks, s.gaps = 0, nil, nil, nil
+	s.status, s.body, s.chunks, s.streamErr = 0, nil, nil, nil
+}
+
+// awaitDelivery blocks the node until the client reports the chunk it just
+// wrote, and reports whether that happened.
+func (s *mountFeatureState) awaitDelivery(ctx context.Context, delivered <-chan struct{}) bool {
+	select {
+	case <-delivered:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-time.After(streamAck):
+		s.mu.Lock()
+		s.stalled = true
+		s.mu.Unlock()
+		return false
+	}
+}
+
+// noteDelivery is the other half. The channel holds the whole stream, so the
+// client never blocks here even once the node has stopped listening.
+func (s *mountFeatureState) noteDelivery() {
+	select {
+	case s.delivered <- struct{}{}:
+	default:
+	}
 }
 
 func (s *mountFeatureState) record(r *http.Request) {
@@ -108,8 +141,19 @@ func (s *mountFeatureState) anAgentNode(name string) error {
 		s.record(r)
 		writeJSON(w, http.StatusOK, map[string]interface{}{"origin": "node:" + name, "sessions": []interface{}{}})
 	})
+	// delivered belongs to this node: the handler closes over it, so a request
+	// left over from an earlier scenario cannot reach the next one's gate.
+	delivered := make(chan struct{}, 8)
+	s.delivered = delivered
 	mux.HandleFunc("/v1/responses", func(w http.ResponseWriter, r *http.Request) {
 		s.record(r)
+		// Read the request out before answering, the way a node that parses a
+		// JSON body does. A node that answers first leaves the relay's
+		// transport still writing that body while this server drains and
+		// closes it - the server does that the moment a response header goes
+		// out - and the transport answers the failed write by tearing down the
+		// connection, which cuts the very stream this scenario is about.
+		_, _ = io.Copy(io.Discard, r.Body)
 		w.Header().Set("Content-Type", "text/event-stream")
 		fl, ok := w.(http.Flusher)
 		if !ok {
@@ -119,7 +163,9 @@ func (s *mountFeatureState) anAgentNode(name string) error {
 		for i := 0; i < 3; i++ {
 			_, _ = fmt.Fprintf(w, "data: chunk-%d\n\n", i)
 			fl.Flush()
-			time.Sleep(80 * time.Millisecond)
+			if !s.awaitDelivery(r.Context(), delivered) {
+				return
+			}
 		}
 		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
 		fl.Flush()
@@ -169,7 +215,11 @@ func (s *mountFeatureState) callWithoutCredential(path, node string) error {
 }
 
 func (s *mountFeatureState) streamFromNode(path, node string) error {
-	req, err := http.NewRequest(http.MethodPost, s.relay.URL+swarmdto.MountPath+node+path, strings.NewReader(`{"stream":true}`))
+	// The deadline is what a wedged stream runs into instead of the package's
+	// own ten-minute timeout, which would say nothing about which step hung.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*streamAck)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.relay.URL+swarmdto.MountPath+node+path, strings.NewReader(`{"stream":true}`))
 	if err != nil {
 		return err
 	}
@@ -183,19 +233,19 @@ func (s *mountFeatureState) streamFromNode(path, node string) error {
 	s.status = res.StatusCode
 
 	sc := bufio.NewScanner(res.Body)
-	last := time.Now()
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 		if line == "" {
 			continue
 		}
 		s.chunks = append(s.chunks, line)
-		s.gaps = append(s.gaps, time.Since(last))
-		last = time.Now()
-		if strings.Contains(line, "[DONE]") {
-			break
-		}
+		s.noteDelivery()
 	}
+	// Reading to the end rather than stopping at [DONE] leaves the relay's
+	// copy finished before the next step tears the servers down. Closing the
+	// body early would cancel that copy in flight, and the scenario would be
+	// asserting on a stream it had just cut itself.
+	s.streamErr = sc.Err()
 	return nil
 }
 
@@ -234,19 +284,22 @@ func (s *mountFeatureState) nodeSawAuthorization(want string) error {
 }
 
 func (s *mountFeatureState) receivedStreamedChunks() error {
-	if len(s.chunks) != 4 {
-		return fmt.Errorf("received %d chunks, want 4: %v", len(s.chunks), s.chunks)
+	s.mu.Lock()
+	stalled := s.stalled
+	s.mu.Unlock()
+	// The node writes a chunk and then waits to hear that it arrived, so a
+	// relay that buffered the response leaves it waiting: the whole answer
+	// would only be handed over once the handler had returned, and the handler
+	// cannot return until the client has seen the chunk before it.
+	if stalled {
+		return fmt.Errorf("the node waited %s for a chunk to reach the client, so the relay buffered the response: %v", streamAck, s.chunks)
 	}
-	// If the relay buffered the response, every chunk would land at once at the
-	// end. Seeing the gaps proves each was forwarded as the node produced it.
-	var spread int
-	for _, gap := range s.gaps[1:] {
-		if gap > 40*time.Millisecond {
-			spread++
-		}
+	if s.streamErr != nil {
+		return fmt.Errorf("the stream ended early: %v (chunks %v)", s.streamErr, s.chunks)
 	}
-	if spread < 2 {
-		return fmt.Errorf("chunks arrived together, so the relay buffered them: %v", s.gaps)
+	want := []string{"data: chunk-0", "data: chunk-1", "data: chunk-2", "data: [DONE]"}
+	if !slices.Equal(s.chunks, want) {
+		return fmt.Errorf("received %v, want %v", s.chunks, want)
 	}
 	return nil
 }

--- a/external/swarm/mount.go
+++ b/external/swarm/mount.go
@@ -4,6 +4,7 @@ package swarm
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -120,6 +121,20 @@ func (s *Server) handleMount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The transport carrying this request reads the body from a goroutine of
+	// its own, and net/http closes an inbound body the moment the handler
+	// writes response headers - which, for a proxied stream, is while the node
+	// is still answering. Having copied the declared length, the transport
+	// reads once more to see whether the body was longer than it claimed; if
+	// that read lands after the close it fails, the transport drops the
+	// connection to the node, and an answer that had already started arrives
+	// truncated. Nothing can follow the length the client declared, so the
+	// forwarded body answers that read here rather than reaching for a body
+	// that is no longer there.
+	if r.Body != nil && r.ContentLength > 0 {
+		r.Body = &declaredBody{rc: r.Body, left: r.ContentLength}
+	}
+
 	proxy := &httputil.ReverseProxy{
 		Rewrite:   s.rewriteFor(node, target, rest),
 		Transport: node.Transport.RoundTripper(),
@@ -137,6 +152,30 @@ func (s *Server) handleMount(w http.ResponseWriter, r *http.Request) {
 	}
 	proxy.ServeHTTP(w, r)
 }
+
+// declaredBody is a request body bounded by the length its sender declared.
+//
+// It is deliberately not a plain io.LimitReader: the point is the Close, which
+// belongs to the inbound server and may happen while the transport is still
+// reading. Past the declared length the wrapper stops asking.
+type declaredBody struct {
+	rc   io.ReadCloser
+	left int64
+}
+
+func (b *declaredBody) Read(p []byte) (int, error) {
+	if b.left <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > b.left {
+		p = p[:b.left]
+	}
+	n, err := b.rc.Read(p)
+	b.left -= int64(n)
+	return n, err
+}
+
+func (b *declaredBody) Close() error { return b.rc.Close() }
 
 // rewriteFor builds the request the node will see.
 func (s *Server) rewriteFor(node Node, target *url.URL, rest string) func(*httputil.ProxyRequest) {

--- a/external/swarm/swarm_test.go
+++ b/external/swarm/swarm_test.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +22,12 @@ import (
 	"github.com/EvilFreelancer/coddy-agent/internal/netx"
 	swarmdto "github.com/EvilFreelancer/coddy-agent/internal/swarm"
 )
+
+// streamAck bounds how long a stand-in node waits to hear that the chunk it
+// just wrote reached the client. It is a deadlock guard, not a measurement: a
+// relay that forwards a chunk answers in microseconds, and a relay that
+// buffered the response never answers at all.
+const streamAck = 10 * time.Second
 
 // testClock lets a lease expire without the test sleeping through its TTL.
 type testClock struct {
@@ -475,6 +483,138 @@ func TestMountRemainderRejectsAmbiguousPaths(t *testing.T) {
 				t.Fatalf("mountRemainder(%q) = %q, want %q", tc.path, got, tc.want)
 			}
 		})
+	}
+}
+
+// closingBody behaves like the request body net/http hands a handler: once the
+// server has closed it, every further read fails.
+//
+// A read past the declared length waits for that close before it answers. That
+// is the ordering a busy machine produces on its own - the inbound server
+// closing the body before the transport asks whether anything followed it -
+// held here as a certainty rather than a probability.
+type closingBody struct {
+	data   []byte
+	off    int
+	closed chan struct{}
+}
+
+func newClosingBody(data string) *closingBody {
+	return &closingBody{data: []byte(data), closed: make(chan struct{})}
+}
+
+func (b *closingBody) Read(p []byte) (int, error) {
+	if b.off >= len(b.data) {
+		select {
+		case <-b.closed:
+		case <-time.After(streamAck):
+		}
+	}
+	select {
+	case <-b.closed:
+		return 0, http.ErrBodyReadAfterClose
+	default:
+	}
+	if b.off >= len(b.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, b.data[b.off:])
+	b.off += n
+	if b.off >= len(b.data) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (b *closingBody) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+// A node answers while the relay is still finishing the request it was
+// sending, and net/http closes an inbound request body the moment those
+// response headers go out. The transport's last read - the one asking whether
+// the body ran past the length it declared - then lands on a body that is
+// already gone, and failing it costs the whole connection to the node. The
+// answer already on its way is cut, and the next request has to dial again.
+//
+// The request goes through the relay's handler directly so the body under it is
+// the test's own, which is the only way to hold that interleaving still.
+func TestMountKeepsTheNodeConnectionWhenTheRequestBodyIsClosed(t *testing.T) {
+	body := newClosingBody(`{"stream":true}`)
+
+	var dialled atomic.Int64
+	node := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Errorf("node reading the request body: %v", err)
+		}
+		// Stand in for the inbound server, which closes a request body as soon
+		// as the handler writes response headers - here, as soon as the node
+		// has something to say.
+		_ = body.Close()
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("no flusher on the node")
+			return
+		}
+		for i := 0; i < 3; i++ {
+			_, _ = fmt.Fprintf(w, "data: chunk-%d\n\n", i)
+			fl.Flush()
+		}
+	}))
+	node.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			dialled.Add(1)
+		}
+	}
+	node.Start()
+	defer node.Close()
+
+	srv, ts := mountTestRelay(t, node.URL)
+	defer ts.Close()
+
+	req := httptest.NewRequest(http.MethodPost, swarmdto.MountPath+"nas02/v1/responses", body)
+	req.ContentLength = int64(len(body.data))
+	req.Header.Set("Authorization", "Bearer client-secret")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	for i := 0; i < 3; i++ {
+		if chunk := fmt.Sprintf("data: chunk-%d", i); !strings.Contains(rec.Body.String(), chunk) {
+			t.Fatalf("the answer was cut before %s: %q", chunk, rec.Body.String())
+		}
+	}
+
+	// A second request proves the connection outlived the first: a torn-down
+	// one is not in the pool to reuse, and the node sees a fresh dial.
+	again := httptest.NewRequest(http.MethodGet, swarmdto.MountPath+"nas02/coddy/sessions", nil)
+	again.Header.Set("Authorization", "Bearer client-secret")
+	srv.Handler().ServeHTTP(httptest.NewRecorder(), again)
+
+	if got := dialled.Load(); got != 1 {
+		t.Fatalf("the node was dialled %d times, want 1: the relay dropped the connection it was streaming over", got)
+	}
+}
+
+// A body that disappears before it delivered what it promised is a real
+// failure, and stays one: the node would otherwise be told a truncated request
+// was the whole of it.
+func TestMountBodyReportsAShortRequest(t *testing.T) {
+	inner := newClosingBody("half")
+	forwarded := &declaredBody{rc: inner, left: 64}
+
+	if _, err := forwarded.Read(make([]byte, 2)); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	_ = inner.Close()
+	if _, err := forwarded.Read(make([]byte, 16)); err != http.ErrBodyReadAfterClose {
+		t.Fatalf("read after a short body returned %v, want %v", err, http.ErrBodyReadAfterClose)
 	}
 }
 

--- a/external/swarm/tunnel_test.go
+++ b/external/swarm/tunnel_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -125,7 +126,15 @@ func TestTunnelCarriesRequestsToAnUnreachableNode(t *testing.T) {
 
 // A turn arrives as a stream, and it has to stay a stream all the way through a
 // connection that runs backwards.
+//
+// The node writes a chunk and then waits to hear that it arrived before writing
+// the next, so what the test observes is the delivery itself rather than the
+// wall-clock gaps between arrivals. A tunnel that buffered would leave the node
+// waiting: its answer reaches the client only once the handler has returned,
+// and the handler cannot return until the client has seen the chunk before.
 func TestTunnelStreamsWithoutBuffering(t *testing.T) {
+	delivered := make(chan struct{}, 8)
+	var stalled atomic.Bool
 	stand := newTunnelStand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		fl, ok := w.(http.Flusher)
@@ -136,11 +145,20 @@ func TestTunnelStreamsWithoutBuffering(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			_, _ = fmt.Fprintf(w, "data: chunk-%d\n\n", i)
 			fl.Flush()
-			time.Sleep(80 * time.Millisecond)
+			select {
+			case <-delivered:
+			case <-r.Context().Done():
+				return
+			case <-time.After(streamAck):
+				stalled.Store(true)
+				return
+			}
 		}
 	}))
 
-	req, _ := http.NewRequest(http.MethodGet, stand.relay.URL+swarmdto.MountPath+"inner/v1/responses", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*streamAck)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, stand.relay.URL+swarmdto.MountPath+"inner/v1/responses", nil)
 	req.Header.Set("Authorization", "Bearer client-secret")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -149,30 +167,26 @@ func TestTunnelStreamsWithoutBuffering(t *testing.T) {
 	defer func() { _ = res.Body.Close() }()
 
 	sc := bufio.NewScanner(res.Body)
-	var gaps []time.Duration
-	last := time.Now()
-	var chunks int
+	var chunks []string
 	for sc.Scan() {
-		if strings.HasPrefix(sc.Text(), "data: ") {
-			chunks++
-			gaps = append(gaps, time.Since(last))
-			last = time.Now()
+		if !strings.HasPrefix(sc.Text(), "data: ") {
+			continue
 		}
-		if chunks == 3 {
-			break
-		}
-	}
-	if chunks != 3 {
-		t.Fatalf("received %d chunks, want 3", chunks)
-	}
-	var spread int
-	for _, g := range gaps[1:] {
-		if g > 40*time.Millisecond {
-			spread++
+		chunks = append(chunks, strings.TrimSpace(sc.Text()))
+		select {
+		case delivered <- struct{}{}:
+		default:
 		}
 	}
-	if spread < 1 {
-		t.Fatalf("chunks arrived together, so something buffered them: %v", gaps)
+	if stalled.Load() {
+		t.Fatalf("the node waited %s for a chunk to reach the client, so something buffered the stream: %v", streamAck, chunks)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("the stream ended early: %v (chunks %v)", err, chunks)
+	}
+	want := []string{"data: chunk-0", "data: chunk-1", "data: chunk-2"}
+	if !slices.Equal(chunks, want) {
+		t.Fatalf("received %v, want %v", chunks, want)
 	}
 }
 


### PR DESCRIPTION
## What was wrong

`TestSwarmMountFeature/A streamed answer arrives chunk by chunk` (`external/swarm`) failed on two of three full `make test` runs on a busy machine, each time logging `httputil: ReverseProxy read error during body copy: unexpected EOF`. The flake turned out to be a real defect in the relay's mount, not a tired assertion.

The request direction is where it happens:

1. a client POSTs to a mount with a `Content-Length`; the transport flushes the request headers and copies the body straight to the node's socket;
2. the node answers, and the relay writes those response headers back to the client;
3. writing them makes the relay's own `http.Server` drain and close the inbound request body (`net/http` `(*chunkWriter).writeHeader`);
4. having copied the declared length, the transport reads the body once more to check it was not longer than declared (`transferWriter.writeBody`, the second `doBodyCopy` into `io.Discard`);
5. that read lands after the close, returns `http: invalid Read on closed Body`, `Request.write` fails, and `persistConn.writeLoop` tears down the connection to the node.

The answer already on its way is cut: the client keeps `data: chunk-0` and gets `unexpected EOF`, and the relay logs `read error during body copy: use of closed network connection`. Idle, the transport finishes both reads in microseconds and nothing shows; under load the goroutine ordering that loses the race is ordinary, which is exactly when a relay is carrying streams.

## The fix

`handleMount` bounds the forwarded body by the length its sender declared (`declaredBody`), so the transport's extra-bytes read is answered there instead of reaching for a body that is no longer present. Nothing can follow a declared length, so the wrapper hides no data and a body that goes away *before* it delivered what it promised still fails, as it should.

## Tests

- `TestMountKeepsTheNodeConnectionWhenTheRequestBodyIsClosed` holds the interleaving still rather than waiting for a busy machine to produce it: the stand-in body answers the read past its declared length only once the node has closed it. Red on the unfixed relay in three of three runs, with both faces of the bug - the whole request failing with `http: invalid Read on closed Body`, and the production symptom of `data: chunk-0` followed by `use of closed network connection`.
- `TestMountBodyReportsAShortRequest` keeps the other half honest: a body that disappears before it delivered its declared length is still an error.
- The streaming specs stopped measuring wall-clock gaps. In `features/swarm_mount.feature` and `TestTunnelStreamsWithoutBuffering` the node now writes a chunk and waits to hear that it arrived, so a relay that buffered is caught by the deadlock it causes rather than by a 40 ms threshold; the stand-in node also reads its request body before answering, the way a node parsing JSON does. Verified against a deliberately buffering relay: both fail with "the node waited 10s for a chunk to reach the client".

## Verification

- 5760 runs of the scenario under the contention that failed the old test 20 of 20 times (`taskset -c 0,1`, 24 parallel copies): no failures.
- `make test` (all 20 tag combinations) green, `make lint` clean including `--build-tags swarm`.

No HTTP surface, config or UI changes, so no OpenAPI, schema or screenshot updates apply.