### PR TITLE
fix(swarm): attach the StartJoins doc comment to StartJoins

### DIFF
--- a/internal/swarm/joinset.go
+++ b/internal/swarm/joinset.go
@@ -19,12 +19,6 @@ type JoinSet struct {
 	wg      sync.WaitGroup
 }
 
-// StartJoins registers this process into every relay listed in swarm.join and
-// keeps those registrations alive until Stop.
-//
-// Both `coddy http` and `coddy swarm` call it: an agent joins a relay, and a
-// relay joins another relay exactly the same way. That symmetry is what makes a
-// chain of relays work without a second mechanism.
 // StartJoinsOptions carries what every join in this process has in common.
 type StartJoinsOptions struct {
 	// Kind is what this process registers as: agent or relay.
@@ -42,6 +36,12 @@ type StartJoinsOptions struct {
 	Log *slog.Logger
 }
 
+// StartJoins registers this process into every relay listed in swarm.join and
+// keeps those registrations alive until Stop.
+//
+// Both `coddy http` and `coddy swarm` call it: an agent joins a relay, and a
+// relay joins another relay exactly the same way. That symmetry is what makes a
+// chain of relays work without a second mechanism.
 func StartJoins(ctx context.Context, cfg *config.Config, opts StartJoinsOptions) (*JoinSet, error) {
 	kind, home, handler, log := opts.Kind, opts.Home, opts.Handler, opts.Log
 	if cfg == nil || len(cfg.Swarm.Join) == 0 {


### PR DESCRIPTION
## Problem

In `internal/swarm/joinset.go` the two paragraphs describing `StartJoins` sat directly above `// StartJoinsOptions carries what every join in this process has in common.` with no blank line between them. Go therefore read the whole block as the doc comment of the options type:

- `go doc ./internal/swarm StartJoinsOptions` printed the prose about registering into every relay listed in `swarm.join`;
- `go doc ./internal/swarm StartJoins` printed the signature and nothing else.

## Fix

Move the `StartJoins` paragraphs down to the `func StartJoins` declaration they describe; leave only its own one-line comment on `StartJoinsOptions`. Comment text is unchanged.

## Verification

- `GOFLAGS=-tags=swarm go doc ./internal/swarm StartJoins` now prints both paragraphs;
- `GOFLAGS=-tags=swarm go doc ./internal/swarm StartJoinsOptions` prints only its own line plus the fields;
- `gofmt -l internal/swarm/joinset.go` empty, `make lint` clean (`0 issues` on all four tag runs; the pre-commit gate ran it too).

Note: `go doc` takes no `-tags` flag in this Go version, the tag goes through `GOFLAGS`. `internal/swarm` is untagged anyway, so the output is identical without it.