### PR TITLE
feat(cli): read long question options in full

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,6 +197,13 @@ comes from the agent's `permission.Options`), the question tool (single or
 multi-select via space, custom free-text answers), model/mode/theme/session
 selectors (`→ ` cursor, type-to-filter, `(i/n)` scroll indicator).
 
+The question modal spends every row on its option label and prints the
+description of the highlighted option under the list, word-wrapped over the
+whole width, so a sentence-long answer stays readable instead of being cut at
+a column boundary. When the question is answered, its tool block shows the
+questions with the chosen answers (`→ answer`, `→ (no answer)` for a dismissed
+one) rather than the JSON the tool hands the model.
+
 ## Flags
 
 `--config --home --cwd --sessions-dir` mirror the other subcommands.

--- a/external/cli/bdd_cli_tui_test.go
+++ b/external/cli/bdd_cli_tui_test.go
@@ -10,6 +10,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -296,12 +297,35 @@ func (s *cliTUIState) stubRunner(ctx context.Context, st *session.State, prompt 
 					s.mu.Unlock()
 				}
 			case "question":
+				// The real agent runs the question tool like any other call:
+				// a tool_call block opens, the arguments stream in, the
+				// operator answers, and the JSON result closes the block.
+				s.toolSeq++
+				s.activeToolID = fmt.Sprintf("call_%d", s.toolSeq)
+				_ = snd.SendSessionUpdate(sessionID, acp.ToolCallUpdate{
+					SessionUpdate: "tool_call", ToolCallID: s.activeToolID,
+					Title: "question", Kind: "other", Status: "pending",
+				})
+				args, _ := json.Marshal(map[string]interface{}{"questions": d.qParams.Questions})
+				_ = snd.SendSessionUpdate(sessionID, acp.ToolCallStatusUpdate{
+					SessionUpdate: "tool_call_update", ToolCallID: s.activeToolID,
+					Status:  "in_progress",
+					Content: []acp.ToolCallResultItem{{Type: "content", Content: acp.ContentBlock{Type: "text", Text: string(args)}}},
+				})
 				res, err := snd.RequestQuestion(ctx, *d.qParams)
+				var answers [][]string
 				if err == nil && res != nil {
+					answers = res.Answers
 					s.mu.Lock()
-					s.questionAns = res.Answers
+					s.questionAns = answers
 					s.mu.Unlock()
 				}
+				result, _ := json.Marshal(acp.QuestionResult{Answers: answers})
+				_ = snd.SendSessionUpdate(sessionID, acp.ToolCallStatusUpdate{
+					SessionUpdate: "tool_call_update", ToolCallID: s.activeToolID,
+					Status:  "completed",
+					Content: []acp.ToolCallResultItem{{Type: "content", Content: acp.ContentBlock{Type: "text", Text: string(result)}}},
+				})
 			case "block":
 				s.blockedCh = d.blockCh
 				select {
@@ -863,6 +887,67 @@ func (s *cliTUIState) operatorChoosesCustomAndTypes(answer string) error {
 	return fmt.Errorf("question answer never arrived")
 }
 
+// The option texts of a real question are sentences, not menu entries: the
+// label of the recommendation and the explanation under it both have to stay
+// readable at 100 columns.
+const (
+	bddLongOptionLabel = "Relay and node both on nas02 (recommended)"
+	bddLongOptionDesc  = "A self-contained pair on nas02 itself: the relay listens on a port and the node dials it, " +
+		"so the swarm survives the laptop going away."
+)
+
+func (s *cliTUIState) stubAsksQuestionWithLongDescriptions() error {
+	s.directives <- stubDirective{kind: "question", qParams: &acp.QuestionRequestParams{
+		SessionID: s.app.sessionID,
+		RequestID: "q2",
+		Questions: []acp.QuestionPrompt{{
+			Header:   "Swarm topology",
+			Question: "Where should the relay live?",
+			Options: []acp.QuestionOption{
+				{Label: bddLongOptionLabel, Description: bddLongOptionDesc},
+				{Label: "Relay on the laptop, node only on nas02", Description: "The swarm is visible from the laptop only."},
+			},
+		}},
+	}}
+	return s.waitScreen("Where should the relay live?", 3*time.Second)
+}
+
+func (s *cliTUIState) questionModalShowsWholeFirstLabel() error {
+	return s.waitScreen(bddLongOptionLabel, 2*time.Second)
+}
+
+// The description sits under the list, wrapped: its tail is on a row of its
+// own instead of being cut off at the end of the option row.
+func (s *cliTUIState) questionModalWrapsSelectedDescription() error {
+	if err := s.waitScreen("A self-contained pair on nas02 itself", 2*time.Second); err != nil {
+		return err
+	}
+	return s.waitScreen("swarm survives the laptop going away.", 2*time.Second)
+}
+
+func (s *cliTUIState) operatorChoosesHighlightedOption() error {
+	s.press("\r")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		n := len(s.questionAns)
+		s.mu.Unlock()
+		if n > 0 {
+			s.directives <- stubDirective{kind: "end"}
+			return s.waitTurnEnd(2 * time.Second)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("question answer never arrived")
+}
+
+func (s *cliTUIState) transcriptShowsQuestionAnswered(question, answer string) error {
+	if err := s.waitScreen(question, 3*time.Second); err != nil {
+		return err
+	}
+	return s.waitScreen("\u2192 "+answer, 3*time.Second)
+}
+
 func (s *cliTUIState) stubObservesQuestionAnswer(answer string) error {
 	s.mu.Lock()
 	ans := s.questionAns
@@ -1088,6 +1173,11 @@ func initializeCLITUIScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the replayed prompt "([^"]*)" renders as a user message block and not as assistant text$`, s.replayedPromptRendersAsUserBlock)
 	sc.Step(`^the stub turn asks a question titled "([^"]*)" that allows a custom answer$`, s.stubAsksQuestion)
 	sc.Step(`^the operator chooses the custom answer and types "([^"]*)"$`, s.operatorChoosesCustomAndTypes)
+	sc.Step(`^the stub turn asks a question whose options carry long descriptions$`, s.stubAsksQuestionWithLongDescriptions)
+	sc.Step(`^the question modal shows the whole label of the first option$`, s.questionModalShowsWholeFirstLabel)
+	sc.Step(`^the question modal wraps the selected option's description below the list$`, s.questionModalWrapsSelectedDescription)
+	sc.Step(`^the operator chooses the highlighted option$`, s.operatorChoosesHighlightedOption)
+	sc.Step(`^the transcript shows the question "([^"]*)" answered with "([^"]*)"$`, s.transcriptShowsQuestionAnswered)
 	sc.Step(`^the stub turn observes the question answer "([^"]*)"$`, s.stubObservesQuestionAnswer)
 	sc.Step(`^the stub turn fails with the error "([^"]*)"$`, s.stubFailsWith)
 	sc.Step(`^the transcript shows an error notice containing "([^"]*)"$`, s.transcriptShowsErrorNotice)

--- a/external/cli/chat.go
+++ b/external/cli/chat.go
@@ -211,6 +211,102 @@ func firstLine(s string) string {
 	return s
 }
 
+// questionPromptText is the one field of a question argument the transcript
+// needs: what the operator was asked.
+type questionPromptText struct {
+	Question string `json:"question"`
+}
+
+// questionReadout turns the question tool's JSON answer into the question and
+// answer pairs the operator saw, so the transcript carries the decision rather
+// than `{"answers":[["..."]]}`. The SPA timeline reads the same result the same
+// way (external/ui/src/ui/chat/questionToolDisplay.ts). Returns "" when the
+// text is not a question result, leaving every other body untouched.
+func questionReadout(argsJSON, resultJSON string) string {
+	// A raw message tells an absent key (not a question result) from the null
+	// list a dismissed question answers with.
+	var result struct {
+		Answers json.RawMessage `json:"answers"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(resultJSON)), &result); err != nil || len(result.Answers) == 0 {
+		return ""
+	}
+	var answers [][]string
+	if err := json.Unmarshal(result.Answers, &answers); err != nil {
+		return ""
+	}
+	questions := questionTexts(argsJSON)
+	rows := max(len(questions), len(answers))
+	if rows == 0 {
+		return "→ (no answer)"
+	}
+	var b strings.Builder
+	for i := 0; i < rows; i++ {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		if i < len(questions) && questions[i] != "" {
+			b.WriteString(questions[i] + "\n")
+		}
+		answer := ""
+		if i < len(answers) {
+			var picked []string
+			for _, one := range answers[i] {
+				if collapsed := collapseSpaces(one); collapsed != "" {
+					picked = append(picked, collapsed)
+				}
+			}
+			answer = strings.Join(picked, ", ")
+		}
+		if answer == "" {
+			answer = "(no answer)"
+		}
+		b.WriteString("→ " + answer)
+	}
+	return b.String()
+}
+
+// questionTexts reads the question prompts out of the call arguments. It
+// tolerates the shapes the tool itself accepts (the array, a single object,
+// and either of them encoded inside a JSON string), and answers nil when the
+// arguments never arrived or say something else.
+func questionTexts(argsJSON string) []string {
+	raw := strings.TrimSpace(argsJSON)
+	if rest, ok := cutArgumentsPrefix(raw); ok {
+		raw = rest
+	}
+	var args struct {
+		Questions json.RawMessage `json:"questions"`
+	}
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		return nil
+	}
+	raw = strings.TrimSpace(string(args.Questions))
+	if strings.HasPrefix(raw, `"`) {
+		var inner string
+		if err := json.Unmarshal([]byte(raw), &inner); err != nil {
+			return nil
+		}
+		raw = strings.TrimSpace(inner)
+	}
+	var prompts []questionPromptText
+	if err := json.Unmarshal([]byte(raw), &prompts); err != nil {
+		var one questionPromptText
+		if err := json.Unmarshal([]byte(raw), &one); err != nil {
+			return nil
+		}
+		prompts = []questionPromptText{one}
+	}
+	texts := make([]string, 0, len(prompts))
+	for _, p := range prompts {
+		texts = append(texts, collapseSpaces(p.Question))
+	}
+	return texts
+}
+
+// collapseSpaces folds every whitespace run into one space.
+func collapseSpaces(s string) string { return strings.Join(strings.Fields(s), " ") }
+
 func (t *toolBox) rebuild() {
 	t.Clear()
 	t.AddChild(tui.NewSpacer(1))
@@ -222,6 +318,11 @@ func (t *toolBox) rebuild() {
 	body := t.preview
 	if t.expanded && t.fullText != "" {
 		body = t.fullText
+	}
+	if t.name == "question" {
+		if readout := questionReadout(t.args, body); readout != "" {
+			body = tui.SanitizeText(readout)
+		}
 	}
 	if t.expanded && t.loadFailed {
 		box.AddChild(tui.NewText(t.theme.Fg(roleDim, "full output unavailable (tool_calls result missing)"), 0, 0, nil))

--- a/external/cli/chat_test.go
+++ b/external/cli/chat_test.go
@@ -474,3 +474,75 @@ func TestConsoleAdoptsTheConfigAfterCommit(t *testing.T) {
 		t.Fatalf("model catalog after the reload = %v", ids)
 	}
 }
+
+// toolBoxText renders a tool box and strips styling, so assertions read what
+// the operator reads.
+func toolBoxText(t *testing.T, tb *toolBox, width int) string {
+	t.Helper()
+	return tui.StripTerminalSequences(strings.Join(tb.Render(width), "\n"))
+}
+
+// The question tool answers the model in JSON. Printing that JSON into the
+// transcript hands the operator `{"answers":[["..."]]}` for a decision they
+// just made; the box shows the question with the answer instead, the way the
+// SPA timeline does.
+func TestQuestionToolBoxShowsTheAnsweredQuestions(t *testing.T) {
+	tb := newToolBox(newTheme("dark"), "call-1", "question", "other", nil)
+	tb.SetArgs(`{"questions":[` +
+		`{"header":"Swarm topology","question":"Where should the relay live?","options":[{"label":"On nas02"}]},` +
+		`{"question":"How is the node started?","options":[{"label":"A systemd service"}]}]}`)
+	tb.SetStatus("completed", `{"answers":[["On nas02"],["A systemd service"]]}`, 0, 0)
+
+	text := toolBoxText(t, tb, 80)
+	for _, want := range []string{
+		"Where should the relay live?", "On nas02",
+		"How is the node started?", "A systemd service",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("%q missing from the box:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "answers") || strings.Contains(text, "[[") {
+		t.Fatalf("raw result JSON still reaches the transcript:\n%s", text)
+	}
+
+	// The arguments also travel behind an "Arguments:" label, and a model may
+	// hand the question list over as one object instead of an array.
+	labelled := newToolBox(newTheme("dark"), "call-1b", "question", "other", nil)
+	labelled.SetArgs(`Arguments: {"questions":{"question":"Where should the relay live?","options":[{"label":"On nas02"}]}}`)
+	labelled.SetStatus("completed", `{"answers":[["On nas02"]]}`, 0, 0)
+	if text := toolBoxText(t, labelled, 80); !strings.Contains(text, "Where should the relay live?") {
+		t.Fatalf("labelled arguments lost the question:\n%s", text)
+	}
+}
+
+// A dismissed question answers with a null list: say so rather than print it.
+func TestQuestionToolBoxReportsADismissedQuestion(t *testing.T) {
+	tb := newToolBox(newTheme("dark"), "call-2", "question", "other", nil)
+	tb.SetArgs(`{"questions":[{"question":"Pick one","options":[{"label":"A"}]}]}`)
+	tb.SetStatus("completed", `{"answers":null}`, 0, 0)
+
+	text := toolBoxText(t, tb, 80)
+	if !strings.Contains(text, "Pick one") || !strings.Contains(text, "no answer") {
+		t.Fatalf("dismissed question renders as %q", text)
+	}
+	if strings.Contains(text, "null") {
+		t.Fatalf("raw result JSON still reaches the transcript:\n%s", text)
+	}
+}
+
+// Only the question tool is reformatted, and only when its result parses: any
+// other body reaches the box unchanged.
+func TestToolBoxLeavesOtherResultsAlone(t *testing.T) {
+	other := newToolBox(newTheme("dark"), "call-3", "read", "read", nil)
+	other.SetStatus("completed", `{"answers":[["A"]]}`, 0, 0)
+	if text := toolBoxText(t, other, 80); !strings.Contains(text, `{"answers":[["A"]]}`) {
+		t.Fatalf("a read result was rewritten:\n%s", text)
+	}
+
+	broken := newToolBox(newTheme("dark"), "call-4", "question", "other", nil)
+	broken.SetStatus("failed", "questions must be non-empty", 0, 0)
+	if text := toolBoxText(t, broken, 80); !strings.Contains(text, "questions must be non-empty") {
+		t.Fatalf("a question error was rewritten:\n%s", text)
+	}
+}

--- a/external/cli/modals.go
+++ b/external/cli/modals.go
@@ -126,7 +126,9 @@ func (m *questionModal) buildQuestion() {
 	if q.Custom {
 		items = append(items, tui.SelectItem{Value: customAnswerValue, Label: "Custom answer..."})
 	}
-	m.list = tui.NewSelectList(items, min(len(items), 8), selectListTheme(th), tui.SelectListLayout{})
+	// Option texts are sentences, so the description belongs under the list,
+	// wrapped, not squeezed into a column beside a cut-off label.
+	m.list = tui.NewSelectList(items, min(len(items), 8), selectListTheme(th), tui.SelectListLayout{DescriptionBelow: true})
 	m.list.OnSelect = func(item tui.SelectItem) { m.confirm(item) }
 	m.list.OnCancel = func() {
 		if m.OnDone != nil {

--- a/external/cli/tui/mainscreen_test.go
+++ b/external/cli/tui/mainscreen_test.go
@@ -194,3 +194,79 @@ func TestAppendingLinesUsesAppendPathWithoutFullRedraw(t *testing.T) {
 		t.Fatalf("appended line missing: %q", out)
 	}
 }
+
+// plainSelectListTheme styles nothing, so assertions read the raw text the
+// list lays out.
+func plainSelectListTheme() SelectListTheme {
+	id := func(s string) string { return s }
+	return SelectListTheme{SelectedText: id, Description: id, ScrollInfo: id, NoMatch: id}
+}
+
+// A question option carries a whole sentence of explanation. Squeezed into the
+// row's description column it loses most of itself and steals the label's
+// width on the way; pi's SettingsList instead wraps the selected item's
+// description under the list, and DescriptionBelow asks for that layout.
+func TestSelectListWrapsTheSelectedDescriptionBelowTheList(t *testing.T) {
+	long := "A self-contained pair on nas02 itself: the relay listens on a port and the node dials it, " +
+		"so the swarm survives the laptop going away."
+	items := []SelectItem{
+		{Value: "0", Label: "Relay and node both on nas02 (recommended)", Description: long},
+		{Value: "1", Label: "Relay on the laptop, node only on nas02", Description: "short"},
+	}
+	list := NewSelectList(items, 8, plainSelectListTheme(), SelectListLayout{DescriptionBelow: true})
+	lines := list.Render(60)
+	if len(lines) == 0 {
+		t.Fatal("nothing rendered")
+	}
+	if !strings.Contains(lines[0], "Relay and node both on nas02 (recommended)") {
+		t.Fatalf("the row must spend the full width on its label, got %q", lines[0])
+	}
+	for i, row := range lines[:2] {
+		if strings.Contains(row, "self-contained") {
+			t.Fatalf("row %d still carries the description: %q", i, row)
+		}
+	}
+	block := strings.Join(lines[2:], "\n")
+	if !strings.Contains(block, "self-contained") || !strings.Contains(block, "laptop going away") {
+		t.Fatalf("the selected description is not readable below the list:\n%s", block)
+	}
+	if got := len(strings.Split(strings.TrimSpace(block), "\n")); got < 2 {
+		t.Fatalf("a sentence that long must wrap, got %d line(s):\n%s", got, block)
+	}
+	for _, line := range lines {
+		if w := VisibleWidth(line); w > 60 {
+			t.Fatalf("line wider than the terminal (%d): %q", w, line)
+		}
+	}
+	// The description follows the cursor.
+	list.MoveDown()
+	if tail := strings.Join(list.Render(60), "\n"); !strings.Contains(tail, "short") {
+		t.Fatalf("the second option's description is missing:\n%s", tail)
+	}
+}
+
+// Without the option nothing moves: slash commands and the selectors keep the
+// two-column layout they were ported with.
+func TestSelectListKeepsTheDescriptionColumnByDefault(t *testing.T) {
+	items := []SelectItem{{Value: "compact", Label: "/compact", Description: "Compact the session"}}
+	lines := NewSelectList(items, 8, plainSelectListTheme(), SelectListLayout{}).Render(60)
+	if len(lines) != 1 {
+		t.Fatalf("expected one row, got %q", lines)
+	}
+	if !strings.Contains(lines[0], "/compact") || !strings.Contains(lines[0], "Compact the session") {
+		t.Fatalf("row lost its description column: %q", lines[0])
+	}
+}
+
+// A label the width cannot hold is cut with an ellipsis, so the operator can
+// see that the text continues instead of reading a word broken mid-syllable.
+func TestSelectListMarksATruncatedLabel(t *testing.T) {
+	items := []SelectItem{{Value: "0", Label: "Relay and node both on nas02 (recommended)"}}
+	lines := NewSelectList(items, 8, plainSelectListTheme(), SelectListLayout{DescriptionBelow: true}).Render(24)
+	if len(lines) == 0 || !strings.Contains(lines[0], "...") {
+		t.Fatalf("truncated label carries no ellipsis: %q", lines)
+	}
+	if w := VisibleWidth(lines[0]); w > 24 {
+		t.Fatalf("truncated row is %d wide: %q", w, lines[0])
+	}
+}

--- a/external/cli/tui/selectlist.go
+++ b/external/cli/tui/selectlist.go
@@ -35,6 +35,12 @@ type SelectListTheme struct {
 type SelectListLayout struct {
 	MinPrimaryColumnWidth int
 	MaxPrimaryColumnWidth int
+	// DescriptionBelow moves descriptions out of the rows: every row spends
+	// the whole width on its label, and the selected item's description is
+	// word-wrapped under the list (port of pi-tui SettingsList's description
+	// block). Sentence-long option texts stay readable that way, where the
+	// column layout would cut both the label and the description.
+	DescriptionBelow bool
 }
 
 // SelectList renders a scrolling selection list with `→ ` cursor prefix and an
@@ -170,7 +176,7 @@ func (s *SelectList) Render(width int) []string {
 	for i := startIndex; i < endIndex; i++ {
 		item := s.filteredItems[i]
 		desc := ""
-		if item.Description != "" {
+		if item.Description != "" && !s.layout.DescriptionBelow {
 			desc = strings.TrimSpace(newlineRunRegex.ReplaceAllString(item.Description, " "))
 		}
 		lines = append(lines, s.renderItem(item, i == s.selectedIndex, width, desc, primaryColumnWidth))
@@ -178,6 +184,23 @@ func (s *SelectList) Render(width int) []string {
 	if startIndex > 0 || endIndex < len(s.filteredItems) {
 		scrollText := "  (" + strconv.Itoa(s.selectedIndex+1) + "/" + strconv.Itoa(len(s.filteredItems)) + ")"
 		lines = append(lines, s.theme.ScrollInfo(TruncateToWidth(scrollText, width-2, "")))
+	}
+	return append(lines, s.descriptionBlock(width)...)
+}
+
+// descriptionBlock renders the selected row's description under the list,
+// wrapped and indented, when the layout asked for it (pi-tui SettingsList).
+func (s *SelectList) descriptionBlock(width int) []string {
+	if !s.layout.DescriptionBelow {
+		return nil
+	}
+	item := s.SelectedItem()
+	if item == nil || strings.TrimSpace(item.Description) == "" {
+		return nil
+	}
+	lines := []string{""}
+	for _, line := range WrapTextWithANSI(item.Description, max(1, width-4)) {
+		lines = append(lines, s.theme.Description("  "+line))
 	}
 	return lines
 }
@@ -207,7 +230,7 @@ func (s *SelectList) renderItem(item SelectItem, isSelected bool, width int, des
 	}
 
 	maxWidth := width - prefixWidth - 2
-	value := TruncateToWidth(s.displayValue(item), maxWidth, "")
+	value := TruncateToWidth(s.displayValue(item), maxWidth, "...")
 	if isSelected {
 		return s.theme.SelectedText(prefix + value)
 	}

--- a/features/cli_tui.feature
+++ b/features/cli_tui.feature
@@ -97,6 +97,21 @@ Feature: Interactive console TUI
     And the operator chooses the custom answer and types "my own words"
     Then the stub turn observes the question answer "my own words"
 
+  Scenario: A question with long options reads in full
+    When the console app starts
+    And the operator submits the prompt "ask me something"
+    And the stub turn asks a question whose options carry long descriptions
+    Then the question modal shows the whole label of the first option
+    And the question modal wraps the selected option's description below the list
+
+  Scenario: An answered question renders as the question and the answer
+    When the console app starts
+    And the operator submits the prompt "ask me something"
+    And the stub turn asks a question whose options carry long descriptions
+    And the operator chooses the highlighted option
+    Then the transcript shows the question "Where should the relay live?" answered with "Relay and node both on nas02 (recommended)"
+    And the transcript does not show "answers"
+
   Scenario: A failed prompt reports the error and the editor recovers
     When the console app starts
     And the operator submits the prompt "boom"


### PR DESCRIPTION
## Problem

The console question modal laid every option out as a pi `SelectList` row: a 32-column
label beside its description, both hard-cut at the column boundary. Question options are
sentences, not menu entries, so a real question read like this at 200 columns:

```
────────────────────────────────────────────────────────────────────────────────────────
 Топология роя
 Своя (swarm) = relay + node. Где должен жить relay, чтобы nas02 был узлом роя?
→ Relay + node оба на nas02 (рек  Самодостаточная связка на самом nas02: relay слушает по
  Relay на pasha-lt, node только  nas02 будет узлом роя, а relay крутится на моей машине.
 ↑↓ navigate · enter choose · esc cancel
────────────────────────────────────────────────────────────────────────────────────────
```

And after answering, the transcript printed the JSON the tool hands the model:

```
 question

 {"answers":[["Relay + node оба на nas02 (рекомендую)"],["systemd-сервис (рекомендую)"]]}
```

## How pi solves it

pi keeps the two-column `SelectList` for menu-shaped lists and has a second layout for text
that does not fit a column: `packages/tui/src/components/settings-list.ts` prints the
**selected** item's description **under** the list, word-wrapped over the full width
(`wrapTextWithAnsi(description, width - 4)`, two-space indent). Rows then spend their whole
width on the label.

## Change

- `SelectListLayout` grows `DescriptionBelow`. With it, rows carry no description column and
  the highlighted item's description is wrapped under the list — the pi `SettingsList` block,
  ported into the existing component rather than duplicated;
- the question modal (`external/cli/modals.go`) asks for that layout;
- a label the width still cannot hold is cut with `...` instead of mid-word;
- the `question` tool block renders the questions with the answers chosen for them
  (`→ answer`, `→ (no answer)` for a dismissed question) instead of the raw result JSON. The
  SPA timeline already reads the same result the same way
  (`external/ui/src/ui/chat/questionToolDisplay.ts`); the console now matches it. The JSON the
  model receives is unchanged.

Slash commands and the model/mode/theme/session selectors keep the two-column layout they were
ported with.

## After

Modal (100 columns, from the BDD frame snapshot):

```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Swarm topology
 Where should the relay live?
→ Relay and node both on nas02 (recommended)
  Relay on the laptop, node only on nas02

  A self-contained pair on nas02 itself: the relay listens on a port and the node dials it, so the
  swarm survives the laptop going away.
 ↑↓ navigate · enter choose · esc cancel
────────────────────────────────────────────────────────────────────────────────────────────────────
```

Answered call in the transcript:

```
 question

 Where should the relay live?
 → Relay and node both on nas02 (recommended)
```

## Tests

- `features/cli_tui.feature` — two scenarios: a question with long options reads in full
  (whole label on the row, description wrapped below), and an answered question renders as the
  question and the answer with no `answers` JSON on screen. The stub runner now frames a
  question in a real tool call (`tool_call` → arguments → answer → JSON result), the way the
  agent does, so the transcript side is covered end to end;
- unit tests for the `SelectList` layout (description below, the column layout unchanged by
  default, truncation marked) and for the readout (multi-question, dismissed, labelled
  `Arguments:` prefix, single-object arguments, other tools left alone).

`make test` green, `make lint` clean. Console TUI only — no SPA surface changed, so no
screenshots; the frames above are the rendered snapshots the BDD harness asserts on.
