### PR TITLE
Fix the loader default for instructions.files that #211 left behind

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1513,3 +1513,57 @@ agent:
 		t.Fatalf("usage_limits_panel missing from the providers field order: %v", order)
 	}
 }
+
+// TestInstructionsDefaultMatchesTheSchema is the guard against the drift this
+// test was written for: the loader, the UI defaults and the embedded schema all
+// have to name the same pair, or a config.yaml validates against a default the
+// binary does not apply.
+func TestInstructionsDefaultMatchesTheSchema(t *testing.T) {
+	want := []string{"AGENTS.md", "DESIGN.md"}
+	assertFiles := func(what string, got []string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s = %v, want %v", what, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s = %v, want %v", what, got, want)
+			}
+		}
+	}
+
+	// An absent key and an explicit empty list are the same thing, as they are
+	// for skills.dirs and hooks.files.
+	for _, tc := range []struct {
+		name  string
+		start config.Instructions
+	}{
+		{"key absent", config.Instructions{}},
+		{"files: []", config.Instructions{Files: []string{}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.start
+			c.ApplyDefaults()
+			assertFiles("instructions.files", c.Files)
+		})
+	}
+
+	assertFiles("the loader defaults", config.DocDefaults(config.Paths{Home: filepath.FromSlash("/agent/home")}).Instructions.Files)
+	assertFiles("the UI example config", config.SchemaExampleConfigJSON().Instructions.Files)
+
+	var schema struct {
+		Properties struct {
+			Instructions struct {
+				Properties struct {
+					Files struct {
+						Default []string `json:"default"`
+					} `json:"files"`
+				} `json:"properties"`
+			} `json:"instructions"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(config.ConfigSchemaJSON(), &schema); err != nil {
+		t.Fatal(err)
+	}
+	assertFiles("the embedded schema default", schema.Properties.Instructions.Properties.Files.Default)
+}

--- a/internal/config/instructions.go
+++ b/internal/config/instructions.go
@@ -2,19 +2,28 @@ package config
 
 import "strings"
 
-// Instructions configures which files from the session CWD are read as user-provided
-// instructions and appended to the system prompt. Compatible with the AGENTS.md convention
-// used by other AI coding agents.
+// Instructions configures which files are read as user-provided instructions and
+// appended to the system prompt. Compatible with the AGENTS.md convention used by
+// other AI coding agents, and not limited to the session CWD: ${CODDY_HOME},
+// ${CWD} and a leading ~ expand, and an absolute entry is read as it stands.
 type Instructions struct {
-	// Files is the list of filenames (relative to session CWD) to read.
-	// Defaults to ["AGENTS.md"] when empty.
+	// Files is the list of instruction files to read, in the order listed.
+	// Defaults to DefaultInstructionFiles() when empty.
 	Files []string `yaml:"files"`
+}
+
+// DefaultInstructionFiles is the pair a directory describes itself with, the
+// same one the project docs preamble reads for the workspace root and for the
+// agent home (rules.LoadProjectDocs). Kept as a function so the schema default,
+// the UI defaults and the loader cannot drift apart.
+func DefaultInstructionFiles() []string {
+	return []string{"AGENTS.md", "DESIGN.md"}
 }
 
 // ApplyDefaults sets the default file list when empty.
 func (c *Instructions) ApplyDefaults() {
 	if len(c.Files) == 0 {
-		c.Files = []string{"AGENTS.md"}
+		c.Files = DefaultInstructionFiles()
 	}
 }
 

--- a/internal/config/schema_ui_defaults.go
+++ b/internal/config/schema_ui_defaults.go
@@ -46,7 +46,7 @@ func SchemaExampleConfigJSON() *ConfigJSON {
 			AskPrompt:   "ask.md",
 		},
 		Instructions: InstructionsJSON{
-			Files: []string{"AGENTS.md"},
+			Files: DefaultInstructionFiles(),
 		},
 		Skills: SkillsJSON{
 			Dirs: []string{


### PR DESCRIPTION
[#211](https://github.com/coddy-project/coddy-agent/pull/211) documented `instructions.files` as
defaulting to the pair a directory describes itself with. The embedded schema, the generated
reference table, the Settings field description and `docs/features/rules.md` all say
`["AGENTS.md", "DESIGN.md"]` - the loader still applied `["AGENTS.md"]`.

An edit failed silently in that branch and nothing caught it: no test pinned the value, and the
visible effect is nil, because the workspace's `DESIGN.md` reaches the prompt through the project
docs preamble either way. What was actually wrong is that a config validated against a default the
binary does not apply.

The loader and the UI example config now take the pair from one `DefaultInstructionFiles()`, and
`TestInstructionsDefaultMatchesTheSchema` holds the loader, that example and the default inside the
embedded schema to the same value - including the `files: []` spelling, which means the default here
as it does for `skills.dirs` and `hooks.files`.

Verified by restoring the old loader default: the test fails with `instructions.files = [AGENTS.md]`.

`make test` green (49 packages), `make lint` clean, `make docs-check` clean. No schema or
documentation change, so the site copies stay in sync.