### PR TITLE
test(bgtask): wait for the persist and the final notification, not for the in-memory flip

### DIFF
--- a/internal/bgtask/bgtask_test.go
+++ b/internal/bgtask/bgtask_test.go
@@ -94,6 +94,11 @@ func newTestPool(t *testing.T, runner Runner, cfg Config) *Pool {
 	return p
 }
 
+// waitForStatus polls the in-memory snapshot until it reads want. That flip is
+// the first thing the supervisor publishes: the record on disk is written and
+// the final notification is sent afterwards. A test that goes on to read the
+// session bundle or a subscriber's log must synchronise on those instead
+// (waitUntilFinished for the bundle, the subscriber itself for its log).
 func waitForStatus(t *testing.T, p *Pool, sessionID, taskID string, want Status) Snapshot {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
@@ -111,6 +116,22 @@ func waitForStatus(t *testing.T, p *Pool, sessionID, taskID string, want Status)
 	}
 	t.Fatalf("task %s stayed %q, want %q", taskID, last.Status, want)
 	return last
+}
+
+// waitUntilFinished blocks on Pool.Wait, which the supervisor releases only
+// after the task record is persisted, and checks the settled status. It is the
+// synchronisation a test needs before reading the session bundle: the in-memory
+// status flips before the persist, so waitForStatus is not enough there.
+func waitUntilFinished(t *testing.T, p *Pool, sessionID, taskID string, want Status) Snapshot {
+	t.Helper()
+	snap, err := p.Wait(context.Background(), sessionID, taskID, 3*time.Second)
+	if err != nil {
+		t.Fatalf("Wait(%q): %v", taskID, err)
+	}
+	if snap.Status != want {
+		t.Fatalf("task %s is %q after Wait, want %q", taskID, snap.Status, want)
+	}
+	return snap
 }
 
 func TestResolveTimeoutSeconds(t *testing.T) {
@@ -335,10 +356,17 @@ func TestPoolNotifiesSubscribers(t *testing.T) {
 
 	var mu sync.Mutex
 	var seen []Status
+	finished := make(chan struct{}, 1)
 	p.Subscribe(func(s Snapshot) {
 		mu.Lock()
 		seen = append(seen, s.Status)
 		mu.Unlock()
+		if s.Status.Finished() {
+			select {
+			case finished <- struct{}{}:
+			default:
+			}
+		}
 	})
 
 	snap, err := p.Start(Spec{SessionID: "s1", Command: "make"})
@@ -346,7 +374,14 @@ func TestPoolNotifiesSubscribers(t *testing.T) {
 		t.Fatalf("Start(): %v", err)
 	}
 	runner.last().finish(0)
-	waitForStatus(t, p, "s1", snap.ID, StatusSucceeded)
+	// The final notification is sent after the status flips in memory and
+	// after Wait is released, so neither orders it: the subscriber's own
+	// signal is what to wait on.
+	select {
+	case <-finished:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("subscriber never saw task %s finish", snap.ID)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -408,7 +443,10 @@ func TestTaskOutputAndMetadataPersistUnderTheSessionDir(t *testing.T) {
 		t.Fatalf("Start(): %v", err)
 	}
 	runner.last().finish(0)
-	waitForStatus(t, p, "s1", snap.ID, StatusSucceeded)
+	// The bundle is written after the in-memory status flips, so polling Get
+	// could read it while meta.json still says running (CI saw that as an
+	// orphaned row). Wait returns only once the record is on disk.
+	waitUntilFinished(t, p, "s1", snap.ID, StatusSucceeded)
 
 	text, truncated, ok := PersistedOutput(sessionDir, snap.ID)
 	if !ok {


### PR DESCRIPTION
## What

Fixes the flaky `TestTaskOutputAndMetadataPersistUnderTheSessionDir` in `internal/bgtask`, seen in the `Test suite (gateway)` job of https://github.com/coddy-project/coddy-agent/actions/runs/34710011944 on https://github.com/coddy-project/coddy-agent/pull/213, whose changes are confined to `external/cli` and cannot touch this package. Test-only change, no production code moved.

## Root cause

`Pool.supervise` sets the final status on the in-memory snapshot under the task lock, unlocks, and only then writes `meta.json`, closes `done` and notifies subscribers. The helper `waitForStatus` polls `Get`, so it returns the moment the in-memory status flips. A test that then reads the bundle can find a record that still says `running`, and `LoadPersisted` reports an unfinished record as `orphaned`, which is exactly the observed value.

The "persist before releasing waiters" comment in the supervisor is honoured: `Stop` and `Wait` return after the persist. Polling `Get` is simply not covered by that contract.

`TestPoolNotifiesSubscribers` had the same shape with a different downstream effect: it polled `Get` and then read the subscriber's log, but the final notification is delivered after `done` closes, so the log could still hold only `running`.

## Why the test side and not the pool

Every reader of `LoadPersisted` gives the live pool row precedence: the HTTP list (`backgroundRowsForSession`) skips persisted ids the pool knows, the HTTP get asks the pool first, and `Survivors`, `ClearFinished` and `stopSurvivor` all skip or only run for tasks the pool does not hold. `Wait`, `Stop` and the final `notify` all happen after the persist. Nothing outside the test can observe the stale record, so reordering the supervisor would change production for no caller.

## Fix

- `waitUntilFinished`, a helper that blocks on `Pool.Wait` (released only after the persist) and checks the settled status; the persistence test uses it.
- `TestPoolNotifiesSubscribers` waits on the subscriber's own signal for the finished notification, which neither `Get` nor `Wait` orders.
- The comment on `waitForStatus` now says what it does and does not order. Its other callers only read fields set in the same critical section as the status (`ExitCode`, `FinishedAt`, the in-memory output), or go on to `Stop`, which itself waits for `done`, so they are unchanged.

## Verification

- Red: with a temporary `time.Sleep` between the unlock and the persist in `supervise` (never committed), both tests failed on every run, the first with the exact `Status:orphaned` row from CI and the second with `subscriber saw [running]`. With the fix applied and the sleep still in place, both passed.
- `go test -tags=gateway -count=50 ./internal/bgtask/` on the real code: pass.
- `go test -race -tags=gateway -count=10 ./internal/bgtask/`: pass.
- `make test`: pass. `make lint`: clean.

No `features/` scenario: the pool's behaviour did not change, and the happy path of background tasks is already covered by `features/background_tasks.feature`.
