### PR TITLE
fix(cli): operator prompts queue for the modal slot instead of replacing each other

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3523,6 +3523,14 @@ a column boundary. When the question is answered, its tool block shows the
 questions with the chosen answers (`→ answer`, `→ (no answer)` for a dismissed
 one) rather than the JSON the tool hands the model.
 
+A permission request and a question are prompts a turn is blocked on, so they
+queue for the modal slot rather than replace each other: the one on screen
+keeps it and says how many are waiting behind it, and each is shown in arrival
+order as the previous is answered. A selector never takes the slot from either
+of them - losing a picker costs a keystroke, losing a prompt would leave its
+turn waiting for an answer with nothing on screen to give it. A prompt whose
+turn ended while it waited is dropped instead of shown.
+
 ## Flags
 
 `--config --home --cwd --sessions-dir` mirror the other subcommands.
@@ -3634,9 +3642,11 @@ process working directory, resolved like `coddy mcp`. Under
 
 In the console a `spawn_agent` call shows as a tool box like any other, and the
 status line reads `Running subagent <name>` with its elapsed counter for as long
-as the child runs. A child's permission request, while its spawning turn is
-still alive, opens the usual modal in the parent chat with the title prefixed
-`[subagent <name>]`. Child sessions (`sub_…` ids) are read-only transcripts:
+as the child runs. A child's permission request opens the usual modal in the
+parent chat with the title prefixed `[subagent <name>]`, waiting its turn when
+the parent is itself holding a prompt. A child started in the background
+outlives its spawning turn, so its request stays on screen after that turn
+ends. Child sessions (`sub_…` ids) are read-only transcripts:
 `-c` never picks one, and a prompt sent to one is refused with a message naming
 the parent session.
 

--- a/docs/surfaces/console.md
+++ b/docs/surfaces/console.md
@@ -217,6 +217,14 @@ a column boundary. When the question is answered, its tool block shows the
 questions with the chosen answers (`→ answer`, `→ (no answer)` for a dismissed
 one) rather than the JSON the tool hands the model.
 
+A permission request and a question are prompts a turn is blocked on, so they
+queue for the modal slot rather than replace each other: the one on screen
+keeps it and says how many are waiting behind it, and each is shown in arrival
+order as the previous is answered. A selector never takes the slot from either
+of them - losing a picker costs a keystroke, losing a prompt would leave its
+turn waiting for an answer with nothing on screen to give it. A prompt whose
+turn ended while it waited is dropped instead of shown.
+
 ## Flags
 
 `--config --home --cwd --sessions-dir` mirror the other subcommands.
@@ -328,9 +336,11 @@ process working directory, resolved like `coddy mcp`. Under
 
 In the console a `spawn_agent` call shows as a tool box like any other, and the
 status line reads `Running subagent <name>` with its elapsed counter for as long
-as the child runs. A child's permission request, while its spawning turn is
-still alive, opens the usual modal in the parent chat with the title prefixed
-`[subagent <name>]`. Child sessions (`sub_…` ids) are read-only transcripts:
+as the child runs. A child's permission request opens the usual modal in the
+parent chat with the title prefixed `[subagent <name>]`, waiting its turn when
+the parent is itself holding a prompt. A child started in the background
+outlives its spawning turn, so its request stays on screen after that turn
+ends. Child sessions (`sub_…` ids) are read-only transcripts:
 `-c` never picks one, and a prompt sent to one is refused with a message naming
 the parent session.
 

--- a/external/cli/app.go
+++ b/external/cli/app.go
@@ -123,6 +123,11 @@ type App struct {
 	workStop  context.CancelFunc
 
 	modal tui.Component
+	// openGate is the request the modal on screen is waiting on, when that
+	// modal is a gate; gateQueue holds the permission requests and questions
+	// that arrived while it had the slot, in arrival order.
+	openGate  *operatorGate
+	gateQueue []operatorGate
 
 	mdTheme tui.MarkdownTheme
 
@@ -584,6 +589,55 @@ func (a *App) appendStatus(role, msg string) {
 
 // --- modal management ---
 
+// operatorGate is one blocking prompt waiting for the modal slot: a permission
+// request or a question. Exactly one of the two is set.
+type operatorGate struct {
+	perm  *permRequest
+	quest *questRequest
+}
+
+// turnCtx returns the requesting turn's context.
+func (g operatorGate) turnCtx() context.Context {
+	switch {
+	case g.perm != nil:
+		return g.perm.ctx
+	case g.quest != nil:
+		return g.quest.ctx
+	}
+	return nil
+}
+
+// stale reports whether the worker behind the gate has already given up, so
+// showing it would ask the operator to answer nobody.
+func (g operatorGate) stale() bool {
+	ctx := g.turnCtx()
+	return ctx != nil && ctx.Err() != nil
+}
+
+// gateModal reports whether the slot is held by a prompt somebody is blocked
+// on. Those are the only modals that must never be replaced: a picker loses a
+// keystroke, a gate loses the answer its turn cannot continue without.
+func (a *App) gateModal() bool {
+	switch a.modal.(type) {
+	case *permissionModal, *questionModal:
+		return true
+	}
+	return false
+}
+
+// queuedGateNote tells the open gate how many more are behind it, so a second
+// prompt arriving during the first is visible instead of silent.
+func (a *App) queuedGateNote() {
+	switch m := a.modal.(type) {
+	case *permissionModal:
+		m.SetQueued(len(a.gateQueue))
+	case *questionModal:
+		m.SetQueued(len(a.gateQueue))
+	}
+}
+
+// openModal gives the slot to c. Callers that can lose their modal without
+// consequence go through openOverlay instead.
 func (a *App) openModal(c tui.Component) {
 	a.modal = c
 	a.editorWrap.Clear()
@@ -593,17 +647,75 @@ func (a *App) openModal(c tui.Component) {
 	}
 }
 
+// openOverlay shows a picker unless a gate holds the slot. A picker dropped
+// here costs the operator a keystroke; a gate dropped here hangs its turn with
+// nothing on screen to unblock it.
+func (a *App) openOverlay(c tui.Component) bool {
+	if a.gateModal() {
+		return false
+	}
+	a.openModal(c)
+	return true
+}
+
 func (a *App) closeModal() {
 	// The gate is answered; the status line goes back to the gated step itself
 	// (an approved tool only starts executing now, so its clock restarts too).
 	a.unblockStatus()
 	a.modal = nil
+	a.openGate = nil
 	a.editorWrap.Clear()
 	a.editorWrap.AddChild(a.editor)
 	a.screen.SetFocus(a.editor)
+	a.openNextGate()
 }
 
+// openNextGate hands the freed slot to the oldest gate still waiting for an
+// answer, dropping the ones whose turn has since ended.
+func (a *App) openNextGate() {
+	for len(a.gateQueue) > 0 {
+		next := a.gateQueue[0]
+		a.gateQueue = a.gateQueue[1:]
+		if next.stale() {
+			continue
+		}
+		switch {
+		case next.perm != nil:
+			a.showPermissionModal(*next.perm)
+		case next.quest != nil:
+			a.showQuestionModal(*next.quest)
+		default:
+			continue
+		}
+		return
+	}
+}
+
+// dropStaleGates forgets queued gates whose turn is gone, so the note on the
+// open gate counts only prompts that can still be answered.
+func (a *App) dropStaleGates() {
+	live := a.gateQueue[:0]
+	for _, g := range a.gateQueue {
+		if !g.stale() {
+			live = append(live, g)
+		}
+	}
+	a.gateQueue = live
+	a.queuedGateNote()
+}
+
+// openPermissionModal shows the request, or queues it behind the gate already
+// waiting for an answer.
 func (a *App) openPermissionModal(req permRequest) {
+	if a.gateModal() {
+		a.gateQueue = append(a.gateQueue, operatorGate{perm: &req})
+		a.queuedGateNote()
+		return
+	}
+	a.showPermissionModal(req)
+}
+
+func (a *App) showPermissionModal(req permRequest) {
 	a.blockStatus("Waiting for your approval")
 	m := newPermissionModal(a.theme, req.params, a.screen.RequestRender)
 	m.OnDone = func(res *acp.PermissionResult) {
@@ -612,9 +724,22 @@ func (a *App) openPermissionModal(req permRequest) {
 		a.screen.RequestRender()
 	}
 	a.openModal(m)
+	a.openGate = &operatorGate{perm: &req}
+	m.SetQueued(len(a.gateQueue))
 }
 
+// openQuestionModal shows the question, or queues it behind the gate already
+// waiting for an answer.
 func (a *App) openQuestionModal(req questRequest) {
+	if a.gateModal() {
+		a.gateQueue = append(a.gateQueue, operatorGate{quest: &req})
+		a.queuedGateNote()
+		return
+	}
+	a.showQuestionModal(req)
+}
+
+func (a *App) showQuestionModal(req questRequest) {
 	a.blockStatus("Waiting for your answer")
 	m := newQuestionModal(a.theme, req.params, a.screen.RequestRender)
 	m.OnDone = func(res *acp.QuestionResult) {
@@ -623,6 +748,8 @@ func (a *App) openQuestionModal(req questRequest) {
 		a.screen.RequestRender()
 	}
 	a.openModal(m)
+	a.openGate = &operatorGate{quest: &req}
+	m.SetQueued(len(a.gateQueue))
 }
 
 // --- submit / turn ---
@@ -755,7 +882,7 @@ func (a *App) openModelSelector() {
 		}
 		a.setModel(item.Value)
 	}
-	a.openModal(sel)
+	a.openOverlay(sel)
 }
 
 func (a *App) setModel(id string) {

--- a/external/cli/bdd_cli_tui_test.go
+++ b/external/cli/bdd_cli_tui_test.go
@@ -129,6 +129,10 @@ type cliTUIState struct {
 
 	prevSessionID string
 
+	// bgPerm carries the answer to the permission a background subagent asked
+	// for while the turn was parked in a question.
+	bgPerm chan *acp.PermissionResult
+
 	printOut  *syncBuffer
 	printDone chan error
 
@@ -174,6 +178,7 @@ func (s *cliTUIState) reset() {
 	s.toolSeq = 0
 	s.blockedCh = nil
 	s.prevSessionID = ""
+	s.bgPerm = nil
 	s.printOut = nil
 	s.printDone = nil
 	s.mgr = nil
@@ -1001,6 +1006,114 @@ func (s *cliTUIState) operatorChoosesHighlightedOption() error {
 	return fmt.Errorf("question answer never arrived")
 }
 
+// bddSubagentCommand is the command the background child asks to run while the
+// parent turn is parked in a question.
+const bddSubagentCommand = "rm -rf /tmp/scratch"
+
+// backgroundSubagentAsksPermission is what a `spawn_agent` child started with
+// background: true does in production: it runs on its own goroutine and relays
+// its permission request to the parent's surface, which may already be holding
+// a gate of its own.
+func (s *cliTUIState) backgroundSubagentAsksPermission() error {
+	snd := s.app.Sender()
+	reply := make(chan *acp.PermissionResult, 1)
+	s.mu.Lock()
+	s.bgPerm = reply
+	s.mu.Unlock()
+	go func() {
+		// The child carries its own effective mode, so a bypassed parent does
+		// not auto-allow it.
+		res, _ := snd.RequestPermission(context.Background(), acp.PermissionRequestParams{
+			SessionID:               s.app.sessionID,
+			EffectivePermissionMode: config.PermModeAsk,
+			ToolCall: acp.PermissionToolCall{
+				ToolCallID: "child_call_1",
+				Title:      "[subagent explore] Run: " + bddSubagentCommand,
+				Status:     "pending",
+			},
+			Options: []acp.PermissionOption{
+				{OptionID: "allow", Name: "Allow", Kind: "allow_once"},
+				{OptionID: "reject", Name: "Reject", Kind: "reject_once"},
+			},
+		})
+		reply <- res
+	}()
+	// Wait for the UI loop to have taken the request, whichever way it
+	// handles it: the queued note when it waits its turn, the permission
+	// modal when it takes the screen from the question. Which of the two
+	// happened is what the next steps assert, so the failure names the
+	// symptom rather than the missing hint.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		screen := s.screenText()
+		if strings.Contains(screen, "prompt is waiting behind this one") ||
+			strings.Contains(screen, "Permission required") {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("the subagent's permission never reached the UI loop; last frame:\n%s", s.screenText())
+}
+
+func (s *cliTUIState) questionIsStillThePromptOnScreen() error {
+	if _, ok := s.app.modal.(*questionModal); !ok {
+		return fmt.Errorf("modal = %T, want the question still holding the slot", s.app.modal)
+	}
+	return s.waitScreen("Pick or type", 2*time.Second)
+}
+
+func (s *cliTUIState) questionModalSaysAnotherPromptWaits() error {
+	return s.waitScreen("1 more prompt is waiting behind this one", 2*time.Second)
+}
+
+// operatorAnswersQuestionKeepingTurn confirms the highlighted option and leaves
+// the turn running, so the queued gate has somewhere to arrive.
+func (s *cliTUIState) operatorAnswersQuestionKeepingTurn() error {
+	s.press("\r")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		n := len(s.questionAns)
+		s.mu.Unlock()
+		if n > 0 {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("question answer never arrived")
+}
+
+func (s *cliTUIState) subagentPermissionIsThePromptOnScreen() error {
+	if err := s.waitScreen("Permission required", 3*time.Second); err != nil {
+		return err
+	}
+	if _, ok := s.app.modal.(*permissionModal); !ok {
+		return fmt.Errorf("modal = %T, want the queued permission promoted", s.app.modal)
+	}
+	return s.waitScreen(bddSubagentCommand, 2*time.Second)
+}
+
+func (s *cliTUIState) operatorAllowsSubagentCommand() error {
+	s.press("\r")
+	return nil
+}
+
+func (s *cliTUIState) subagentReceivesItsAnswer() error {
+	s.mu.Lock()
+	reply := s.bgPerm
+	s.mu.Unlock()
+	select {
+	case res := <-reply:
+		if res == nil || res.OptionID != "allow" {
+			return fmt.Errorf("subagent permission = %+v, want allow", res)
+		}
+	case <-time.After(3 * time.Second):
+		return fmt.Errorf("the subagent never got an answer: its gate was dropped")
+	}
+	s.directives <- stubDirective{kind: "end"}
+	return s.waitTurnEnd(2 * time.Second)
+}
+
 func (s *cliTUIState) transcriptShowsQuestionAnswered(question, answer string) error {
 	if err := s.waitScreen(question, 3*time.Second); err != nil {
 		return err
@@ -1266,6 +1379,13 @@ func initializeCLITUIScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the stub turn asks a question whose options carry long descriptions$`, s.stubAsksQuestionWithLongDescriptions)
 	sc.Step(`^the question modal shows the whole label of the first option$`, s.questionModalShowsWholeFirstLabel)
 	sc.Step(`^the question modal wraps the selected option's description below the list$`, s.questionModalWrapsSelectedDescription)
+	sc.Step(`^a background subagent asks permission while the question is open$`, s.backgroundSubagentAsksPermission)
+	sc.Step(`^the question is still the prompt on screen$`, s.questionIsStillThePromptOnScreen)
+	sc.Step(`^the question modal says another prompt is waiting behind it$`, s.questionModalSaysAnotherPromptWaits)
+	sc.Step(`^the operator answers the question without ending the turn$`, s.operatorAnswersQuestionKeepingTurn)
+	sc.Step(`^the subagent's permission is the prompt on screen$`, s.subagentPermissionIsThePromptOnScreen)
+	sc.Step(`^the operator allows the subagent's command$`, s.operatorAllowsSubagentCommand)
+	sc.Step(`^the subagent receives its answer$`, s.subagentReceivesItsAnswer)
 	sc.Step(`^the operator chooses the highlighted option$`, s.operatorChoosesHighlightedOption)
 	sc.Step(`^the transcript shows the question "([^"]*)" answered with "([^"]*)"$`, s.transcriptShowsQuestionAnswered)
 	sc.Step(`^the stub turn observes the question answer "([^"]*)"$`, s.stubObservesQuestionAnswer)

--- a/external/cli/chat_test.go
+++ b/external/cli/chat_test.go
@@ -323,6 +323,170 @@ func TestAssistantMessageStartsWithASeparatorRow(t *testing.T) {
 	}
 }
 
+// --- app.go: the modal slot and the operator gate queue ---
+
+// gateRequests are the two blocking prompts a console turn can raise. Both are
+// driven through the real sender so the test exercises the same channels the UI
+// loop reads.
+func questionGate(t *testing.T, a *App, id string) (chan *acp.QuestionResult, questRequest) {
+	t.Helper()
+	done := make(chan *acp.QuestionResult, 1)
+	go func() {
+		res, _ := a.Sender().RequestQuestion(context.Background(), acp.QuestionRequestParams{
+			SessionID: "s1", RequestID: id,
+			Questions: []acp.QuestionPrompt{{Question: "Pick " + id, Options: []acp.QuestionOption{{Label: "A"}}}},
+		})
+		done <- res
+	}()
+	select {
+	case req := <-a.questCh:
+		return done, req
+	case <-time.After(2 * time.Second):
+		t.Fatalf("question %s never reached the UI loop", id)
+	}
+	return nil, questRequest{}
+}
+
+func permissionGate(t *testing.T, a *App, ctx context.Context, id string) (chan *acp.PermissionResult, permRequest) {
+	t.Helper()
+	done := make(chan *acp.PermissionResult, 1)
+	go func() {
+		res, _ := a.Sender().RequestPermission(ctx, acp.PermissionRequestParams{
+			SessionID:               "s1",
+			EffectivePermissionMode: config.PermModeAsk,
+			ToolCall:                acp.PermissionToolCall{ToolCallID: id, Title: "Run: " + id},
+			Options:                 []acp.PermissionOption{{OptionID: "allow", Name: "Allow"}, {OptionID: "reject", Name: "Reject"}},
+		})
+		done <- res
+	}()
+	select {
+	case req := <-a.permCh:
+		return done, req
+	case <-time.After(2 * time.Second):
+		t.Fatalf("permission %s never reached the UI loop", id)
+	}
+	return nil, permRequest{}
+}
+
+// A gate is answered by exactly one modal, so a gate arriving while another
+// one is on screen has to wait: replacing the modal leaves the first worker
+// blocked on a reply nothing can send any more.
+func TestGatesQueueInsteadOfReplacingEachOther(t *testing.T) {
+	a := newTestApp(t)
+
+	first, firstReq := questionGate(t, a, "q_1")
+	a.openQuestionModal(firstReq)
+	second, secondReq := questionGate(t, a, "q_2")
+	a.openQuestionModal(secondReq)
+
+	if _, ok := a.modal.(*questionModal); !ok {
+		t.Fatalf("modal = %T, want the first question still holding the slot", a.modal)
+	}
+	if len(a.gateQueue) != 1 {
+		t.Fatalf("gateQueue = %d, want the second question queued", len(a.gateQueue))
+	}
+	if rows := renderedRows(a.modal, 80); !rows["1 more prompt is waiting behind this one"] {
+		t.Fatalf("the open gate does not say another one is waiting:\n%v", rows)
+	}
+
+	a.modal.(*questionModal).OnDone(&acp.QuestionResult{Answers: [][]string{{"A"}}})
+	if got := <-first; got == nil || len(got.Answers) == 0 {
+		t.Fatalf("first question answered with %+v", got)
+	}
+	if _, ok := a.modal.(*questionModal); !ok {
+		t.Fatalf("modal = %T, want the queued question promoted", a.modal)
+	}
+	a.modal.(*questionModal).OnDone(&acp.QuestionResult{Answers: [][]string{{"A"}}})
+	select {
+	case <-second:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the queued question was dropped and its turn can never finish")
+	}
+	if a.modal != nil || a.openGate != nil {
+		t.Fatalf("modal = %T / openGate = %v, want the slot free", a.modal, a.openGate)
+	}
+}
+
+// A queued gate whose turn ended in the meantime is forgotten rather than put
+// on screen: its worker stopped listening, so answering it would tell nobody.
+func TestAQueuedGateOfAFinishedTurnIsDropped(t *testing.T) {
+	a := newTestApp(t)
+
+	open, openReq := questionGate(t, a, "q_1")
+	a.openQuestionModal(openReq)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, queued := permissionGate(t, a, ctx, "call_1")
+	a.openPermissionModal(queued)
+	if len(a.gateQueue) != 1 {
+		t.Fatalf("gateQueue = %d, want the permission queued", len(a.gateQueue))
+	}
+	cancel()
+
+	a.modal.(*questionModal).OnDone(&acp.QuestionResult{Answers: [][]string{{"A"}}})
+	<-open
+	if a.modal != nil {
+		t.Fatalf("modal = %T, want the cancelled gate dropped instead of shown", a.modal)
+	}
+	if len(a.gateQueue) != 0 {
+		t.Fatalf("gateQueue = %d, want it drained", len(a.gateQueue))
+	}
+}
+
+// A picker is a convenience; a gate is a turn waiting for an answer. When the
+// two want the slot at the same time the gate keeps it.
+func TestAPickerDoesNotTakeTheSlotFromAGate(t *testing.T) {
+	a := newTestApp(t)
+
+	done, req := questionGate(t, a, "q_1")
+	a.openQuestionModal(req)
+
+	sel := newSelectorModal(a.theme, "Select model", []tui.SelectItem{{Value: "m", Label: "m"}}, 4, func() {})
+	if a.openOverlay(sel) {
+		t.Fatal("the picker took the slot from a gate")
+	}
+	if _, ok := a.modal.(*questionModal); !ok {
+		t.Fatalf("modal = %T, want the question still holding the slot", a.modal)
+	}
+
+	a.modal.(*questionModal).OnDone(&acp.QuestionResult{Answers: [][]string{{"A"}}})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the question was dropped")
+	}
+}
+
+// The gate of a background subagent outlives the turn that spawned it: the
+// child is still running, and the turn ending must not take its prompt away.
+func TestABackgroundGateSurvivesTheTurnThatSpawnedIt(t *testing.T) {
+	a := newTestApp(t)
+	a.turnActive = true
+	a.turnSessionID = "s1"
+	a.sessionID = "s1"
+
+	done, req := permissionGate(t, a, context.Background(), "child_call_1")
+	a.openPermissionModal(req)
+	if _, ok := a.modal.(*permissionModal); !ok {
+		t.Fatalf("modal = %T, want the child's permission on screen", a.modal)
+	}
+
+	a.applyLoopMessage(updateMsg{sessionID: "s1", update: turnDone{sessionID: "s1", stop: "end_turn"}})
+	if _, ok := a.modal.(*permissionModal); !ok {
+		t.Fatalf("modal = %T, want the still-waiting child gate left alone", a.modal)
+	}
+
+	a.modal.(*permissionModal).OnDone(&acp.PermissionResult{Outcome: "selected", OptionID: "allow"})
+	select {
+	case res := <-done:
+		if res == nil || res.OptionID != "allow" {
+			t.Fatalf("child permission = %+v, want allow", res)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the child's permission was dropped by the parent turn ending")
+	}
+}
+
 // --- run.go: the console turn agent and the staged config flow ---
 
 // stagedConfigBackend stands in for an OpenAI-compatible server answering

--- a/external/cli/modals.go
+++ b/external/cli/modals.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -15,8 +16,9 @@ import (
 type permissionModal struct {
 	tui.Container
 
-	theme *tui.Theme
-	list  *tui.SelectList
+	theme  *tui.Theme
+	list   *tui.SelectList
+	queued *tui.Text
 
 	OnDone func(res *acp.PermissionResult)
 }
@@ -51,10 +53,36 @@ func newPermissionModal(theme *tui.Theme, params acp.PermissionRequestParams, re
 	}
 	m.AddChild(tui.NewSpacer(1))
 	m.AddChild(m.list)
+	m.queued = tui.NewText("", 1, 0, nil)
+	m.AddChild(m.queued)
 	m.AddChild(tui.NewText(th.Fg(roleDim, "↑↓ navigate · enter choose · esc reject"), 1, 0, nil))
 	m.AddChild(tui.NewDynamicBorder(th.FgFn(roleWarning)))
 	_ = requestRender
 	return m
+}
+
+// SetQueued names how many further gates wait behind this one. A lone request
+// leaves the row empty, and an empty row renders nothing.
+func (m *permissionModal) SetQueued(n int) {
+	if m.queued == nil {
+		return
+	}
+	m.queued.SetText(queuedGateRow(m.theme, n))
+}
+
+// queuedGateRow is the shared wording for both gate modals. It returns the
+// bare empty string for none, uncoloured: tui.Text renders nothing only for
+// text that is whitespace all the way through, and colouring "" would leave a
+// blank row under every single prompt.
+func queuedGateRow(th *tui.Theme, n int) string {
+	switch {
+	case n <= 0:
+		return ""
+	case n == 1:
+		return th.Fg(roleMuted, "1 more prompt is waiting behind this one")
+	default:
+		return th.Fg(roleMuted, fmt.Sprintf("%d more prompts are waiting behind this one", n))
+	}
 }
 
 func permissionBody(params acp.PermissionRequestParams) string {
@@ -83,6 +111,9 @@ type questionModal struct {
 	inCustom bool
 	list     *tui.SelectList
 	render   func()
+	// queuedCount survives the per-question rebuilds, so the note stays on
+	// screen while the operator walks a multi-question prompt.
+	queuedCount int
 
 	OnDone func(res *acp.QuestionResult)
 }
@@ -143,6 +174,7 @@ func (m *questionModal) buildQuestion() {
 	}
 	m.AddChild(tui.NewText(th.Fg(roleAccent, th.Bold(tui.SanitizeText(q.Question))), 1, 0, nil))
 	m.AddChild(m.list)
+	m.AddChild(tui.NewText(queuedGateRow(th, m.queuedCount), 1, 0, nil))
 	hint := "↑↓ navigate · enter choose · esc cancel"
 	if q.Multiple {
 		hint = "↑↓ navigate · space toggle · enter confirm · esc cancel"
@@ -150,6 +182,42 @@ func (m *questionModal) buildQuestion() {
 	m.AddChild(tui.NewText(th.Fg(roleDim, hint), 1, 0, nil))
 	m.AddChild(tui.NewDynamicBorder(th.FgFn(roleBorderAccent)))
 	m.inCustom = false
+}
+
+// SetQueued names how many further gates wait behind this one. The note is a
+// child of the rebuilt block, so the cursor is carried across the rebuild: a
+// second prompt arriving must not move the operator's highlight.
+func (m *questionModal) SetQueued(n int) {
+	if m.queuedCount == n {
+		return
+	}
+	m.queuedCount = n
+	if m.inCustom {
+		return
+	}
+	keep := m.highlightedOption()
+	m.buildQuestion()
+	if keep >= 0 {
+		m.list.SetSelectedIndex(keep)
+	}
+}
+
+// highlightedOption is the index of the option under the cursor, or -1 when
+// the cursor is on the custom-answer row (which buildQuestion rebuilds last
+// anyway) or the list is empty. Item values carry the option index.
+func (m *questionModal) highlightedOption() int {
+	if m.list == nil {
+		return -1
+	}
+	it := m.list.SelectedItem()
+	if it == nil {
+		return -1
+	}
+	idx, err := strconv.Atoi(it.Value)
+	if err != nil {
+		return -1
+	}
+	return idx
 }
 
 func (m *questionModal) buildCustom() {

--- a/external/cli/sender.go
+++ b/external/cli/sender.go
@@ -17,14 +17,17 @@ type updateMsg struct {
 }
 
 // permRequest is a blocking permission round-trip between a turn worker and
-// the UI loop.
+// the UI loop. ctx is the requesting turn's: a gate queued behind another one
+// is dropped instead of shown once its turn is gone.
 type permRequest struct {
+	ctx    context.Context
 	params acp.PermissionRequestParams
 	reply  chan *acp.PermissionResult
 }
 
 // questRequest is the question-tool round-trip.
 type questRequest struct {
+	ctx    context.Context
 	params acp.QuestionRequestParams
 	reply  chan *acp.QuestionResult
 }
@@ -71,7 +74,7 @@ func (s *sender) RequestPermission(ctx context.Context, params acp.PermissionReq
 	if mode == config.PermModeBypass {
 		return &acp.PermissionResult{Outcome: "allow", OptionID: "allow"}, nil
 	}
-	req := permRequest{params: params, reply: make(chan *acp.PermissionResult, 1)}
+	req := permRequest{ctx: ctx, params: params, reply: make(chan *acp.PermissionResult, 1)}
 	select {
 	case s.app.permCh <- req:
 	case <-ctx.Done():
@@ -91,7 +94,7 @@ func (s *sender) RequestPermission(ctx context.Context, params acp.PermissionReq
 
 // RequestQuestion blocks the calling turn worker until the operator answers.
 func (s *sender) RequestQuestion(ctx context.Context, params acp.QuestionRequestParams) (*acp.QuestionResult, error) {
-	req := questRequest{params: params, reply: make(chan *acp.QuestionResult, 1)}
+	req := questRequest{ctx: ctx, params: params, reply: make(chan *acp.QuestionResult, 1)}
 	select {
 	case s.app.questCh <- req:
 	case <-ctx.Done():

--- a/external/cli/slash.go
+++ b/external/cli/slash.go
@@ -94,7 +94,7 @@ func (a *App) openModeSelector() {
 		}
 		a.applyMode(item.Value)
 	}
-	a.openModal(sel)
+	a.openOverlay(sel)
 }
 
 func (a *App) openThemeSelector() {
@@ -113,7 +113,7 @@ func (a *App) openThemeSelector() {
 		}
 		a.screen.RequestRender()
 	}
-	a.openModal(sel)
+	a.openOverlay(sel)
 }
 
 // switchTheme rebuilds themed content in place, preserving the editor text.
@@ -223,7 +223,12 @@ func (a *App) openResumePicker(res *acp.SessionListResult) {
 		}
 		a.resumeInto(item.Value)
 	}
-	a.openModal(sel)
+	// The list is fetched asynchronously, so a permission prompt or a question
+	// can have taken the slot since /resume was typed. Say so instead of
+	// letting the command look like it did nothing.
+	if !a.openOverlay(sel) {
+		a.appendStatus(roleWarning, "Answer the open prompt first, then /resume again")
+	}
 }
 
 // resumeInto switches the transcript to an existing session, serialized the

--- a/external/cli/updates.go
+++ b/external/cli/updates.go
@@ -19,10 +19,13 @@ func (a *App) applyLoopMessage(msg updateMsg) {
 			a.turnActive = false
 			a.stopSpinner()
 			a.stopUsageResume()
-			// A permission or question modal belonging to this turn is now
-			// orphaned (the worker already unblocked via ctx cancellation).
-			switch a.modal.(type) {
-			case *permissionModal, *questionModal:
+			// A permission or question modal whose worker already unblocked
+			// (via ctx cancellation) is orphaned, and so is anything queued
+			// behind it. Drop the queue first, so closing the modal does not
+			// promote a dead gate. A gate from a background subagent still
+			// running outlives the turn that spawned it and stays on screen.
+			a.dropStaleGates()
+			if a.openGate != nil && a.openGate.stale() {
 				a.closeModal()
 			}
 			if fn := a.pendingSwitch; fn != nil {

--- a/features/cli_tui.feature
+++ b/features/cli_tui.feature
@@ -111,6 +111,19 @@ Feature: Interactive console TUI
     Then the question modal shows the whole label of the first option
     And the question modal wraps the selected option's description below the list
 
+  Scenario: A prompt arriving during a question waits instead of taking the screen
+    When the console app starts
+    And the operator submits the prompt "ask me something"
+    And the stub turn asks a question titled "Pick or type" that allows a custom answer
+    And a background subagent asks permission while the question is open
+    Then the question is still the prompt on screen
+    And the question modal says another prompt is waiting behind it
+    When the operator answers the question without ending the turn
+    Then the stub turn observes the question answer "Option A"
+    And the subagent's permission is the prompt on screen
+    When the operator allows the subagent's command
+    Then the subagent receives its answer
+
   Scenario: An answered question renders as the question and the answer
     When the console app starts
     And the operator submits the prompt "ask me something"


### PR DESCRIPTION
## The report

A user in the console: generation suddenly stopped, the token counters froze, no
question form ever appeared. He opened the web UI and found the same session
sitting on an unanswered question.

## What actually happens

The console has one modal slot (`App.modal`) and every opener took it
unconditionally. When a second operator prompt arrived while the question tool
held the slot, `openModal` replaced the question modal outright:

1. the question modal opens, the turn worker blocks on its reply channel;
2. a second gate arrives and takes the slot; the question modal leaves the tree
   and its reply channel is orphaned;
3. answering the second one calls `closeModal`, so the editor comes back and the
   screen looks idle;
4. the question's worker is still blocked on `<-req.reply`. Nothing on screen can
   send it. The spinner runs, no updates arrive, and the `question` tool call
   stays `in_progress` in the persisted transcript — which is exactly what the
   web UI renders as "a question is waiting".

The path that reaches it in practice is a `spawn_agent` child started with
`background: true`: the parent does not wait for it, so the parent can be parked
in the question tool while the detached child relays its own permission request
to the same surface.

## The fix

Prompts somebody is blocked on (permission requests and questions) queue for the
slot in arrival order:

- the prompt on screen keeps it and names how many are waiting behind it;
- each queued prompt is shown as the previous one is answered;
- a prompt whose turn ended while it waited is dropped instead of shown to nobody;
- selectors go through `openOverlay` and never take the slot from a prompt (a
  dropped picker costs a keystroke; a dropped prompt hangs a turn). The `/resume`
  list is fetched asynchronously, so when it is refused the console says so
  instead of looking like the command did nothing;
- a turn ending closes only a modal whose own requester is gone, so a background
  child's prompt outlives the turn that spawned it.

## What the operator sees

The modal, rendered by the real component at 96 columns. A single prompt is
unchanged, to the row:

```
────────────────────────────────────────────────────────────────────────────────
 Where to put the relay
 The swarm relay has to live somewhere the nodes can reach. Which placement do you want?
→ Relay and node both on nas02 (recommended)
  Relay on a public VPS, nodes dial out

  One box carries the relay and the first node; simplest to operate.
 ↑↓ navigate · enter choose · esc cancel
────────────────────────────────────────────────────────────────────────────────
```

With a background subagent's permission queued behind it:

```
────────────────────────────────────────────────────────────────────────────────
 Where to put the relay
 The swarm relay has to live somewhere the nodes can reach. Which placement do you want?
→ Relay and node both on nas02 (recommended)
  Relay on a public VPS, nodes dial out

  One box carries the relay and the first node; simplest to operate.
 1 more prompt is waiting behind this one
 ↑↓ navigate · enter choose · esc cancel
────────────────────────────────────────────────────────────────────────────────
```

Answering the question promotes the one that was waiting:

```
────────────────────────────────────────────────────────────────────────────────
 Permission required
 [subagent explore] Run: rm -rf /tmp/scratch

→ Allow
  Reject
 ↑↓ navigate · enter choose · esc reject
────────────────────────────────────────────────────────────────────────────────
```

## Tests

Happy path in `features/cli_tui.feature`, driven through the real app loop with a
background subagent asking permission while the question is open. Without the fix
it fails on the symptom:

```
Then the question is still the prompt on screen
  Error: modal = *cli.permissionModal, want the question still holding the slot
```

Edge cases as unit tests in `external/cli/chat_test.go`: two prompts queue and both
get answered; a queued prompt whose turn ended is dropped; a picker cannot take the
slot from a prompt; a background child's prompt survives its spawning turn ending.

`make test` green (49 packages, no failures), `make lint` clean, `make docs-check`
clean.

## Notes

- The console screenshot set on `docs/surfaces/console.md` covers the launch
  frame, the model selector and the usage footer; it has never shown the question
  or permission modal, so this change updates the prose of that page and does not
  add a one-off modal capture. The rendered frames above are the evidence.
- `make site-docs-check` reports `llms.txt` / `llms-full.txt` drift, but it
  reports the same on `main` with this branch's docs stashed, so the site layer
  was already behind before this change. Per the workflow the site commit follows
  the merge anyway.
- Not addressed here, because it is a product call rather than a defect: the
  `question` tool still blocks a turn under `permission_mode: bypass`. The user
  expected bypass to cover questions too. Say the word and I will make bypass
  suppress or auto-answer them.
