### PR TITLE
fix(cli): hand the block directive over instead of pausing for it

### DIFF
--- a/external/cli/bdd_cli_tui_test.go
+++ b/external/cli/bdd_cli_tui_test.go
@@ -95,6 +95,9 @@ type stubDirective struct {
 	preview string
 	err     error
 	blockCh chan struct{}
+	// taken is closed by the turn that pops this directive, so a step can wait
+	// for the hand-off instead of guessing at it with a pause.
+	taken   chan struct{}
 	qParams *acp.QuestionRequestParams
 }
 
@@ -327,6 +330,9 @@ func (s *cliTUIState) stubRunner(ctx context.Context, st *session.State, prompt 
 					Content: []acp.ToolCallResultItem{{Type: "content", Content: acp.ContentBlock{Type: "text", Text: string(result)}}},
 				})
 			case "block":
+				if d.taken != nil {
+					close(d.taken)
+				}
 				s.blockedCh = d.blockCh
 				select {
 				case <-ctx.Done():
@@ -746,10 +752,26 @@ func (s *cliTUIState) stubObservesPermissionOutcome(outcome, option string) erro
 	return nil
 }
 
+// stubBlockTakeTimeout bounds the wait for a turn to take the block directive.
+var stubBlockTakeTimeout = 5 * time.Second
+
+// stubBlocksUntilCancelled parks the running turn inside the stub until
+// something cancels it.
+//
+// It returns only once that turn has actually taken the directive. The
+// directives channel is shared by every turn, so a step that returned on a
+// timer left the directive queued whenever the machine was busy: the next turn
+// popped it and waited on a channel nobody would close, and the console sat on
+// "Waiting for the model" with the rest of the script stranded behind it.
 func (s *cliTUIState) stubBlocksUntilCancelled() error {
-	s.directives <- stubDirective{kind: "block", blockCh: make(chan struct{})}
-	time.Sleep(100 * time.Millisecond)
-	return nil
+	taken := make(chan struct{})
+	s.directives <- stubDirective{kind: "block", blockCh: make(chan struct{}), taken: taken}
+	select {
+	case <-taken:
+		return nil
+	case <-time.After(stubBlockTakeTimeout):
+		return fmt.Errorf("no turn took the block directive within %s", stubBlockTakeTimeout)
+	}
 }
 
 func (s *cliTUIState) operatorPressesEscape() error {

--- a/external/cli/stub_directive_test.go
+++ b/external/cli/stub_directive_test.go
@@ -1,0 +1,68 @@
+//go:build cli
+
+package cli
+
+// The scripted-turn directives of the TUI harness are one buffered channel
+// shared by every turn, so a directive that outlives the turn it was written
+// for is picked up by the next one. These tests pin the handshake that stops
+// that from happening.
+
+import (
+	"testing"
+	"time"
+)
+
+// A block directive is the dangerous one: the turn that takes it waits on a
+// channel only the cancelling step closes. Leaked into a later turn, that turn
+// waits forever - the console sits on "Waiting for the model" and every
+// directive queued behind it is stranded, which is how this reached CI as a
+// load-sensitive failure of "Starting a new session drops updates from the old
+// one".
+func TestStubBlockStepWaitsUntilTheTurnTakesTheDirective(t *testing.T) {
+	s := &cliTUIState{directives: make(chan stubDirective, 16)}
+
+	// A consumer that arrives later than the step's own patience, the way a
+	// loaded machine does.
+	const consumerDelay = 300 * time.Millisecond
+	consumed := make(chan stubDirective, 1)
+	go func() {
+		time.Sleep(consumerDelay)
+		d := <-s.directives
+		if d.taken != nil {
+			close(d.taken)
+		}
+		consumed <- d
+	}()
+
+	start := time.Now()
+	if err := s.stubBlocksUntilCancelled(); err != nil {
+		t.Fatalf("stubBlocksUntilCancelled: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	select {
+	case d := <-consumed:
+		if d.kind != "block" {
+			t.Fatalf("consumed directive kind = %q, want block", d.kind)
+		}
+	default:
+		t.Fatalf("the step returned after %v with the block directive still queued; "+
+			"a later turn would take it and wait on a channel nobody closes", elapsed)
+	}
+	if len(s.directives) != 0 {
+		t.Fatalf("%d directive(s) left queued after the step returned", len(s.directives))
+	}
+}
+
+// The step must fail rather than hang when nothing ever takes the directive,
+// so a broken harness reports itself instead of burning the suite timeout.
+func TestStubBlockStepFailsWhenNoTurnTakesTheDirective(t *testing.T) {
+	s := &cliTUIState{directives: make(chan stubDirective, 16)}
+	prev := stubBlockTakeTimeout
+	stubBlockTakeTimeout = 150 * time.Millisecond
+	defer func() { stubBlockTakeTimeout = prev }()
+
+	if err := s.stubBlocksUntilCancelled(); err == nil {
+		t.Fatal("expected an error when no turn consumes the block directive")
+	}
+}


### PR DESCRIPTION
## What was wrong

`TestCLITUIFeature/Starting a new session drops updates from the old one` (`external/cli`) failed on CI under load with `screen never showed "fresh reply"`. The captured frame shows the console stuck on `⠧ Waiting for the model · 2s`: the prompt went in, no stub reply ever came back. It passed on a re-run of the same tree and locally, which is what made it look like noise.

It is not noise. It is a defect in the harness that only shows when the machine is busy.

## Cause

The scripted-turn directives are **one buffered channel shared by every turn**. The step behind `And the stub turn blocks until cancelled` pushed a `block` directive and then slept 100 ms, hoping the running turn would take it:

```go
s.directives <- stubDirective{kind: "block", blockCh: make(chan struct{})}
time.Sleep(100 * time.Millisecond)
return nil
```

On a loaded machine it did not. `/new` cancelled that turn with the directive still queued, so:

1. the **next** turn popped the stale `block`,
2. and waited on `blockCh` - a channel only the cancelling step closes, and that turn's own context is not the one that was cancelled,
3. so it waited forever, with the `stream` and `end` directives scripted after it stranded behind that wait.

Hence "Waiting for the model" and no reply. The scenario's own subject - a directive leaking across the session boundary - is exactly what the harness was doing to itself.

## Fix

The directive carries a `taken` channel that the turn closes when it actually pops it, and the step returns only then, so a directive can no longer outlive the turn it was written for. A turn that never takes it fails the step after five seconds with a named error instead of hanging until the suite times out.

## Reproduction

The bug is load-dependent, so I made the load explicit rather than guessing: injecting a 300 ms delay into the directive consumer reproduces **the exact CI failure**, and the fixed step passes under the same delay.

| | old step | new step |
|---|---|---|
| consumer delayed 300 ms | `screen never showed "fresh reply"` | pass |
| no delay | pass | pass |

Two unit tests in `external/cli/stub_directive_test.go` pin it without needing the delay: one asserts the step does not return while the directive is still queued, the other that it reports an error instead of hanging when nothing takes it. Both fail on the old step and pass on the new one - verified on this branch's base, not only on the older tree.

## The other sleeps

All thirteen `time.Sleep` calls in the harness were reviewed. Eleven are polling loops with deadlines, which is the right shape. The remaining two - spacing two `ctrl+c` presses, and letting one-shot mode start - carry no directive that could leak into a later turn, so they are left alone.

One weaker spot worth naming rather than changing here: `cancelledTurnEmitsLateChunk` sleeps 150 ms before a **negative** assertion (`the transcript does not show "stale text"`). A sleep is the only option for asserting absence, but on a slow machine that assertion can pass before the chunk would have arrived - a false green rather than a flake. Tightening it is a separate change.

## Verification

- `go test -tags cli ./external/cli/ -count=2` green; the TUI feature suite green at `-count=5`.
- `make lint` green, including the `cli`, `swarm` and `gateway` tagged passes.
- `make test` running at the time of writing; the result is reported in a comment below rather than claimed here.

