### PR TITLE
fix: a provider's tool call id cannot address a folder outside the session bundle

### DIFF
--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -13,7 +13,7 @@ Every session is a directory under the sessions root, `$CODDY_HOME/sessions/<id>
 | `assets/` | files uploaded through the composer, saved read-only, with PNG previews under `thumbnails/` |
 | `todos/active.md` | the current todo checklist; `todos/archive/` keeps replaced and archived lists |
 | `plans/<slug>.plan.md` | design plans written in plan mode |
-| `tool_calls/<id>/` | `args.json`, `result.md` and `meta.json` of every tool call, so a full result can be fetched after the stream showed a preview |
+| `tool_calls/<id>/` | `args.json`, `result.md` and `meta.json` of every tool call, so a full result can be fetched after the stream showed a preview. The id is the model provider's, so it names the folder only while it is a plain single name (letters, digits, `_`, `.`, `-`, at most 128 characters); anything else - a separator, a traversal, an id longer than a file name - is stored under a digest of it instead, and `meta.json` carries the `toolCallId` the provider sent either way |
 | `stats.json` | token totals of the completed model calls |
 | `branches.json` | the branch points of an edited conversation |
 | `diffs/turn_<n>.json` | the workspace files each turn changed, replayed backwards when a branch is created |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6374,7 +6374,7 @@ Every session is a directory under the sessions root, `$CODDY_HOME/sessions/<id>
 | `assets/` | files uploaded through the composer, saved read-only, with PNG previews under `thumbnails/` |
 | `todos/active.md` | the current todo checklist; `todos/archive/` keeps replaced and archived lists |
 | `plans/<slug>.plan.md` | design plans written in plan mode |
-| `tool_calls/<id>/` | `args.json`, `result.md` and `meta.json` of every tool call, so a full result can be fetched after the stream showed a preview |
+| `tool_calls/<id>/` | `args.json`, `result.md` and `meta.json` of every tool call, so a full result can be fetched after the stream showed a preview. The id is the model provider's, so it names the folder only while it is a plain single name (letters, digits, `_`, `.`, `-`, at most 128 characters); anything else - a separator, a traversal, an id longer than a file name - is stored under a digest of it instead, and `meta.json` carries the `toolCallId` the provider sent either way |
 | `stats.json` | token totals of the completed model calls |
 | `branches.json` | the branch points of an edited conversation |
 | `diffs/turn_<n>.json` | the workspace files each turn changed, replayed backwards when a branch is created |

--- a/external/httpserver/coddy_toolcalls_test.go
+++ b/external/httpserver/coddy_toolcalls_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/EvilFreelancer/coddy-agent/internal/acp"
@@ -75,5 +76,56 @@ func TestToolCallListReturnsTodoPlanSnapshot(t *testing.T) {
 	}
 	if len(body.ToolCalls[0].PlanSnapshot) != len(want) || body.ToolCalls[0].PlanSnapshot[1].Content != "Render preview" {
 		t.Fatalf("planSnapshot = %+v, want %+v", body.ToolCalls[0].PlanSnapshot, want)
+	}
+}
+
+// The toolCallId of GET /coddy/sessions/{id}/tool-calls/{toolCallId} is whatever
+// the caller puts in the path, percent-encoded separators included, and it is
+// resolved inside the session bundle. A traversal must not read the tool call of
+// another session.
+func TestToolCallGetCannotReachAnotherSessionsBundle(t *testing.T) {
+	cfg := &config.Config{}
+	runner := func(context.Context, *session.State, []acp.ContentBlock, acp.UpdateSender) (string, error) {
+		return string(acp.StopReasonEndTurn), nil
+	}
+	root := t.TempDir()
+	store := &session.FileStore{Root: filepath.Join(root, "sessions")}
+	mgr := session.NewManager(cfg, noopSender{}, runner, slog.Default(), t.TempDir(), store)
+	srv := New(cfg, mgr, slog.Default(), t.TempDir())
+
+	victim, err := mgr.HandleSessionNew(t.Context(), acp.SessionNewParams{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	victimState := mgr.SessionByID(victim.SessionID)
+	if victimState == nil {
+		t.Fatal("victim session missing")
+	}
+	const secret = "SECRET_OF_ANOTHER_SESSION"
+	if err := session.MarkToolCallStarted(victimState.GetPersistedSessionDir(), "call_secret", "read", "tool", "in_progress"); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WriteToolCallResult(victimState.GetPersistedSessionDir(), "call_secret", secret); err != nil {
+		t.Fatal(err)
+	}
+
+	caller, err := mgr.HandleSessionNew(t.Context(), acp.SessionNewParams{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// tool_calls/ is one segment deep inside the bundle, so two levels up land on
+	// the sessions root and the next name is another bundle. The separators are
+	// percent-encoded, which is how a traversal survives the mux: the pattern
+	// matches one segment and the handler is handed the decoded value.
+	traversal := "..%2F..%2F" + victim.SessionID + "%2Ftool_calls%2Fcall_secret"
+	req := httptest.NewRequest(http.MethodGet, "/coddy/sessions/"+caller.SessionID+"/tool-calls/"+traversal, nil)
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatalf("a traversal id read another session's tool call: %s", rec.Body.String())
 	}
 }

--- a/features/tool_call_persistence.feature
+++ b/features/tool_call_persistence.feature
@@ -1,0 +1,30 @@
+Feature: Tool call records stay inside the session bundle
+  The id of a tool call comes from the model's provider, and the bundle keeps one
+  folder per call under tool_calls/. An id that no filesystem can take as a folder
+  name - a traversal, a path separator, or one longer than a name may be - is kept
+  under a name derived from it, with the id itself in meta.json, so the record
+  never lands outside the bundle and is never lost. The turn runs to its end
+  either way, and the arguments a permission prompt would resume on are readable
+  under the id the provider sent.
+
+  Scenario: An id that points outside the bundle writes nothing outside it
+    Given a session bundle in its own store and a workspace file "note.txt"
+    When the model reads "note.txt" under the tool call id "../../escaped"
+    Then nothing is written outside the session bundle
+    And the bundle holds one tool call folder
+    And the tool call arguments and result are readable under the id the provider sent
+    And the turn ended with the model's answer
+
+  Scenario: An id longer than a file name keeps its record
+    Given a session bundle in its own store and a workspace file "note.txt"
+    When the model reads "note.txt" under a tool call id of 300 characters
+    Then the bundle holds one tool call folder
+    And the tool call arguments and result are readable under the id the provider sent
+    And the turn ended with the model's answer
+
+  Scenario: An ordinary provider id keeps its own folder name
+    Given a session bundle in its own store and a workspace file "note.txt"
+    When the model reads "note.txt" under the tool call id "call_abc123"
+    Then the bundle holds the tool call folder "call_abc123"
+    And the tool call arguments and result are readable under the id the provider sent
+    And the turn ended with the model's answer

--- a/internal/agent/bdd_tool_call_persistence_test.go
+++ b/internal/agent/bdd_tool_call_persistence_test.go
@@ -1,0 +1,245 @@
+package agent
+
+// Godog harness for features/tool_call_persistence.feature: drives the real Agent
+// through a scripted provider that hands out the tool call ids itself, then asserts
+// where the record of that call landed on disk. The ids are the ones a provider
+// could send and a filesystem cannot take as a folder name.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"github.com/EvilFreelancer/coddy-agent/internal/acp"
+	"github.com/EvilFreelancer/coddy-agent/internal/config"
+	"github.com/EvilFreelancer/coddy-agent/internal/llm"
+	"github.com/EvilFreelancer/coddy-agent/internal/session"
+)
+
+const tcpNotePayload = "NOTE_PAYLOAD_7f3a"
+
+type tcpFeatureState struct {
+	root       string
+	cwd        string
+	sessionDir string
+	st         *session.State
+	provider   *evScriptProvider
+	toolCallID string
+	answer     string
+}
+
+func (s *tcpFeatureState) reset() error {
+	s.provider = &evScriptProvider{}
+	s.toolCallID = ""
+	s.answer = ""
+	root, err := os.MkdirTemp("", "coddy-bdd-tcid-*")
+	if err != nil {
+		return err
+	}
+	s.root = root
+	// The workspace and the session store are siblings under one root, so an id
+	// that escapes the bundle has somewhere visible to land.
+	s.cwd = filepath.Join(root, "workspace")
+	s.sessionDir = filepath.Join(root, "store", "bundle")
+	if err := os.MkdirAll(s.cwd, 0o755); err != nil {
+		return err
+	}
+	return os.MkdirAll(s.sessionDir, 0o755)
+}
+
+func (s *tcpFeatureState) close() {
+	if s.root != "" {
+		_ = os.RemoveAll(s.root)
+		s.root = ""
+	}
+	s.st = nil
+}
+
+func (s *tcpFeatureState) bundleWithWorkspaceFile(name string) error {
+	return os.WriteFile(filepath.Join(s.cwd, name), []byte(tcpNotePayload+"\n"), 0o644)
+}
+
+// readUnderID runs one turn in which the model reads a workspace file with the
+// given tool call id and then answers.
+func (s *tcpFeatureState) readUnderID(path, id string) error {
+	s.toolCallID = id
+	s.answer = "read it"
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{{Name: "fake", Type: "openai", APIKey: "test"}},
+		Models:    []config.ModelEntry{{Model: "fake/model", MaxTokens: 100, MaxContextTokens: 128000}},
+		Agent:     config.Agent{Model: "fake/model"},
+		Tools:     config.Tools{PermissionMode: config.PermModeBypass},
+	}
+	s.st = &session.State{ID: "sess_bdd_toolcallid", CWD: s.cwd, Mode: session.ModeAgent, SessionDir: s.sessionDir}
+	ag := NewAgent(cfg, s.st, resumePermissionSender{}, nil)
+	ag.providerFactory = func(llm.ProviderInput) (llm.Provider, error) { return s.provider, nil }
+	args, _ := json.Marshal(map[string]interface{}{"path": path})
+	s.provider.steps = []evStep{
+		{calls: []llm.ToolCall{{ID: id, Name: "read", InputJSON: string(args)}}},
+		{text: s.answer},
+	}
+	_, err := ag.Run(context.Background(), []acp.ContentBlock{{Type: "text", Text: "read the note"}})
+	return err
+}
+
+func (s *tcpFeatureState) readUnderLongID(path string, n int) error {
+	return s.readUnderID(path, strings.Repeat("z", n))
+}
+
+func (s *tcpFeatureState) nothingOutsideTheBundle() error {
+	// Under the root only the workspace and the store; under the store only the
+	// bundle. A traversal id would have created a sibling of one of them.
+	rootEntries, err := entryNames(s.root)
+	if err != nil {
+		return err
+	}
+	if strings.Join(rootEntries, ",") != "store,workspace" {
+		return fmt.Errorf("the root holds %v, want only the store and the workspace", rootEntries)
+	}
+	storeEntries, err := entryNames(filepath.Join(s.root, "store"))
+	if err != nil {
+		return err
+	}
+	if strings.Join(storeEntries, ",") != "bundle" {
+		return fmt.Errorf("the store holds %v, want only the bundle", storeEntries)
+	}
+	workspaceEntries, err := entryNames(s.cwd)
+	if err != nil {
+		return err
+	}
+	if strings.Join(workspaceEntries, ",") != "note.txt" {
+		return fmt.Errorf("the workspace holds %v, want only the file it started with", workspaceEntries)
+	}
+	return nil
+}
+
+func (s *tcpFeatureState) bundleHoldsOneToolCallFolder() error {
+	dirs, err := session.ListToolCalls(s.sessionDir)
+	if err != nil {
+		return fmt.Errorf("list tool calls: %w", err)
+	}
+	if len(dirs) != 1 {
+		return fmt.Errorf("the bundle holds %d tool call folders, want 1: %v", len(dirs), dirs)
+	}
+	if err := session.ValidateToolCallID(dirs[0]); err != nil {
+		return fmt.Errorf("folder name %q is not a safe single path segment: %w", dirs[0], err)
+	}
+	return nil
+}
+
+func (s *tcpFeatureState) bundleHoldsToolCallFolder(name string) error {
+	if err := s.bundleHoldsOneToolCallFolder(); err != nil {
+		return err
+	}
+	dirs, err := session.ListToolCalls(s.sessionDir)
+	if err != nil {
+		return err
+	}
+	if dirs[0] != name {
+		return fmt.Errorf("the tool call folder is %q, want %q", dirs[0], name)
+	}
+	return nil
+}
+
+func (s *tcpFeatureState) recordReadableUnderProviderID() error {
+	args, err := session.ReadToolCallArgs(s.sessionDir, s.toolCallID)
+	if err != nil {
+		return fmt.Errorf("read the persisted arguments: %w", err)
+	}
+	if !strings.Contains(args, "note.txt") {
+		return fmt.Errorf("the persisted arguments are %q, want the path the model asked for", args)
+	}
+	result, err := session.ReadToolCallResult(s.sessionDir, s.toolCallID)
+	if err != nil {
+		return fmt.Errorf("read the persisted result: %w", err)
+	}
+	if !strings.Contains(result, tcpNotePayload) {
+		return fmt.Errorf("the persisted result is %q, want the file's content", result)
+	}
+	meta, err := session.ReadToolCallMeta(s.sessionDir, s.toolCallID)
+	if err != nil {
+		return fmt.Errorf("read the persisted metadata: %w", err)
+	}
+	if meta.ToolCallID != s.toolCallID {
+		return fmt.Errorf("meta.json records the id as %q, want %q", meta.ToolCallID, s.toolCallID)
+	}
+	if meta.Status != "completed" {
+		return fmt.Errorf("meta.json records the status as %q, want completed", meta.Status)
+	}
+	return nil
+}
+
+func (s *tcpFeatureState) turnEndedWithTheAnswer() error {
+	var sawToolResult bool
+	for _, m := range s.st.GetMessages() {
+		if m.Role == llm.RoleTool && m.ToolCallID == s.toolCallID && strings.Contains(m.Content, tcpNotePayload) {
+			sawToolResult = true
+		}
+	}
+	if !sawToolResult {
+		return fmt.Errorf("the transcript has no tool result for %q, so the loop lost the call", s.toolCallID)
+	}
+	msgs := s.st.GetMessages()
+	if len(msgs) == 0 {
+		return fmt.Errorf("the transcript is empty")
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != llm.RoleAssistant || !strings.Contains(last.Content, s.answer) {
+		return fmt.Errorf("the turn ended on %s %q, want the model's answer", last.Role, last.Content)
+	}
+	return nil
+}
+
+func entryNames(dir string) ([]string, error) {
+	de, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(de))
+	for _, e := range de {
+		out = append(out, e.Name())
+	}
+	return out, nil
+}
+
+func initializeToolCallPersistenceScenario(sc *godog.ScenarioContext) {
+	s := &tcpFeatureState{}
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		return ctx, s.reset()
+	})
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		s.close()
+		return ctx, nil
+	})
+
+	sc.Step(`^a session bundle in its own store and a workspace file "([^"]*)"$`, s.bundleWithWorkspaceFile)
+	sc.Step(`^the model reads "([^"]*)" under the tool call id "([^"]*)"$`, s.readUnderID)
+	sc.Step(`^the model reads "([^"]*)" under a tool call id of (\d+) characters$`, s.readUnderLongID)
+	sc.Step(`^nothing is written outside the session bundle$`, s.nothingOutsideTheBundle)
+	sc.Step(`^the bundle holds one tool call folder$`, s.bundleHoldsOneToolCallFolder)
+	sc.Step(`^the bundle holds the tool call folder "([^"]*)"$`, s.bundleHoldsToolCallFolder)
+	sc.Step(`^the tool call arguments and result are readable under the id the provider sent$`, s.recordReadableUnderProviderID)
+	sc.Step(`^the turn ended with the model's answer$`, s.turnEndedWithTheAnswer)
+}
+
+func TestToolCallPersistenceFeature(t *testing.T) {
+	suite := godog.TestSuite{
+		Name:                "tool-call-persistence",
+		ScenarioInitializer: initializeToolCallPersistenceScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/tool_call_persistence.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("tool call persistence feature suite failed")
+	}
+}

--- a/internal/session/toolcalls_store.go
+++ b/internal/session/toolcalls_store.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,6 +27,23 @@ type ToolCallMeta struct {
 	PlanSnapshot []acp.PlanEntry `json:"planSnapshot,omitempty"`
 }
 
+// ToolCallDirName maps a tool call id to the name of its folder under
+// tool_calls/. An id that is already a safe single path segment keeps its own
+// name, so every bundle written so far reads back unchanged; anything else - a
+// provider that sends "../x", an id carrying a separator, one longer than a file
+// name may be - is stored under a digest of the id instead of escaping the
+// bundle or losing the record, and meta.json keeps the id itself. A derived name
+// is a safe segment in its turn, so resolving one again is a no-op and a folder
+// name handed back by ListToolCalls addresses the same folder.
+func ToolCallDirName(toolCallID string) string {
+	id := strings.TrimSpace(toolCallID)
+	if ValidateToolCallID(id) == nil {
+		return id
+	}
+	sum := sha256.Sum256([]byte(id))
+	return "tc_" + hex.EncodeToString(sum[:16])
+}
+
 func toolCallDir(sessionDir, toolCallID string) (string, error) {
 	if strings.TrimSpace(sessionDir) == "" {
 		return "", fmt.Errorf("session directory is empty")
@@ -33,7 +52,7 @@ func toolCallDir(sessionDir, toolCallID string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("toolCallId is empty")
 	}
-	return filepath.Join(sessionDir, toolCallsDirName, id), nil
+	return filepath.Join(sessionDir, toolCallsDirName, ToolCallDirName(id)), nil
 }
 
 func ensureToolCallDir(sessionDir, toolCallID string) (string, error) {

--- a/internal/session/toolcalls_store_test.go
+++ b/internal/session/toolcalls_store_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -88,5 +90,126 @@ func TestWriteToolCallArgsKeepsLargeIntegers(t *testing.T) {
 	}
 	if !strings.Contains(got, "\n  \"n\": ") {
 		t.Fatalf("the persisted arguments are pretty-printed, got %q", got)
+	}
+}
+
+// A tool call id arrives from the model's provider, so it is never trusted as a
+// path: an id carrying a traversal or a separator must keep its record inside the
+// bundle instead of writing a folder next to it.
+func TestToolCallStoreKeepsUnsafeIDsInsideTheBundle(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{"../../escaped", "../escaped", "a/b", `a\b`, ".hidden", "..", strings.Repeat("z", 300)} {
+		root := t.TempDir()
+		sd := filepath.Join(root, "store", "bundle")
+		if err := os.MkdirAll(sd, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := MarkToolCallStarted(sd, id, "read", "tool", "in_progress"); err != nil {
+			t.Fatalf("MarkToolCallStarted(%q): %v", id, err)
+		}
+		if err := WriteToolCallArgs(sd, id, `{"path":"note.txt"}`); err != nil {
+			t.Fatalf("WriteToolCallArgs(%q): %v", id, err)
+		}
+		if err := WriteToolCallResult(sd, id, "PAYLOAD"); err != nil {
+			t.Fatalf("WriteToolCallResult(%q): %v", id, err)
+		}
+		if err := MarkToolCallFinished(sd, id, "read", "tool", "completed"); err != nil {
+			t.Fatalf("MarkToolCallFinished(%q): %v", id, err)
+		}
+
+		// Nothing outside the bundle: the only new entry under the store root
+		// is the bundle itself, and the bundle holds exactly one tool call.
+		entries, err := os.ReadDir(filepath.Join(root, "store"))
+		if err != nil {
+			t.Fatalf("ReadDir(store): %v", err)
+		}
+		if len(entries) != 1 || entries[0].Name() != "bundle" {
+			names := make([]string, 0, len(entries))
+			for _, e := range entries {
+				names = append(names, e.Name())
+			}
+			t.Fatalf("id %q wrote outside the bundle: store holds %v", id, names)
+		}
+		if rootEntries, err := os.ReadDir(root); err != nil {
+			t.Fatalf("ReadDir(root): %v", err)
+		} else if len(rootEntries) != 1 || rootEntries[0].Name() != "store" {
+			t.Fatalf("id %q wrote above the store: root holds %d entries", id, len(rootEntries))
+		}
+		dirs, err := ListToolCalls(sd)
+		if err != nil {
+			t.Fatalf("ListToolCalls(%q): %v", id, err)
+		}
+		if len(dirs) != 1 {
+			t.Fatalf("id %q produced %d tool call folders, want 1: %v", id, len(dirs), dirs)
+		}
+		if err := ValidateToolCallID(dirs[0]); err != nil {
+			t.Fatalf("id %q produced an unsafe folder name %q: %v", id, dirs[0], err)
+		}
+
+		// The record reads back under the id the provider sent, and the raw id
+		// is what meta.json carries.
+		if got, err := ReadToolCallResult(sd, id); err != nil || strings.TrimSpace(got) != "PAYLOAD" {
+			t.Fatalf("ReadToolCallResult(%q) = %q, %v", id, got, err)
+		}
+		if got, err := ReadToolCallArgs(sd, id); err != nil || !strings.Contains(got, "note.txt") {
+			t.Fatalf("ReadToolCallArgs(%q) = %q, %v", id, got, err)
+		}
+		meta, err := ReadToolCallMeta(sd, id)
+		if err != nil {
+			t.Fatalf("ReadToolCallMeta(%q): %v", id, err)
+		}
+		if meta.ToolCallID != id {
+			t.Fatalf("meta.json lost the raw id: got %q, want %q", meta.ToolCallID, id)
+		}
+		if meta.Status != "completed" || strings.TrimSpace(meta.StartedAt) == "" {
+			t.Fatalf("id %q lost its bookkeeping: %+v", id, meta)
+		}
+
+		// A folder name handed back by the listing resolves to the same folder,
+		// so reading a bundle through ListToolCalls is not a second mapping.
+		if got, err := ReadToolCallResult(sd, dirs[0]); err != nil || strings.TrimSpace(got) != "PAYLOAD" {
+			t.Fatalf("ReadToolCallResult(%q) through the folder name = %q, %v", dirs[0], got, err)
+		}
+	}
+}
+
+// An empty id is refused outright: there is no folder to put the record in, and
+// the callers already treat the error as "this call was not persisted".
+func TestToolCallStoreRefusesEmptyID(t *testing.T) {
+	t.Parallel()
+	sd := t.TempDir()
+	for _, id := range []string{"", "   "} {
+		if err := WriteToolCallResult(sd, id, "x"); err == nil {
+			t.Fatalf("WriteToolCallResult(%q): expected an error", id)
+		}
+		if _, err := ReadToolCallArgs(sd, id); err == nil {
+			t.Fatalf("ReadToolCallArgs(%q): expected an error", id)
+		}
+	}
+}
+
+// A provider id that is already a safe folder name keeps it, so bundles written
+// before the mapping existed read back unchanged.
+func TestToolCallDirNameKeepsSafeIDsVerbatim(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{"call_abc123", "toolu_01A09q90qw90lq917835lq9", "chatcmpl-tool.9f0e", "0"} {
+		if got := ToolCallDirName(id); got != id {
+			t.Fatalf("ToolCallDirName(%q) = %q, want the id itself", id, got)
+		}
+	}
+	// The same unusable id always maps to the same folder, and two of them do
+	// not share one.
+	a, b := ToolCallDirName("../../x"), ToolCallDirName("../../y")
+	if a == "" || a == b {
+		t.Fatalf("derived names must be stable and distinct: %q, %q", a, b)
+	}
+	if got := ToolCallDirName("../../x"); got != a {
+		t.Fatalf("derived name is not stable: %q then %q", a, got)
+	}
+	if err := ValidateToolCallID(a); err != nil {
+		t.Fatalf("derived name %q is not a safe folder name: %v", a, err)
+	}
+	if got := ToolCallDirName(a); got != a {
+		t.Fatalf("resolving a derived name again must be a no-op: %q -> %q", a, got)
 	}
 }

--- a/internal/session/validate.go
+++ b/internal/session/validate.go
@@ -22,3 +22,28 @@ func ValidateFolderSessionID(id string) error {
 	}
 	return nil
 }
+
+var toolCallFolderPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
+
+// ValidateToolCallID reports whether a tool call id can be used verbatim as the
+// name of its folder under tool_calls/. The id is whatever the model's provider
+// sent, so nothing about it is trusted: "../x" or an id carrying a separator
+// would put the folder outside the session bundle, and one past the filesystem's
+// name limit could not be created at all. Ids that fail this are not refused -
+// ToolCallDirName derives a safe name for them - so the set is deliberately
+// narrow.
+func ValidateToolCallID(id string) error {
+	if id == "" {
+		return fmt.Errorf("invalid tool call id: must not be empty")
+	}
+	if id != filepath.Base(id) || strings.ContainsAny(id, `/\`) {
+		return fmt.Errorf("invalid tool call id: must not contain path separators")
+	}
+	if strings.HasPrefix(id, ".") {
+		return fmt.Errorf("invalid tool call id: hidden names and traversal are not allowed")
+	}
+	if !toolCallFolderPattern.MatchString(id) {
+		return fmt.Errorf("invalid tool call id: only letters, digits, underscore, dot, and hyphen allowed (max 128 chars)")
+	}
+	return nil
+}

--- a/internal/session/validate_test.go
+++ b/internal/session/validate_test.go
@@ -1,6 +1,9 @@
 package session
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateFolderSessionID(t *testing.T) {
 	if err := ValidateFolderSessionID(`sess_deadbeefdeadbeefdeadbeefdead`); err != nil {
@@ -11,5 +14,34 @@ func TestValidateFolderSessionID(t *testing.T) {
 	}
 	if err := ValidateFolderSessionID(`.hidden`); err == nil {
 		t.Fatal(`expected rejection for dot prefix`)
+	}
+}
+
+func TestValidateToolCallID(t *testing.T) {
+	for _, id := range []string{"call_abc123", "toolu_01A09q90qw90lq917835lq9", "chatcmpl-tool.9f0e", "0", "a-b_c.d"} {
+		if err := ValidateToolCallID(id); err != nil {
+			t.Fatalf("ValidateToolCallID(%q): %v", id, err)
+		}
+	}
+	for _, id := range []string{
+		``,
+		`   `,
+		`../x`,
+		`../../escaped`,
+		`a/b`,
+		`/abs`,
+		`a\b`,
+		`.hidden`,
+		`.`,
+		`..`,
+		`a:b`,
+		`a b`,
+		`a*b`,
+		`a` + "\x00" + `b`,
+		strings.Repeat("z", 300),
+	} {
+		if err := ValidateToolCallID(id); err == nil {
+			t.Fatalf("ValidateToolCallID(%q): expected a rejection", id)
+		}
 	}
 }


### PR DESCRIPTION
## The bug

`internal/session/toolcalls_store.go` built the folder of a tool call out of the id the model's provider sent, after trimming whitespace and nothing else:

```go
return filepath.Join(sessionDir, toolCallsDirName, id), nil
```

`filepath.Join` cleans what it joins, so an id like `../../x`, or one carrying a separator, resolved to a folder outside the session bundle. Every function in that file goes through it, and so does `GET /coddy/sessions/{id}/tool-calls/{toolCallId}`.

Two consequences, both reproduced by the tests in this PR before the fix:

- **A cross-session read over HTTP.** `GET /coddy/sessions/<caller>/tool-calls/..%2F..%2F<other>%2Ftool_calls%2Fcall_secret` returned the `result.md` and `meta.json` of another session's tool call. Percent-encoded separators survive the mux: the pattern matches one segment and `r.PathValue` hands the handler the decoded value.
- **A record written outside the bundle, or lost.** With the id `../../escaped` the agent created a folder next to the bundle, under the sessions root. With an id longer than a file name (300 characters) nothing was persisted at all: `MkdirAll` failed with `ENAMETOOLONG` and every write was discarded, so the tool call had no `args.json` for a permission resume to bind to.

Found during the cross-review of `docs/plans/session-bus.md` (section 12).

## The fix

`session.ValidateToolCallID` says whether an id can be a folder name (one path segment, `[A-Za-z0-9_.-]`, no leading dot, at most 128 characters), in the shape of the existing `ValidateFolderSessionID`. `session.ToolCallDirName` maps an id to its folder:

- an id that is already a safe single segment keeps its own name, so every bundle written so far reads back unchanged;
- anything else is stored under `tc_` plus a digest of the raw id, and `meta.json` carries the `toolCallId` the provider sent either way;
- a derived name is a safe segment in its turn, so resolving one again is a no-op and a name from `ListToolCalls` addresses the same folder.

`toolCallDir` is the only place that changed, so reads and writes agree and the HTTP route resolves the same way.

### Why not refuse the id

Refusing was the other option the review offered, and the two call sites that consume the error make it cost more than it buys:

- `internal/agent/react.go:1197` - a failed args persist cancels the call *before* the permission prompt ("the arguments could not be persisted");
- `internal/agent/resume_permission.go:62` - a resume that cannot read the approved arguments fails closed and leaves the gate pending.

So a provider whose ids are merely unusual rather than malicious would lose every permission-gated tool call. Mapping closes the traversal with no behaviour lost, and it also fixes the over-long id that used to persist nothing.

## Tests

- `features/tool_call_persistence.feature` plus the godog harness `internal/agent/bdd_tool_call_persistence_test.go`: the real agent runs a turn under a traversal id, a 300-character id and an ordinary id. Before the fix the first wrote `store/escaped` and the second persisted nothing; the third passed then and passes now, which is the backward-compatibility check.
- `internal/session/toolcalls_store_test.go`: `../../escaped`, `../escaped`, `a/b`, `a\b`, `.hidden`, `..`, a 300-character id - nothing outside the bundle, one folder per call, the record readable under the id the provider sent, `meta.json` keeping the raw id; an empty id still returns an error; safe ids keep their own folder name.
- `internal/session/validate_test.go`: the validator over valid ids (`call_abc123`, `toolu_...`, `chatcmpl-tool.9f0e`) and rejected ones (separators, traversal, dot prefix, control characters, spaces, over-long).
- `external/httpserver/coddy_toolcalls_test.go`: the route cannot reach another session's bundle (the case above; it fails on the old code).

## Checks

- `make test` green (exit 0, no failures).
- `make lint` clean, `make check-windows` clean (this is path code, and `filepath.Base` treats `\` as a separator there).
- `make docs` run: `docs/features/sessions.md` describes what names the `tool_calls/<id>/` folder now; `docs/llms-full.txt` regenerated, `make docs-check` clean.
- No config, CLI or HTTP surface change, so no schema, man page, completions or OpenAPI edit.

## Follow-up after the merge

`make site-docs` for `coddy-project.github.io`: `llms-full.txt` carries the changed page, and it names pages by their path on `main`, so the site commit follows this merge (workflow step 8). The site is otherwise in sync with `main` today.
