### PR TITLE
Bound the limit wait by what it charged, not by the wall clock

### DIFF
--- a/features/llm_limit_wait.feature
+++ b/features/llm_limit_wait.feature
@@ -25,7 +25,7 @@ Feature: Coddy waits for a hit usage limit to lift when asked to
     And wait_for_limit_reset is on with a maximum of 300 ms
     When the user sends a turn
     Then the turn fails with the quota reset error after 1 provider call
-    And the turn took less than 300 ms
+    And the turn never waited on the limit
 
   Scenario: The retry wrapper's own verdict drives the wait
     Given an agent whose provider answers a 429 naming a reset in 1 s through the retry wrapper and then answers "done"
@@ -47,7 +47,7 @@ Feature: Coddy waits for a hit usage limit to lift when asked to
     And wait_for_limit_reset is on with a maximum of 300 ms
     When the user sends a turn
     Then the turn fails with the quota reset error after 1 provider call
-    And the turn took less than 300 ms
+    And the turn never waited on the limit
 
   Scenario: The retry wrapper's own sleeps count against the same maximum
     Given an agent whose provider answers a 429 naming a reset in 1 s twice through the retry wrapper and then answers "done"
@@ -55,21 +55,21 @@ Feature: Coddy waits for a hit usage limit to lift when asked to
     When the user sends a turn
     Then the turn fails with the quota reset error after 2 provider calls
     And the turn took at least 1 s
-    And the turn took less than 1500 ms
+    And the turn waited less than 1500 ms on the limit
 
   Scenario: An explicit zero never sleeps on a limit, the retry wrapper included
     Given an agent whose provider answers a 429 naming a reset in 1 s through the retry wrapper and then answers "done"
     And wait_for_limit_reset is on with a maximum of 0 ms
     When the user sends a turn
     Then the turn fails with the quota reset error after 1 provider call
-    And the turn took less than 300 ms
+    And the turn never waited on the limit
 
   Scenario: Stop during the wait ends the turn as cancelled
     Given an agent whose provider first reports a limit that lifts in 30 s and then answers "done"
     And wait_for_limit_reset is on
     When the user sends a turn and stops it while it waits
     Then the turn ends as cancelled after 1 provider call
-    And the turn took less than 1000 ms
+    And the turn waited less than 1000 ms on the limit
 
   Scenario: A retry sleep on a call that then succeeded counts against the same maximum
     Given an agent whose provider sleeps through a 429 naming a reset in 1 s, answers nothing, hits the limit again and then answers "done"
@@ -77,7 +77,7 @@ Feature: Coddy waits for a hit usage limit to lift when asked to
     When the user sends a turn
     Then the turn fails with the quota reset error after 3 provider calls
     And the turn took at least 1 s
-    And the turn took less than 1500 ms
+    And the turn waited less than 1500 ms on the limit
 
   Scenario: A 429 that names no pause never starts a wait
     Given an agent whose provider keeps answering 429 without naming a pause and would then answer "done"
@@ -92,4 +92,4 @@ Feature: Coddy waits for a hit usage limit to lift when asked to
     When the user sends a turn and the client goes away while it waits
     Then the turn fails with the quota reset error after 1 provider call
     And the error names the interrupted wait
-    And the turn took less than 1000 ms
+    And the turn waited less than 1000 ms on the limit

--- a/internal/agent/bdd_limit_wait_test.go
+++ b/internal/agent/bdd_limit_wait_test.go
@@ -127,6 +127,7 @@ type limitWaitState struct {
 	sender     *limitWaitSender
 	cfg        *config.Config
 	state      *session.State
+	ag         *Agent
 	tmp        []string
 
 	started time.Time
@@ -143,6 +144,7 @@ func (s *limitWaitState) reset() error {
 	s.sender = &limitWaitSender{}
 	s.cfg = nil
 	s.state = nil
+	s.ag = nil
 	s.took = 0
 	s.reply = ""
 	s.stop = ""
@@ -330,6 +332,7 @@ func (s *limitWaitState) theTurnEndsAsCancelledAfterCalls(calls int) error {
 
 func (s *limitWaitState) agent() *Agent {
 	ag := NewAgent(s.cfg, s.state, s.sender, nil)
+	s.ag = ag
 	ag.providerFactory = func(in llm.ProviderInput) (llm.Provider, error) {
 		if !s.viaWrapper {
 			return s.provider, nil
@@ -378,6 +381,11 @@ func (s *limitWaitState) theTurnEndsWithAfterCalls(reply string, calls int) erro
 	return nil
 }
 
+// theTurnTookAtLeast stays on the turn's wall clock: a lower bound only ever
+// grows on a slow machine, and it is the honest proof that the wait really
+// happened. The ledger is no good for it - the loop's wait runs to a ResetAt
+// the provider stamped before the error travelled up, so it books slightly
+// less than the pause the scenario names.
 func (s *limitWaitState) theTurnTookAtLeast(sec int) error {
 	if s.took < time.Duration(sec)*time.Second {
 		return fmt.Errorf("turn took %v, want at least %ds", s.took, sec)
@@ -385,9 +393,29 @@ func (s *limitWaitState) theTurnTookAtLeast(sec int) error {
 	return nil
 }
 
-func (s *limitWaitState) theTurnTookLessThan(ms int) error {
-	if s.took >= time.Duration(ms)*time.Millisecond {
-		return fmt.Errorf("turn took %v, want less than %dms", s.took, ms)
+// waited is what the turn charged against its wait_for_limit_reset maximum:
+// every sleep the retry wrapper took after a 429 plus every wait the loop
+// spent on a reset, each booked as the time it really took. That ledger, not
+// the turn's wall clock, is what the maximum bounds, and reading it keeps the
+// upper bounds below free of the harness's own setup time - on a loaded CI
+// runner that overhead alone used to overrun them.
+func (s *limitWaitState) waited() time.Duration {
+	if s.ag == nil {
+		return 0
+	}
+	return s.ag.limitLedgerFor().Spent()
+}
+
+func (s *limitWaitState) theTurnWaitedLessThan(ms int) error {
+	if got := s.waited(); got >= time.Duration(ms)*time.Millisecond {
+		return fmt.Errorf("turn waited %v on the limit, want less than %dms", got, ms)
+	}
+	return nil
+}
+
+func (s *limitWaitState) theTurnNeverWaited() error {
+	if got := s.waited(); got != 0 {
+		return fmt.Errorf("turn waited %v on the limit, want no wait at all", got)
 	}
 	return nil
 }
@@ -457,7 +485,8 @@ func initializeLimitWaitScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the turn ends as cancelled after (\d+) provider calls?$`, s.theTurnEndsAsCancelledAfterCalls)
 	sc.Step(`^the turn ends with "([^"]+)" after (\d+) provider calls$`, s.theTurnEndsWithAfterCalls)
 	sc.Step(`^the turn took at least (\d+) s$`, s.theTurnTookAtLeast)
-	sc.Step(`^the turn took less than (\d+) ms$`, s.theTurnTookLessThan)
+	sc.Step(`^the turn waited less than (\d+) ms on the limit$`, s.theTurnWaitedLessThan)
+	sc.Step(`^the turn never waited on the limit$`, s.theTurnNeverWaited)
 	sc.Step(`^the client saw a resuming usage update with the reset time$`, s.theClientSawAResumingUpdate)
 	sc.Step(`^the client saw no resuming usage update$`, s.theClientSawNoResumingUpdate)
 	sc.Step(`^the turn fails with the quota reset error after (\d+) provider calls?$`, s.theTurnFailsWithTheQuotaResetErrorAfterCalls)


### PR DESCRIPTION
The scenario `A retry sleep on a call that then succeeded counts against the same maximum` in `features/llm_limit_wait.feature` is flaky on CI. It failed on run 34465171127 with `turn took 1.811144797s, want less than 1500ms`; a plain re-run of the same commit passed.

## Cause

`the turn took less than N ms` measured `time.Since(started)`, the whole turn, so creating the agent, its temp dirs and the prompt counted against a budget meant for the wait. The turn really sleeps 1.00008 s waiting out the simulated 429, which left about 500 ms for everything else. `internal/agent` takes ~43 s on a GitHub runner against ~26 s locally, and the failing run spent 811 ms of that budget on overhead alone.

What `agent.wait_for_limit_reset`'s maximum bounds is not the turn's duration but the turn's ledger: every sleep the retry wrapper takes after a 429 (`llm.LimitLedger`) plus every wait the loop spends on a reset (`limitWaitLedger` in `internal/agent/limit_wait.go`). That is bookkeeping, not timing.

## Change

Test-only. No production code moved, `limit_wait.go` is untouched: the harness is already in `package agent`, so it reads `limitLedgerFor().Spent()` directly and no seam had to be opened.

Every scenario carrying the step was checked, not just the failing one:

| Scenario budget | Was | Now | Measured |
|---|---|---|---|
| 300 ms (3 scenarios) | 300 ms of wall clock shared with all setup | `the turn never waited on the limit` | charged exactly 0, no timer at all |
| 1500 ms (2 scenarios) | 500 ms shared with setup | `the turn waited less than 1500 ms on the limit` | 1.00008 s charged, 500 ms of pure sleep headroom |
| 1000 ms (2 scenarios) | 1000 ms shared with setup | `the turn waited less than 1000 ms on the limit` | ~4.4 ms, cut by the cancel, against a 30 s reset |

The `at least 1 s` half deliberately stays on the wall clock. A lower bound only grows on a slow machine, so it cannot flake that way, and it is the honest proof that the wait really happened. The ledger is the wrong instrument for it: the loop's wait runs to a `ResetAt` the provider stamped before the error travelled up, so it books slightly less than the pause the scenario names. That reasoning is a comment on the step.

## Verification

A temporary patch injected a delay before `ag.Run` standing in for a loaded runner's overhead. At 600 ms the old assertions failed five of twelve scenarios, including the CI one (`turn took 1.602964703s, want less than 1500ms`). With this change 600 ms passes, and so does 2 s. The test binary also ran four times on two pinned cores under twelve busy-loop processes, green. The injected delay is not in the diff.

`make test` green: 806 package runs across the full tag matrix, exit 0. `make lint` clean on all four tag sets. Both re-checked after rebasing onto main.
